### PR TITLE
ci: automate nx release with manual dispatch and PR preview

### DIFF
--- a/.github/scripts/format-release-preview.ts
+++ b/.github/scripts/format-release-preview.ts
@@ -1,0 +1,147 @@
+#!/usr/bin/env bun
+// Parse `nx release --dry-run` output into a markdown block for a PR comment.
+//
+// Usage: bun .github/scripts/format-release-preview.ts <dry-run-log>
+
+const MARKER = '<!-- nx-release-preview -->'
+
+const logPath = Bun.argv[2]
+if (!logPath) {
+  Bun.stderr.write('usage: format-release-preview.ts <dry-run-log>\n')
+  process.exit(2)
+}
+
+const file = Bun.file(logPath)
+if (!(await file.exists())) {
+  Bun.stderr.write(`format-release-preview: cannot read ${logPath}\n`)
+  process.exit(1)
+}
+
+const raw = await file.text()
+const ESC = String.fromCharCode(27)
+const ansi = new RegExp(`${ESC}\\[[0-9;]*m`, 'g')
+const clean = raw.replace(ansi, '')
+const lines = clean.split('\n')
+
+type Bump = { project: string; from: string; to: string; specifier: string }
+
+const partials = new Map<string, Partial<Bump>>()
+const mergeBump = (project: string, patch: Partial<Bump>) => {
+  partials.set(project, { ...(partials.get(project) ?? { project }), ...patch })
+}
+
+const projectStart = / NX {3}Running release version for project:\s+(\S+)/
+const fromPattern =
+  /^(\S+)\s+(?:.*Current version\s+.*?\s+is\s+(\S+)|.*Falling back to the version\s+(\S+)\s+in manifest)/
+const specifierPattern = /^(\S+)\s+.*Resolved the specifier as\s+"(\w+)"/
+// A project can emit multiple "New version X written" lines during one run
+// (once from a dependency bump, again from commits). We keep the last.
+const newVersionPattern = /^(\S+)\s+.*New version\s+(\S+)\s+written/
+
+type ChangelogEntry = { project: string; body: string }
+const changelogs: ChangelogEntry[] = []
+const previewHeader =
+  / NX {3}Previewing an entry in .*CHANGELOG\.md for\s+(\S+)@(\S+)/
+
+let activeProject: string | null = null
+
+for (let i = 0; i < lines.length; i++) {
+  const line = lines[i]
+
+  const header = line.match(previewHeader)
+  if (header) {
+    const project = header[1]
+    const body: string[] = []
+    let started = false
+    for (let j = i + 1; j < lines.length; j++) {
+      const l = lines[j]
+      if (l.startsWith('+')) {
+        started = true
+        body.push(l.replace(/^\+\s?/, ''))
+      } else if (started) {
+        break
+      }
+    }
+    if (body.length > 0) {
+      changelogs.push({ project, body: body.join('\n').trim() })
+    }
+    continue
+  }
+
+  const startMatch = line.match(projectStart)
+  if (startMatch) {
+    activeProject = startMatch[1]
+    continue
+  }
+  if (!activeProject) continue
+
+  const fromMatch = line.match(fromPattern)
+  if (fromMatch && fromMatch[1] === activeProject) {
+    const from = fromMatch[2] ?? fromMatch[3]
+    if (from) mergeBump(activeProject, { from })
+    continue
+  }
+
+  const specMatch = line.match(specifierPattern)
+  if (specMatch && specMatch[1] === activeProject) {
+    mergeBump(activeProject, { specifier: specMatch[2] })
+    continue
+  }
+
+  const newMatch = line.match(newVersionPattern)
+  if (newMatch && newMatch[1] === activeProject) {
+    mergeBump(activeProject, { to: newMatch[2] })
+  }
+}
+
+const isComplete = (b: Partial<Bump>): b is Bump =>
+  typeof b.project === 'string' &&
+  typeof b.from === 'string' &&
+  typeof b.to === 'string' &&
+  typeof b.specifier === 'string'
+
+const bumps = [...partials.values()]
+  .filter(isComplete)
+  .filter((b) => b.from !== b.to)
+
+const out: string[] = []
+out.push(MARKER)
+out.push('## Nx Release Preview')
+out.push('')
+
+if (bumps.length === 0) {
+  out.push('_No packages will be released by this PR._')
+  out.push('')
+  out.push(
+    'This usually means no conventional commits since the last tag touched a released package, or all commits are non-releasing types (`chore`, `docs`, etc.).',
+  )
+} else {
+  out.push(`If merged, \`nx release\` will tag **${bumps.length}** package(s):`)
+  out.push('')
+  out.push('| Package | Bump | From | To |')
+  out.push('| --- | --- | --- | --- |')
+  for (const b of bumps) {
+    out.push(`| \`${b.project}\` | ${b.specifier} | ${b.from} | **${b.to}** |`)
+  }
+  out.push('')
+
+  if (changelogs.length > 0) {
+    out.push('<details><summary>Changelog preview</summary>')
+    out.push('')
+    for (const c of changelogs) {
+      out.push(`### ${c.project}`)
+      out.push('')
+      out.push(c.body)
+      out.push('')
+    }
+    out.push('</details>')
+    out.push('')
+  }
+}
+
+out.push('---')
+out.push(
+  '_Dry-run preview only. Versions and tags are created when a maintainer runs the `Release` workflow manually._',
+)
+
+await Bun.write(Bun.stdout, `${out.join('\n')}\n`)

--- a/.github/scripts/format-release-preview.ts
+++ b/.github/scripts/format-release-preview.ts
@@ -32,7 +32,7 @@ const mergeBump = (project: string, patch: Partial<Bump>) => {
 
 const projectStart = / NX {3}Running release version for project:\s+(\S+)/
 const fromPattern =
-  /^(\S+)\s+(?:.*Current version\s+.*?\s+is\s+(\S+)|.*Falling back to the version\s+(\S+)\s+in manifest)/
+  /^(\S+)\s+.*(?:Resolved the current version as\s+(\S+)|Falling back to the version\s+(\S+)\s+in manifest)/
 const specifierPattern = /^(\S+)\s+.*Resolved the specifier as\s+"(\w+)"/
 // A project can emit multiple "New version X written" lines during one run
 // (once from a dependency bump, again from commits). We keep the last.

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -1,0 +1,61 @@
+name: Release Preview
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: release-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  preview:
+    name: Preview nx release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@v2
+
+      - run: bun install
+
+      - name: Run nx release (dry run)
+        id: dry_run
+        run: |
+          set -o pipefail
+          bunx nx release --dry-run --skip-publish --verbose 2>&1 | tee release-preview.txt
+
+      - name: Format preview comment
+        run: bun .github/scripts/format-release-preview.ts release-preview.txt > preview-comment.md
+
+      - name: Post or update PR comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs')
+            const body = fs.readFileSync('preview-comment.md', 'utf8')
+            const marker = '<!-- nx-release-preview -->'
+            const { owner, repo } = context.repo
+            const issue_number = context.issue.number
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number, per_page: 100,
+            })
+            const existing = comments.find((c) => c.body && c.body.includes(marker))
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: existing.id, body,
+              })
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number, body,
+              })
+            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (print the plan without creating commits or tags)'
+        type: boolean
+        default: false
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: nx release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: oven-sh/setup-bun@v2
+
+      - run: bun install
+
+      - name: Configure git identity
+        # Uses the official github-actions[bot] noreply address (user id 41898282).
+        # This attributes release commits to the bot in the GitHub UI with its avatar.
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Release (dry run)
+        if: ${{ inputs.dry_run }}
+        run: |
+          set -o pipefail
+          {
+            echo '## Nx Release Dry Run'
+            echo ''
+            echo '```'
+            bunx nx release --dry-run --skip-publish --verbose
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Release
+        if: ${{ !inputs.dry_run }}
+        run: bunx nx release --skip-publish --verbose
+
+      - name: Push release commit and tags
+        if: ${{ !inputs.dry_run }}
+        run: git push --follow-tags origin HEAD:main

--- a/nx-tools/plain-text-changelog-renderer.js
+++ b/nx-tools/plain-text-changelog-renderer.js
@@ -1,0 +1,37 @@
+// Custom Nx changelog renderer that strips emoji from the section headers
+// Nx hardcodes in its default renderer (Breaking Changes, Updated Dependencies,
+// Thank You). Commit-type section titles (Features, Fixes, Performance) are
+// driven by nx.json's release.conventionalCommits.types overrides, so this
+// renderer doesn't need to touch those.
+
+const DefaultChangelogRenderer =
+  require('nx/release/changelog-renderer').default
+
+class PlainTextChangelogRenderer extends DefaultChangelogRenderer {
+  renderBreakingChanges() {
+    const unique = Array.from(new Set(this.breakingChanges))
+    return ['### Breaking Changes', '', ...unique]
+  }
+
+  renderDependencyBumps() {
+    const markdownLines = ['', '### Updated Dependencies', '']
+    for (const bump of this.dependencyBumps ?? []) {
+      markdownLines.push(
+        `- Updated ${bump.dependencyName} to ${bump.newVersion}`,
+      )
+    }
+    return markdownLines
+  }
+
+  async renderAuthors() {
+    // Delegate resolution to the parent (maps authors to GitHub usernames via
+    // ungh / the gh CLI) and swap the only emoji heading for a plain one.
+    const lines = await super.renderAuthors()
+    return lines.map((line) =>
+      line === '### ❤️ Thank You' ? '### Thank You' : line,
+    )
+  }
+}
+
+module.exports = PlainTextChangelogRenderer
+module.exports.default = PlainTextChangelogRenderer

--- a/nx.json
+++ b/nx.json
@@ -37,6 +37,9 @@
     }
   },
   "release": {
+    "releaseTag": {
+      "strictPreid": false
+    },
     "groups": {
       "typescript": {
         "projects": ["packages/niivue", "packages/nv-*"],

--- a/nx.json
+++ b/nx.json
@@ -53,7 +53,16 @@
     "changelog": {
       "automaticFromRef": true,
       "workspaceChangelog": false,
-      "projectChangelogs": true
+      "projectChangelogs": {
+        "renderer": "{workspaceRoot}/nx-tools/plain-text-changelog-renderer.js"
+      }
+    },
+    "conventionalCommits": {
+      "types": {
+        "feat": { "changelog": { "title": "Features" } },
+        "fix": { "changelog": { "title": "Fixes" } },
+        "perf": { "changelog": { "title": "Performance" } }
+      }
     }
   },
   "analytics": false


### PR DESCRIPTION
## Summary

- New `Release` workflow (manual dispatch, with optional `dry_run` input) runs `nx release --skip-publish` and pushes the release commit + per-package tags back to `main`. npm publish stays a deliberate manual step.
- New `Release Preview` workflow runs on every PR and posts a sticky comment showing the packages that would be released if the PR is merged, plus the generated changelog entries.
- Custom Nx changelog renderer at `nx-tools/plain-text-changelog-renderer.js` drops the emoji Nx hardcodes in the Breaking Changes / Updated Dependencies / Thank You headers.
- `nx.json` wires up the renderer and overrides the visible commit-type titles (`feat`, `fix`, `perf`) to emoji-free text.

## Notes

- Release commits are authored by `github-actions[bot]` via its official noreply address (`41898282+github-actions[bot]@users.noreply.github.com`).
- If `main` has branch protection blocking direct pushes, the `git push --follow-tags` step will fail. Fix is either to allow `github-actions[bot]` to bypass, or to change the workflow to open a PR instead.