### PR TITLE
Drawing

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "nx-mono-repo-test",

--- a/packages/dev-images/images/volumes/torso.nii.gz
+++ b/packages/dev-images/images/volumes/torso.nii.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:312d36ca5a5673cbe57c88524afc85680acb5227de3716b4b1dc954c40e07a25
+size 8479151

--- a/packages/dev-images/images/volumes/torsoLabel.nii.gz
+++ b/packages/dev-images/images/volumes/torsoLabel.nii.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63d6f34036e1143b23bd8a3f558c507cc5516a59662a921e858c9ed0c9145865
+size 43556

--- a/packages/niivue/AGENTS.md
+++ b/packages/niivue/AGENTS.md
@@ -420,7 +420,7 @@ Priority: mosaic string > render-only > single slice > hero layout > multiplanar
 The 3D render shaders (`wgpu/render.wgsl`, `gl/renderShader.ts`) use a multi-pass ray-march:
 
 1. **Background pass** (fast + fine): Gradient lighting via matcap. Handles clip planes.
-2. **Optional passes** (overlay, PAQD, drawing): Each uses `rayMarchPass()` (fast skip + fine accumulation with premultiplied alpha), then `depthAwareMix()` for depth-correct compositing.
+2. **Optional passes** (overlay, PAQD, drawing): Each uses `rayMarchPass()` (fast skip + fine accumulation with premultiplied alpha), then `depthAwareMix()` for depth-correct compositing. When `gradientAmount > 0`, the drawing pass applies matcap lighting at first hit using a gradient sampled from the drawing volume (same uniform gate as the background pass).
 
 Guards: Each optional pass checks `textureSize > 2` (placeholder is 2×2×2 all zeros).
 

--- a/packages/niivue/AGENTS.md
+++ b/packages/niivue/AGENTS.md
@@ -357,7 +357,7 @@ Fragment shaders in `gl/meshShader.ts` (GLSL) and `wgpu/mesh.wgsl` (WGSL): phong
 
 Volumes apply in GPU shader. Mesh layers apply during CPU compositing (`mesh/layers/index.ts`).
 
-**Label colormaps:** Discrete indexed colors for atlas volumes. `NVCmaps.makeLabelLut()` → `NVImage.colormapLabel`. Orient shader uses nearest-neighbor LUT sampling. `calMin`/`calMax`/`colormapType` are ignored for label volumes.
+**Label colormaps:** Discrete indexed colors for atlas volumes. `NVCmaps.makeLabelLut()` → `NVImage.colormapLabel`. Orient shader uses nearest-neighbor LUT sampling. `calMin`/`calMax`/`colormapType` are ignored for label volumes. When a colormap registered via `addColormap(name, cmap)` includes a `labels?: string[]` field (e.g. the built-in `_draw` colormap), the drawing volume surfaces the human-readable label (e.g. `"11bladder"`) in the `locationChange` event's `string` field instead of a numeric fallback like `"draw:11"`.
 
 ## Drawing (voxel bitmap editing)
 

--- a/packages/niivue/examples/vox.draw.html
+++ b/packages/niivue/examples/vox.draw.html
@@ -43,7 +43,7 @@
       <button type="button" id="closeBtn" disabled>Close</button>
       &nbsp;
       <button type="button" id="loadBtn">Load</button>
-      <input type="file" id="loadFile" accept=".nii,.nii.gz" style="display:none" />
+      <input type="file" id="loadFile" accept=".nii,.gz" style="display:none" />
       &nbsp;
       <button type="button" id="leftBtn">L</button>
       <button type="button" id="rightBtn">R</button>

--- a/packages/niivue/examples/vox.draw.js
+++ b/packages/niivue/examples/vox.draw.js
@@ -83,8 +83,20 @@ async function openDrawing(source) {
 }
 
 loadFile.onchange = async function () {
-  if (!this.files?.[0]) return
-  await openDrawing(this.files[0])
+  const file = this.files?.[0]
+  if (!file) return
+  const name = file.name.toLowerCase()
+  if (!name.endsWith('.nii') && !name.endsWith('.nii.gz')) {
+    alert(`Unsupported file: ${file.name}\nExpected .nii or .nii.gz`)
+    this.value = ''
+    return
+  }
+  const ok = await openDrawing(file)
+  if (!ok) {
+    alert(
+      `Could not load ${file.name} as a drawing.\nCheck the browser console for details.`,
+    )
+  }
   this.value = ''
 }
 

--- a/packages/niivue/examples/vox.torso.html
+++ b/packages/niivue/examples/vox.torso.html
@@ -14,8 +14,8 @@
         <option value="0">Axial</option>
         <option value="1">Coronal</option>
         <option value="2">Sagittal</option>
-        <option value="4" selected>Render</option>
-        <option value="3">A+C+S+R</option>
+        <option value="4">Render</option>
+        <option value="3" selected>A+C+S+R</option>
       </select>
       &nbsp;
       <label for="clipSelect">Clip Planes</label>
@@ -29,7 +29,11 @@
         <option>6</option>
       </select>
       &nbsp;
-      <label for="gradSlider">Lighting</label>
+      <label for="matcapSelect">Matcap</label>
+      <select id="matcapSelect">
+        <option>Cortex</option>
+        <option selected>Shiny</option>
+      </select>
       <input
         type="range"
         min="0"
@@ -41,7 +45,7 @@
       <button type="button" id="benchBtn">Benchmark</button>
       &nbsp;
       <label for="webgpuCheck">WebGPU</label>
-      <input type="checkbox" id="webgpuCheck"/>
+      <input type="checkbox" id="webgpuCheck" checked/>
     </header>
     <main id="canvas-container">
       <canvas id="gl1"></canvas>

--- a/packages/niivue/examples/vox.torso.html
+++ b/packages/niivue/examples/vox.torso.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+    <title>Torso</title>
+    <link rel="icon" href="data:,">
+    <link rel="stylesheet" href="/niivue.css" />
+  </head>
+  <body>
+    <header>
+      <select id="sliceType">
+        <option value="0">Axial</option>
+        <option value="1">Coronal</option>
+        <option value="2">Sagittal</option>
+        <option value="4" selected>Render</option>
+        <option value="3">A+C+S+R</option>
+      </select>
+      &nbsp;
+      <label for="clipSelect">Clip Planes</label>
+      <select id="clipSelect">
+        <option>0</option>
+        <option selected>1</option>
+        <option>2</option>
+        <option>3</option>
+        <option>4</option>
+        <option>5</option>
+        <option>6</option>
+      </select>
+      &nbsp;
+      <label for="gradSlider">Lighting</label>
+      <input
+        type="range"
+        min="0"
+        max="100"
+        value="40"
+        class="slider"
+        id="gradSlider"
+      />
+      <button type="button" id="benchBtn">Benchmark</button>
+      &nbsp;
+      <label for="webgpuCheck">WebGPU</label>
+      <input type="checkbox" id="webgpuCheck"/>
+    </header>
+    <main id="canvas-container">
+      <canvas id="gl1"></canvas>
+    </main>
+    <footer id="location">NiiVue</footer>
+    <script type="module" src="./vox.torso.js"></script>
+  </body>
+</html>

--- a/packages/niivue/examples/vox.torso.js
+++ b/packages/niivue/examples/vox.torso.js
@@ -124,7 +124,7 @@ const nv1 = new NiiVue({
   showRender: SHOW_RENDER.ALWAYS,
 })
 await nv1.attachToCanvas(gl1)
-nv1.sliceType = 4
+sliceType.onchange()
 await nv1.loadVolumes([{ url: '/volumes/torso.nii.gz' }])
 nv1.addEventListener('locationChange', (e) => handleLocationChange(e.detail))
 gradSlider.oninput()

--- a/packages/niivue/examples/vox.torso.js
+++ b/packages/niivue/examples/vox.torso.js
@@ -1,4 +1,6 @@
+import { cortex, shiny } from '../src/assets/matcaps'
 import NiiVue from '../src/index.ts'
+import { SHOW_RENDER } from '../src/NVConstants.ts'
 
 gradSlider.oninput = () => {
   nv1.volumeIllumination = Number(gradSlider.value) / 100
@@ -62,27 +64,31 @@ clipSelect.onchange = function () {
   }
   nv1.setClipPlanes(planes)
 }
+matcapSelect.onchange = async () => {
+  await nv1.loadMatcap(matcapSelect.value)
+}
 benchBtn.onclick = async () => {
   const view = nv1.view
-  if (!view || typeof view.renderAndFlushOffscreen !== 'function') {
-    console.warn('renderAndFlushOffscreen unavailable')
+  if (!view) {
+    console.warn('bench harness unavailable')
     return
   }
+  const bench = view.bench
   const backend = view.device ? 'WebGPU' : view.gl ? 'WebGL2' : 'unknown'
   const WARMUP = 10
   const SAMPLES = 200
   benchBtn.disabled = true
   benchBtn.textContent = 'Benchmarking...'
-  for (let i = 0; i < WARMUP; i++) await view.renderAndFlushOffscreen()
+  for (let i = 0; i < WARMUP; i++) await bench.renderAndFlushOffscreen()
   // Sanity check for WebGL2: confirm the offscreen FBO actually got pixels.
   // Helps catch silent no-renders (incomplete FBO, stale bounds, etc.).
-  if (view.gl && view._benchFbo) {
+  if (view.gl && bench.fboW > 0) {
     const gl = view.gl
-    gl.bindFramebuffer(gl.READ_FRAMEBUFFER, view._benchFbo)
+    gl.bindFramebuffer(gl.READ_FRAMEBUFFER, bench.fbo)
     const pix = new Uint8Array(4)
     gl.readPixels(
-      view._benchFboW >> 1,
-      view._benchFboH >> 1,
+      bench.fboW >> 1,
+      bench.fboH >> 1,
       1,
       1,
       gl.RGBA,
@@ -92,10 +98,10 @@ benchBtn.onclick = async () => {
     gl.bindFramebuffer(gl.READ_FRAMEBUFFER, null)
     const blank = pix[0] === 0 && pix[1] === 0 && pix[2] === 0
     console.log(
-      `${backend} FBO ${view._benchFboW}x${view._benchFboH} bounds=${view._boundsWidth}x${view._boundsHeight} center=[${Array.from(pix)}]${blank ? ' BLANK — NOT RENDERING' : ''}`,
+      `${backend} FBO ${bench.fboW}x${bench.fboH} bounds=${view.boundsWidth}x${view.boundsHeight} center=[${Array.from(pix)}]${blank ? ' BLANK — NOT RENDERING' : ''}`,
     )
   } else {
-    console.log(`${backend} bounds=${view._boundsWidth}x${view._boundsHeight}`)
+    console.log(`${backend} bounds=${view.boundsWidth}x${view.boundsHeight}`)
   }
   const times = new Float64Array(SAMPLES)
   for (let i = 0; i < SAMPLES; i++) {
@@ -113,7 +119,10 @@ benchBtn.onclick = async () => {
   benchBtn.textContent = `${backend} ${fmt(median)}ms`
   benchBtn.disabled = false
 }
-const nv1 = new NiiVue({ backend: 'webgl2' })
+const nv1 = new NiiVue({
+  matcaps: { Cortex: cortex, Shiny: shiny },
+  showRender: SHOW_RENDER.ALWAYS,
+})
 await nv1.attachToCanvas(gl1)
 nv1.sliceType = 4
 await nv1.loadVolumes([{ url: '/volumes/torso.nii.gz' }])
@@ -144,3 +153,4 @@ nv1.drawColormap = '_torso'
 await nv1.loadDrawing('/volumes/torsoLabel.nii.gz')
 nv1.drawIsEnabled = false
 clipSelect.onchange()
+matcapSelect.onchange()

--- a/packages/niivue/examples/vox.torso.js
+++ b/packages/niivue/examples/vox.torso.js
@@ -1,0 +1,146 @@
+import NiiVue from '../src/index.ts'
+
+gradSlider.oninput = () => {
+  nv1.volumeIllumination = Number(gradSlider.value) / 100
+}
+webgpuCheck.onclick = function () {
+  nv1.reinitializeView({ backend: this.checked ? 'webgpu' : 'webgl2' })
+}
+function handleLocationChange(data) {
+  document.getElementById('location').innerHTML = `&nbsp;&nbsp;${data.string}`
+}
+sliceType.onchange = () => {
+  nv1.sliceType = parseInt(sliceType.value, 10)
+}
+clipSelect.onchange = function () {
+  const index = parseInt(this.value, 10) // selected option value as integer
+  let planes = [[2.0, 180, 20]]
+  switch (index) {
+    case 1:
+      planes = [[-0.1, 180, 20]]
+      break
+    case 2:
+      planes = [
+        [0.1, 180, 20],
+        [0.1, 0, -20],
+      ]
+      break
+    case 3:
+      planes = [
+        [0.0, 90, 0], //right center
+        [0.0, 0, -20], //posterior oblique
+        [0.1, 0, -90], //inferior
+      ]
+      break
+    case 4:
+      planes = [
+        [0.3, 270, 0], //left
+        [0.3, 90, 0], //right
+        [0.0, 180, 0], //anterior
+        [0.1, 0, 0], //posterior
+      ]
+      break
+    case 5:
+      planes = [
+        [0.4, 270, 0], //left
+        [0.4, 90, 0], //right
+        [0.4, 180, 0], //anterior
+        [0.2, 0, 0], //posterior
+        [0.1, 0, -90], //inferior
+      ]
+      break
+    case 6:
+      planes = [
+        [0.4, 270, 0], //left
+        [-0.1, 90, 0], //right
+        [0.4, 180, 0], //anterior
+        [0.2, 0, 0], //posterior
+        [0.1, 0, -90], //inferior
+        [0.3, 0, 90], //superior
+      ]
+      break
+  }
+  nv1.setClipPlanes(planes)
+}
+benchBtn.onclick = async () => {
+  const view = nv1.view
+  if (!view || typeof view.renderAndFlushOffscreen !== 'function') {
+    console.warn('renderAndFlushOffscreen unavailable')
+    return
+  }
+  const backend = view.device ? 'WebGPU' : view.gl ? 'WebGL2' : 'unknown'
+  const WARMUP = 10
+  const SAMPLES = 200
+  benchBtn.disabled = true
+  benchBtn.textContent = 'Benchmarking...'
+  for (let i = 0; i < WARMUP; i++) await view.renderAndFlushOffscreen()
+  // Sanity check for WebGL2: confirm the offscreen FBO actually got pixels.
+  // Helps catch silent no-renders (incomplete FBO, stale bounds, etc.).
+  if (view.gl && view._benchFbo) {
+    const gl = view.gl
+    gl.bindFramebuffer(gl.READ_FRAMEBUFFER, view._benchFbo)
+    const pix = new Uint8Array(4)
+    gl.readPixels(
+      view._benchFboW >> 1,
+      view._benchFboH >> 1,
+      1,
+      1,
+      gl.RGBA,
+      gl.UNSIGNED_BYTE,
+      pix,
+    )
+    gl.bindFramebuffer(gl.READ_FRAMEBUFFER, null)
+    const blank = pix[0] === 0 && pix[1] === 0 && pix[2] === 0
+    console.log(
+      `${backend} FBO ${view._benchFboW}x${view._benchFboH} bounds=${view._boundsWidth}x${view._boundsHeight} center=[${Array.from(pix)}]${blank ? ' BLANK — NOT RENDERING' : ''}`,
+    )
+  } else {
+    console.log(`${backend} bounds=${view._boundsWidth}x${view._boundsHeight}`)
+  }
+  const times = new Float64Array(SAMPLES)
+  for (let i = 0; i < SAMPLES; i++) {
+    const t0 = performance.now()
+    await view.renderAndFlushOffscreen()
+    times[i] = performance.now() - t0
+  }
+  const sorted = Array.from(times).sort((a, b) => a - b)
+  const mean = sorted.reduce((s, x) => s + x, 0) / sorted.length
+  const median = sorted[Math.floor(sorted.length * 0.5)]
+  const p95 = sorted[Math.floor(sorted.length * 0.95)]
+  const fmt = (n) => n.toFixed(2)
+  const msg = `${backend}  n=${SAMPLES}  median=${fmt(median)}ms  mean=${fmt(mean)}ms  p95=${fmt(p95)}ms  (~${fmt(1000 / median)} fps)`
+  console.log(msg)
+  benchBtn.textContent = `${backend} ${fmt(median)}ms`
+  benchBtn.disabled = false
+}
+const nv1 = new NiiVue({ backend: 'webgl2' })
+await nv1.attachToCanvas(gl1)
+nv1.sliceType = 4
+await nv1.loadVolumes([{ url: '/volumes/torso.nii.gz' }])
+nv1.addEventListener('locationChange', (e) => handleLocationChange(e.detail))
+gradSlider.oninput()
+nv1.addColormap('_torso', {
+  R: [0, 0, 185, 185, 252, 0, 103, 216, 127, 127, 0, 222],
+  G: [0, 20, 102, 102, 0, 255, 76, 132, 0, 127, 255, 154],
+  B: [0, 152, 83, 83, 0, 0, 71, 105, 127, 0, 255, 132],
+  A: [0, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255],
+  I: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+  labels: [
+    'background',
+    '1spleen',
+    '2kidneyR',
+    '3kidneyL',
+    '4gallbladder',
+    '5esophagus',
+    '6Liver',
+    '7stomach',
+    '8aorta',
+    '9inferiorvenacava',
+    '10pancreas',
+    '11bladder',
+  ],
+})
+nv1.drawColormap = '_torso'
+await nv1.loadDrawing('/volumes/torsoLabel.nii.gz')
+nv1.drawIsEnabled = false
+clipSelect.onchange()

--- a/packages/niivue/src/NVControlBase.ts
+++ b/packages/niivue/src/NVControlBase.ts
@@ -2614,13 +2614,26 @@ export default class NiiVueGPU extends EventTarget {
         dims: back.dimsRAS,
       })
       const img = nii.img
-      if (img instanceof ArrayBuffer) {
-        throw new Error('loadDrawing: expected typed array, got ArrayBuffer')
+      const imgData =
+        img instanceof ArrayBuffer
+          ? new Uint8Array(img)
+          : new Uint8Array(img.buffer, img.byteOffset, img.byteLength)
+      // Drawing voxel count must match background, otherwise transformBitmap
+      // will read out-of-bounds or write truncated output.
+      const backVoxels = back.dimsRAS[1] * back.dimsRAS[2] * back.dimsRAS[3]
+      const drawVoxels = nii.hdr.dims[1] * nii.hdr.dims[2] * nii.hdr.dims[3]
+      if (drawVoxels !== backVoxels) {
+        log.warn(
+          `loadDrawing: drawing dimensions (${nii.hdr.dims[1]}x${nii.hdr.dims[2]}x${nii.hdr.dims[3]} = ${drawVoxels} voxels) do not match background (${back.dimsRAS[1]}x${back.dimsRAS[2]}x${back.dimsRAS[3]} = ${backVoxels} voxels)`,
+        )
+        return false
       }
-      const buf = img.buffer as ArrayBuffer
-      const offset = img.byteOffset
-      const length = img.byteLength
-      const imgData = new Uint8Array(buf, offset, length)
+      if (imgData.length < drawVoxels) {
+        log.warn(
+          `loadDrawing: image data (${imgData.length} bytes) smaller than expected (${drawVoxels})`,
+        )
+        return false
+      }
       const transformedBitmap = transformBitmap({
         inputData: imgData,
         dims: back.dimsRAS,
@@ -2750,7 +2763,8 @@ export default class NiiVueGPU extends EventTarget {
    */
   addColormap(
     name: string,
-    cmap: Pick<ColorMap, 'R' | 'G' | 'B'> & Partial<Pick<ColorMap, 'A' | 'I'>>,
+    cmap: Pick<ColorMap, 'R' | 'G' | 'B'> &
+      Partial<Pick<ColorMap, 'A' | 'I' | 'labels'>>,
   ): string {
     const canonical = NVCmaps.addColormap(name, cmap)
     this.emit('colormapAdded', { name: canonical })

--- a/packages/niivue/src/cmap/NVCmaps.ts
+++ b/packages/niivue/src/cmap/NVCmaps.ts
@@ -88,7 +88,9 @@ export function makeLabelLut(
   if (cm.labels) {
     const nL = cm.labels.length
     if (nL === nLabelsDense) {
-      cmap.labels = cm.labels
+      // Copy to decouple the returned LUT from the caller's array; callers
+      // that mutate their input should not mutate the cached LUT.
+      cmap.labels = cm.labels.slice()
     } else if (nL === nLabels) {
       cmap.labels = Array(nLabelsDense).fill('?')
       for (let i = 0; i < nLabels; i++) {
@@ -108,6 +110,7 @@ type LutDef = {
   B: number[]
   A: number[]
   I: number[]
+  labels?: string[]
 }
 let _lutIndex: Map<string, LutDef> | null = null
 
@@ -133,7 +136,7 @@ function buildLutIndex(): Map<string, LutDef> {
         Array.isArray(mod.B) &&
         Array.isArray(mod.I)
       ) {
-        map.set(name, {
+        const entry: LutDef = {
           R: (mod.R as number[]).map(Number),
           G: (mod.G as number[]).map(Number),
           B: (mod.B as number[]).map(Number),
@@ -141,7 +144,11 @@ function buildLutIndex(): Map<string, LutDef> {
             ? (mod.A as number[]).map(Number)
             : new Array((mod.I as number[]).length).fill(255),
           I: (mod.I as number[]).map(Number),
-        })
+        }
+        if (Array.isArray(mod.labels)) {
+          entry.labels = (mod.labels as string[]).slice()
+        }
+        map.set(name, entry)
       } else {
         // skip malformed JSON but keep dev-visible warning
         log.warn(`Skipping LUT ${path}: expected { R,G,B,I } arrays`)
@@ -184,7 +191,8 @@ export function colormapNames(): string[] {
  */
 export function addColormap(
   name: string,
-  cmap: Pick<ColorMap, 'R' | 'G' | 'B'> & Partial<Pick<ColorMap, 'A' | 'I'>>,
+  cmap: Pick<ColorMap, 'R' | 'G' | 'B'> &
+    Partial<Pick<ColorMap, 'A' | 'I' | 'labels'>>,
 ): string {
   const R = cmap.R.map(Number)
   const G = cmap.G.map(Number)
@@ -214,7 +222,9 @@ export function addColormap(
   }
   const canonical = name.charAt(0).toUpperCase() + name.slice(1)
   const map = buildLutIndex()
-  map.set(canonical, { R, G, B, A, I })
+  const entry: LutDef = { R, G, B, A, I }
+  if (Array.isArray(cmap.labels)) entry.labels = cmap.labels.slice()
+  map.set(canonical, entry)
   return canonical
 }
 

--- a/packages/niivue/src/control/locationTracking.ts
+++ b/packages/niivue/src/control/locationTracking.ts
@@ -119,7 +119,7 @@ export function buildLocationMessage(
               const lut = ctx._drawLut
               const localIdx = drawVal - (lut?.min ?? 0)
               const label = lut?.labels?.[localIdx]
-              str += ` draw:${label ?? drawVal}`
+              str += label ? ` ${label}` : ` draw:${drawVal}`
             }
           }
         }

--- a/packages/niivue/src/gl/NVViewGL.ts
+++ b/packages/niivue/src/gl/NVViewGL.ts
@@ -73,6 +73,13 @@ export default class NVGlview {
   private _boundsOffsetX = 0
   private _boundsOffsetY = 0
   private _isSubCanvasBounds = false
+  // Benchmark-only: offscreen FBO cached for renderAndFlushOffscreen
+  private _benchFbo: WebGLFramebuffer | null = null
+  private _benchColorRbo: WebGLRenderbuffer | null = null
+  private _benchDepthRbo: WebGLRenderbuffer | null = null
+  private _benchFboW = 0
+  private _benchFboH = 0
+  private _benchInProgress = false
 
   constructor(
     canvas: HTMLCanvasElement,
@@ -1019,6 +1026,140 @@ export default class NVGlview {
     }
   }
 
+  /**
+   * Wait until render() would not early-return via RAF. Needed so benchmarks
+   * don't measure a no-op when the view is transiently busy (bind-group upload).
+   */
+  private async _waitForBenchReady(): Promise<void> {
+    const MAX_WAIT_FRAMES = 300
+    let tries = 0
+    while (this.isBusy && tries < MAX_WAIT_FRAMES) {
+      await new Promise<void>((r) => requestAnimationFrame(() => r()))
+      tries++
+    }
+    if (this.isBusy) {
+      throw new Error('renderAndFlush: view still busy after waiting')
+    }
+  }
+
+  /**
+   * Render one frame and block until the GPU finishes executing it.
+   * Not for production use — `render()` is fire-and-forget by design.
+   * Counterpart to NVViewGPU.renderAndFlush; benchmarks use this to
+   * measure true CPU+GPU wall-clock per frame.
+   */
+  async renderAndFlush(): Promise<void> {
+    const gl = this.gl
+    if (!gl) return
+    if (this._benchInProgress) {
+      throw new Error('renderAndFlush: concurrent call not allowed')
+    }
+    this._benchInProgress = true
+    try {
+      if (this._boundsWidth === 0 || this._boundsHeight === 0) this.resize()
+      await this._waitForBenchReady()
+      this.render()
+      // Force true GPU sync. gl.finish() is unreliable on some ANGLE/Metal
+      // paths (returns after flush, not completion). Reading a single pixel
+      // serializes the CPU against all prior GPU work — the standard
+      // WebGL benchmarking sync technique. Scissor is disabled at the end
+      // of render(), so (0,0) is always readable.
+      const pix = new Uint8Array(4)
+      gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pix)
+    } finally {
+      this._benchInProgress = false
+    }
+  }
+
+  /**
+   * Render one frame to an offscreen FBO (bypassing the canvas) and block
+   * until the GPU finishes. Removes compositor / present-time coupling so
+   * benchmarks measure pure render cost. Benchmark-only.
+   *
+   * Sub-renderers in this backend (orient overlay, gradient) unbind to the
+   * default framebuffer when done. To keep our offscreen target active across
+   * those internal passes, we transiently redirect `bindFramebuffer(target, null)`
+   * to bind our FBO instead. Restored on exit. A single-flight guard
+   * (`_benchInProgress`) prevents re-entrancy corrupting the shim.
+   */
+  async renderAndFlushOffscreen(): Promise<void> {
+    const gl = this.gl
+    if (!gl) return
+    if (this._benchInProgress) {
+      throw new Error('renderAndFlushOffscreen: concurrent call not allowed')
+    }
+    this._benchInProgress = true
+    try {
+      if (this._boundsWidth === 0 || this._boundsHeight === 0) this.resize()
+      await this._waitForBenchReady()
+      const w = this._boundsWidth
+      const h = this._boundsHeight
+      if (!this._benchFbo || this._benchFboW !== w || this._benchFboH !== h) {
+        if (this._benchFbo) gl.deleteFramebuffer(this._benchFbo)
+        if (this._benchColorRbo) gl.deleteRenderbuffer(this._benchColorRbo)
+        if (this._benchDepthRbo) gl.deleteRenderbuffer(this._benchDepthRbo)
+        this._benchFbo = null
+        this._benchColorRbo = null
+        this._benchDepthRbo = null
+        const color = gl.createRenderbuffer()
+        gl.bindRenderbuffer(gl.RENDERBUFFER, color)
+        gl.renderbufferStorage(gl.RENDERBUFFER, gl.RGBA8, w, h)
+        const depth = gl.createRenderbuffer()
+        gl.bindRenderbuffer(gl.RENDERBUFFER, depth)
+        gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_COMPONENT24, w, h)
+        gl.bindRenderbuffer(gl.RENDERBUFFER, null)
+        const fbo = gl.createFramebuffer()
+        gl.bindFramebuffer(gl.FRAMEBUFFER, fbo)
+        gl.framebufferRenderbuffer(
+          gl.FRAMEBUFFER,
+          gl.COLOR_ATTACHMENT0,
+          gl.RENDERBUFFER,
+          color,
+        )
+        gl.framebufferRenderbuffer(
+          gl.FRAMEBUFFER,
+          gl.DEPTH_ATTACHMENT,
+          gl.RENDERBUFFER,
+          depth,
+        )
+        const status = gl.checkFramebufferStatus(gl.FRAMEBUFFER)
+        gl.bindFramebuffer(gl.FRAMEBUFFER, null)
+        if (status !== gl.FRAMEBUFFER_COMPLETE) {
+          gl.deleteFramebuffer(fbo)
+          gl.deleteRenderbuffer(color)
+          gl.deleteRenderbuffer(depth)
+          throw new Error(
+            `renderAndFlushOffscreen: FBO incomplete (status 0x${status.toString(16)}) at ${w}x${h}`,
+          )
+        }
+        this._benchFbo = fbo
+        this._benchColorRbo = color
+        this._benchDepthRbo = depth
+        this._benchFboW = w
+        this._benchFboH = h
+      }
+      const myFbo = this._benchFbo
+      const mutGL = gl as unknown as Pick<
+        WebGL2RenderingContext,
+        'bindFramebuffer'
+      >
+      const orig = gl.bindFramebuffer.bind(gl)
+      mutGL.bindFramebuffer = (target, fb) =>
+        orig(target, fb === null ? myFbo : fb)
+      try {
+        gl.bindFramebuffer(gl.FRAMEBUFFER, null) // → redirected to myFbo
+        this.render()
+        const pix = new Uint8Array(4)
+        gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pix)
+      } finally {
+        mutGL.bindFramebuffer = orig
+        orig(gl.FRAMEBUFFER, null)
+      }
+    } finally {
+      this._benchInProgress = false
+    }
+  }
+
   resize(): void {
     if (!this.gl) return
     // Calculate device pixel ratio
@@ -1336,6 +1477,14 @@ export default class NVGlview {
     // Delete font texture
     if (this.fontTexture) gl.deleteTexture(this.fontTexture)
     this.fontTexture = null
+
+    // Delete benchmark-only offscreen FBO + attached renderbuffers
+    if (this._benchFbo) gl.deleteFramebuffer(this._benchFbo)
+    if (this._benchColorRbo) gl.deleteRenderbuffer(this._benchColorRbo)
+    if (this._benchDepthRbo) gl.deleteRenderbuffer(this._benchDepthRbo)
+    this._benchFbo = null
+    this._benchColorRbo = null
+    this._benchDepthRbo = null
 
     // Destroy render layer instances
     this.volumeRenderer.destroy()

--- a/packages/niivue/src/gl/NVViewGL.ts
+++ b/packages/niivue/src/gl/NVViewGL.ts
@@ -25,6 +25,7 @@ import * as NVRuler from '@/view/NVRuler'
 import type { SliceTile } from '@/view/NVSliceLayout'
 import * as NVSliceLayout from '@/view/NVSliceLayout'
 import * as NVUILayout from '@/view/NVUILayout'
+import { GLBench } from './bench'
 import { ColorbarRenderer } from './colorbar'
 import { CrosshairRenderer } from './crosshair'
 import { FontRenderer } from './font'
@@ -73,13 +74,16 @@ export default class NVGlview {
   private _boundsOffsetX = 0
   private _boundsOffsetY = 0
   private _isSubCanvasBounds = false
-  // Benchmark-only: offscreen FBO cached for renderAndFlushOffscreen
-  private _benchFbo: WebGLFramebuffer | null = null
-  private _benchColorRbo: WebGLRenderbuffer | null = null
-  private _benchDepthRbo: WebGLRenderbuffer | null = null
-  private _benchFboW = 0
-  private _benchFboH = 0
-  private _benchInProgress = false
+  // Narrow public getters for bench.ts to read current render-area size
+  // without making the backing fields public or mutable.
+  get boundsWidth(): number {
+    return this._boundsWidth
+  }
+  get boundsHeight(): number {
+    return this._boundsHeight
+  }
+  // Lazily created on first `view.bench` access; see ./bench.ts.
+  private _bench: GLBench | null = null
 
   constructor(
     canvas: HTMLCanvasElement,
@@ -1026,138 +1030,20 @@ export default class NVGlview {
     }
   }
 
-  /**
-   * Wait until render() would not early-return via RAF. Needed so benchmarks
-   * don't measure a no-op when the view is transiently busy (bind-group upload).
-   */
-  private async _waitForBenchReady(): Promise<void> {
-    const MAX_WAIT_FRAMES = 300
-    let tries = 0
-    while (this.isBusy && tries < MAX_WAIT_FRAMES) {
-      await new Promise<void>((r) => requestAnimationFrame(() => r()))
-      tries++
-    }
-    if (this.isBusy) {
-      throw new Error('renderAndFlush: view still busy after waiting')
-    }
+  /** Lazy bench harness. Not for production use. See ./bench.ts. */
+  get bench(): GLBench {
+    if (!this._bench) this._bench = new GLBench(this)
+    return this._bench
   }
 
-  /**
-   * Render one frame and block until the GPU finishes executing it.
-   * Not for production use — `render()` is fire-and-forget by design.
-   * Counterpart to NVViewGPU.renderAndFlush; benchmarks use this to
-   * measure true CPU+GPU wall-clock per frame.
-   */
-  async renderAndFlush(): Promise<void> {
-    const gl = this.gl
-    if (!gl) return
-    if (this._benchInProgress) {
-      throw new Error('renderAndFlush: concurrent call not allowed')
-    }
-    this._benchInProgress = true
-    try {
-      if (this._boundsWidth === 0 || this._boundsHeight === 0) this.resize()
-      await this._waitForBenchReady()
-      this.render()
-      // Force true GPU sync. gl.finish() is unreliable on some ANGLE/Metal
-      // paths (returns after flush, not completion). Reading a single pixel
-      // serializes the CPU against all prior GPU work — the standard
-      // WebGL benchmarking sync technique. Scissor is disabled at the end
-      // of render(), so (0,0) is always readable.
-      const pix = new Uint8Array(4)
-      gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pix)
-    } finally {
-      this._benchInProgress = false
-    }
+  /** Benchmark-only: render to canvas and block until the GPU finishes. */
+  renderAndFlush(): Promise<void> {
+    return this.bench.renderAndFlush()
   }
 
-  /**
-   * Render one frame to an offscreen FBO (bypassing the canvas) and block
-   * until the GPU finishes. Removes compositor / present-time coupling so
-   * benchmarks measure pure render cost. Benchmark-only.
-   *
-   * Sub-renderers in this backend (orient overlay, gradient) unbind to the
-   * default framebuffer when done. To keep our offscreen target active across
-   * those internal passes, we transiently redirect `bindFramebuffer(target, null)`
-   * to bind our FBO instead. Restored on exit. A single-flight guard
-   * (`_benchInProgress`) prevents re-entrancy corrupting the shim.
-   */
-  async renderAndFlushOffscreen(): Promise<void> {
-    const gl = this.gl
-    if (!gl) return
-    if (this._benchInProgress) {
-      throw new Error('renderAndFlushOffscreen: concurrent call not allowed')
-    }
-    this._benchInProgress = true
-    try {
-      if (this._boundsWidth === 0 || this._boundsHeight === 0) this.resize()
-      await this._waitForBenchReady()
-      const w = this._boundsWidth
-      const h = this._boundsHeight
-      if (!this._benchFbo || this._benchFboW !== w || this._benchFboH !== h) {
-        if (this._benchFbo) gl.deleteFramebuffer(this._benchFbo)
-        if (this._benchColorRbo) gl.deleteRenderbuffer(this._benchColorRbo)
-        if (this._benchDepthRbo) gl.deleteRenderbuffer(this._benchDepthRbo)
-        this._benchFbo = null
-        this._benchColorRbo = null
-        this._benchDepthRbo = null
-        const color = gl.createRenderbuffer()
-        gl.bindRenderbuffer(gl.RENDERBUFFER, color)
-        gl.renderbufferStorage(gl.RENDERBUFFER, gl.RGBA8, w, h)
-        const depth = gl.createRenderbuffer()
-        gl.bindRenderbuffer(gl.RENDERBUFFER, depth)
-        gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_COMPONENT24, w, h)
-        gl.bindRenderbuffer(gl.RENDERBUFFER, null)
-        const fbo = gl.createFramebuffer()
-        gl.bindFramebuffer(gl.FRAMEBUFFER, fbo)
-        gl.framebufferRenderbuffer(
-          gl.FRAMEBUFFER,
-          gl.COLOR_ATTACHMENT0,
-          gl.RENDERBUFFER,
-          color,
-        )
-        gl.framebufferRenderbuffer(
-          gl.FRAMEBUFFER,
-          gl.DEPTH_ATTACHMENT,
-          gl.RENDERBUFFER,
-          depth,
-        )
-        const status = gl.checkFramebufferStatus(gl.FRAMEBUFFER)
-        gl.bindFramebuffer(gl.FRAMEBUFFER, null)
-        if (status !== gl.FRAMEBUFFER_COMPLETE) {
-          gl.deleteFramebuffer(fbo)
-          gl.deleteRenderbuffer(color)
-          gl.deleteRenderbuffer(depth)
-          throw new Error(
-            `renderAndFlushOffscreen: FBO incomplete (status 0x${status.toString(16)}) at ${w}x${h}`,
-          )
-        }
-        this._benchFbo = fbo
-        this._benchColorRbo = color
-        this._benchDepthRbo = depth
-        this._benchFboW = w
-        this._benchFboH = h
-      }
-      const myFbo = this._benchFbo
-      const mutGL = gl as unknown as Pick<
-        WebGL2RenderingContext,
-        'bindFramebuffer'
-      >
-      const orig = gl.bindFramebuffer.bind(gl)
-      mutGL.bindFramebuffer = (target, fb) =>
-        orig(target, fb === null ? myFbo : fb)
-      try {
-        gl.bindFramebuffer(gl.FRAMEBUFFER, null) // → redirected to myFbo
-        this.render()
-        const pix = new Uint8Array(4)
-        gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pix)
-      } finally {
-        mutGL.bindFramebuffer = orig
-        orig(gl.FRAMEBUFFER, null)
-      }
-    } finally {
-      this._benchInProgress = false
-    }
+  /** Benchmark-only: render to an offscreen FBO and block until the GPU finishes. */
+  renderAndFlushOffscreen(): Promise<void> {
+    return this.bench.renderAndFlushOffscreen()
   }
 
   resize(): void {
@@ -1478,13 +1364,9 @@ export default class NVGlview {
     if (this.fontTexture) gl.deleteTexture(this.fontTexture)
     this.fontTexture = null
 
-    // Delete benchmark-only offscreen FBO + attached renderbuffers
-    if (this._benchFbo) gl.deleteFramebuffer(this._benchFbo)
-    if (this._benchColorRbo) gl.deleteRenderbuffer(this._benchColorRbo)
-    if (this._benchDepthRbo) gl.deleteRenderbuffer(this._benchDepthRbo)
-    this._benchFbo = null
-    this._benchColorRbo = null
-    this._benchDepthRbo = null
+    // Release benchmark resources (owned by bench module)
+    this._bench?.destroy()
+    this._bench = null
 
     // Destroy render layer instances
     this.volumeRenderer.destroy()

--- a/packages/niivue/src/gl/bench.ts
+++ b/packages/niivue/src/gl/bench.ts
@@ -1,0 +1,189 @@
+import type NVGlview from './NVViewGL'
+
+/**
+ * Benchmark harness for the WebGL2 backend. Not for production use —
+ * `view.render()` is fire-and-forget by design. This helper exists so
+ * benchmarks can measure true CPU+GPU wall-clock per frame.
+ *
+ * Lazily constructed on first access via `view.bench`. Kept in a
+ * separate module so bench-only state (offscreen FBO, concurrent-call
+ * guard) does not pollute the hot-path view class.
+ */
+export class GLBench {
+  private _fbo: WebGLFramebuffer | null = null
+  private _colorRbo: WebGLRenderbuffer | null = null
+  private _depthRbo: WebGLRenderbuffer | null = null
+  private _fboW = 0
+  private _fboH = 0
+  private _inProgress = false
+  // Set by destroy(). Checked after every await so a bench call that was
+  // mid-await when the view tore down its bench exits cleanly rather than
+  // allocating orphan GPU resources on a disposed view.
+  private _disposed = false
+
+  constructor(private view: NVGlview) {}
+
+  /** Offscreen FBO sized to the last bench render, or null before first call. */
+  get fbo(): WebGLFramebuffer | null {
+    return this._fbo
+  }
+  get fboW(): number {
+    return this._fboW
+  }
+  get fboH(): number {
+    return this._fboH
+  }
+
+  /** Render to the canvas and block until the GPU finishes. */
+  async renderAndFlush(): Promise<void> {
+    if (this._disposed) return
+    const view = this.view
+    const gl = view.gl
+    if (!gl) return
+    if (this._inProgress) {
+      throw new Error('renderAndFlush: concurrent call not allowed')
+    }
+    this._inProgress = true
+    try {
+      if (view.boundsWidth === 0 || view.boundsHeight === 0) view.resize()
+      await this._waitForReady()
+      if (this._disposed) return
+      view.render()
+      // Force true GPU sync. gl.finish() is unreliable on some ANGLE/Metal
+      // paths (returns after flush, not completion). Reading a single pixel
+      // serializes the CPU against all prior GPU work — the standard
+      // WebGL benchmarking sync technique. Scissor is disabled at the end
+      // of render(), so (0,0) is always readable.
+      const pix = new Uint8Array(4)
+      gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pix)
+    } finally {
+      this._inProgress = false
+    }
+  }
+
+  /**
+   * Render to an offscreen FBO (bypassing the canvas swap chain) and block
+   * until the GPU finishes. Removes compositor / present-time coupling so
+   * benchmarks measure pure render cost.
+   *
+   * Sub-renderers in this backend (orient overlay, gradient) unbind to the
+   * default framebuffer when done. To keep our offscreen target active
+   * across those internal passes, we transiently redirect
+   * `bindFramebuffer(target, null)` to bind our FBO instead. Restored on
+   * exit. A single-flight guard prevents re-entrancy corrupting the shim.
+   */
+  async renderAndFlushOffscreen(): Promise<void> {
+    if (this._disposed) return
+    const view = this.view
+    const gl = view.gl
+    if (!gl) return
+    if (this._inProgress) {
+      throw new Error('renderAndFlushOffscreen: concurrent call not allowed')
+    }
+    this._inProgress = true
+    try {
+      if (view.boundsWidth === 0 || view.boundsHeight === 0) view.resize()
+      await this._waitForReady()
+      if (this._disposed) return
+      const w = view.boundsWidth
+      const h = view.boundsHeight
+      this._ensureFbo(gl, w, h)
+      const myFbo = this._fbo
+      if (!myFbo) return
+      const mutGL = gl as unknown as Pick<
+        WebGL2RenderingContext,
+        'bindFramebuffer'
+      >
+      const orig = gl.bindFramebuffer.bind(gl)
+      mutGL.bindFramebuffer = (target, fb) =>
+        orig(target, fb === null ? myFbo : fb)
+      try {
+        gl.bindFramebuffer(gl.FRAMEBUFFER, null) // → redirected to myFbo
+        view.render()
+        const pix = new Uint8Array(4)
+        gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pix)
+      } finally {
+        mutGL.bindFramebuffer = orig
+        orig(gl.FRAMEBUFFER, null)
+      }
+    } finally {
+      this._inProgress = false
+    }
+  }
+
+  /** Release all GPU resources owned by this bench. */
+  destroy(): void {
+    this._disposed = true
+    const gl = this.view.gl
+    if (gl) {
+      if (this._fbo) gl.deleteFramebuffer(this._fbo)
+      if (this._colorRbo) gl.deleteRenderbuffer(this._colorRbo)
+      if (this._depthRbo) gl.deleteRenderbuffer(this._depthRbo)
+    }
+    this._fbo = null
+    this._colorRbo = null
+    this._depthRbo = null
+    this._fboW = 0
+    this._fboH = 0
+  }
+
+  private async _waitForReady(): Promise<void> {
+    const view = this.view
+    const MAX_WAIT_FRAMES = 300
+    let tries = 0
+    while (view.isBusy && tries < MAX_WAIT_FRAMES) {
+      await new Promise<void>((r) => requestAnimationFrame(() => r()))
+      tries++
+    }
+    if (view.isBusy) {
+      throw new Error('renderAndFlush: view still busy after waiting')
+    }
+  }
+
+  private _ensureFbo(gl: WebGL2RenderingContext, w: number, h: number): void {
+    if (this._fbo && this._fboW === w && this._fboH === h) return
+    if (this._fbo) gl.deleteFramebuffer(this._fbo)
+    if (this._colorRbo) gl.deleteRenderbuffer(this._colorRbo)
+    if (this._depthRbo) gl.deleteRenderbuffer(this._depthRbo)
+    this._fbo = null
+    this._colorRbo = null
+    this._depthRbo = null
+
+    const color = gl.createRenderbuffer()
+    gl.bindRenderbuffer(gl.RENDERBUFFER, color)
+    gl.renderbufferStorage(gl.RENDERBUFFER, gl.RGBA8, w, h)
+    const depth = gl.createRenderbuffer()
+    gl.bindRenderbuffer(gl.RENDERBUFFER, depth)
+    gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_COMPONENT24, w, h)
+    gl.bindRenderbuffer(gl.RENDERBUFFER, null)
+    const fbo = gl.createFramebuffer()
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fbo)
+    gl.framebufferRenderbuffer(
+      gl.FRAMEBUFFER,
+      gl.COLOR_ATTACHMENT0,
+      gl.RENDERBUFFER,
+      color,
+    )
+    gl.framebufferRenderbuffer(
+      gl.FRAMEBUFFER,
+      gl.DEPTH_ATTACHMENT,
+      gl.RENDERBUFFER,
+      depth,
+    )
+    const status = gl.checkFramebufferStatus(gl.FRAMEBUFFER)
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null)
+    if (status !== gl.FRAMEBUFFER_COMPLETE) {
+      gl.deleteFramebuffer(fbo)
+      gl.deleteRenderbuffer(color)
+      gl.deleteRenderbuffer(depth)
+      throw new Error(
+        `renderAndFlushOffscreen: FBO incomplete (status 0x${status.toString(16)}) at ${w}x${h}`,
+      )
+    }
+    this._fbo = fbo
+    this._colorRbo = color
+    this._depthRbo = depth
+    this._fboW = w
+    this._fboH = h
+  }
+}

--- a/packages/niivue/src/gl/render.ts
+++ b/packages/niivue/src/gl/render.ts
@@ -24,6 +24,7 @@ export class VolumeRenderer extends NVRenderer {
   paqdTexture: WebGLTexture | null
   paqdLutTexture: WebGLTexture | null
   drawingTexture: WebGLTexture | null
+  drawingLinearSampler: WebGLSampler | null
   placeholderOverlay: WebGLTexture | null
   cubeVAO: WebGLVertexArrayObject | null
   vertexBuffer: WebGLBuffer | null
@@ -43,6 +44,7 @@ export class VolumeRenderer extends NVRenderer {
     this.paqdTexture = null
     this.paqdLutTexture = null
     this.drawingTexture = null
+    this.drawingLinearSampler = null
     this.placeholderOverlay = null
     this.cubeVAO = null
     this.vertexBuffer = null
@@ -503,6 +505,31 @@ export class VolumeRenderer extends NVRenderer {
       gl.uniform1i(shader.uniforms.drawing, 5)
     }
 
+    // Bind drawing texture a second time at unit 7, via a LINEAR sampler
+    // object so we can take trilinearly-filtered samples of the same
+    // texture for smooth gradient computation at first-hit (unit 5 keeps
+    // NEAREST filtering for the categorical ray-march).
+    if (!this.drawingLinearSampler) {
+      const s = gl.createSampler()
+      if (s) {
+        gl.samplerParameteri(s, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
+        gl.samplerParameteri(s, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
+        gl.samplerParameteri(s, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+        gl.samplerParameteri(s, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+        gl.samplerParameteri(s, gl.TEXTURE_WRAP_R, gl.CLAMP_TO_EDGE)
+        this.drawingLinearSampler = s
+      }
+    }
+    gl.activeTexture(gl.TEXTURE7)
+    gl.bindTexture(
+      gl.TEXTURE_3D,
+      this.drawingTexture || this.placeholderOverlay,
+    )
+    gl.bindSampler(7, this.drawingLinearSampler)
+    if (shader.uniforms.drawingLinear) {
+      gl.uniform1i(shader.uniforms.drawingLinear, 7)
+    }
+
     // Bind PAQD LUT to unit 6 (nearest-neighbor 2D texture)
     gl.activeTexture(gl.TEXTURE6)
     if (this.paqdLutTexture) {
@@ -711,6 +738,7 @@ export class VolumeRenderer extends NVRenderer {
     if (this.overlayTexture) gl.deleteTexture(this.overlayTexture)
     if (this.paqdTexture) gl.deleteTexture(this.paqdTexture)
     if (this.drawingTexture) gl.deleteTexture(this.drawingTexture)
+    if (this.drawingLinearSampler) gl.deleteSampler(this.drawingLinearSampler)
     if (this.placeholderOverlay) gl.deleteTexture(this.placeholderOverlay)
     this.matcapTexture = null
     this.volumeTexture = null
@@ -718,6 +746,7 @@ export class VolumeRenderer extends NVRenderer {
     this.overlayTexture = null
     this.paqdTexture = null
     this.drawingTexture = null
+    this.drawingLinearSampler = null
     this.placeholderOverlay = null
 
     // Delete shader program

--- a/packages/niivue/src/gl/renderShader.ts
+++ b/packages/niivue/src/gl/renderShader.ts
@@ -15,6 +15,25 @@ uniform sampler3D overlay;
 uniform sampler3D paqd;
 uniform sampler2D paqdLut;
 uniform sampler3D drawing;
+uniform sampler3D drawingLinear;
+
+// Drawing-gradient tuning constants. Kept inline because they are shader
+// authoring choices (widens vs sharpens the gradient stencil), not
+// runtime-tunable parameters.
+// Offset (in voxels) for the 6-tap gradient stencil. The non-integer value
+// exploits the LINEAR sampler — each tap is a trilinear blend of 8 texels,
+// giving a Gaussian-like smoothing for free.
+const float DRAW_GRAD_OFFSET = 1.5;
+// Below this, the gradient is too small to normalize reliably.
+const float DRAW_GRAD_EPSILON = 1e-6;
+// Weighted scalar projection of drawing RGBA → f32. Luminance weights on
+// RGB distinguish distinct label colors; heavy alpha weight (2.0) makes
+// background→drawing transitions dominate. Switched from length(rgba) which
+// missed label-to-label boundaries when two labels had similar-magnitude
+// RGBA vectors (common when labels share alpha=255 and differ only in hue).
+float drawScalar(vec4 c) {
+  return dot(c, vec4(0.299, 0.587, 0.114, 2.0));
+}
 
 struct RayResult {
   vec4 color;
@@ -364,6 +383,39 @@ void main() {
   // Drawing pass (nearest-neighbor sampling — NEAREST filter set by CPU)
   if (textureSize(drawing, 0).x > 2) {
     RayResult result = rayMarchPass(drawing, origStart, dir, origLen, deltaDir, deltaDirFast, ran, earlyTermination);
+    // Matcap lighting at first hit. 6-tap central-difference gradient on
+    // the drawing texture with LINEAR filtering — each tap is a trilinear
+    // blend of 8 texels, which approximates a Gaussian-smoothed sample
+    // (the "bilinear free smoothing" trick). Sampling at 1.5 voxels out
+    // widens the stencil, further reducing per-pixel noise from the
+    // ray-march step discretization and ran jitter. Sign convention:
+    // gx = value(+x) - value(-x), matching the volume gradient (inward-
+    // pointing toward higher drawing density).
+    if (result.color.a > 0.001 && gradientAmount > 0.0) {
+      vec3 dv = DRAW_GRAD_OFFSET / vec3(textureSize(drawingLinear, 0));
+      vec3 hp = result.firstHit.xyz;
+      float vXp = drawScalar(texture(drawingLinear, hp + vec3(dv.x, 0.0, 0.0)));
+      float vXm = drawScalar(texture(drawingLinear, hp - vec3(dv.x, 0.0, 0.0)));
+      float vYp = drawScalar(texture(drawingLinear, hp + vec3(0.0, dv.y, 0.0)));
+      float vYm = drawScalar(texture(drawingLinear, hp - vec3(0.0, dv.y, 0.0)));
+      float vZp = drawScalar(texture(drawingLinear, hp + vec3(0.0, 0.0, dv.z)));
+      float vZm = drawScalar(texture(drawingLinear, hp - vec3(0.0, 0.0, dv.z)));
+      vec3 grad = vec3(vXp - vXm, vYp - vYm, vZp - vZm);
+      if (length(grad) > DRAW_GRAD_EPSILON) {
+        vec3 localNormal = normalize(grad);
+        mat3 norm3d = mat3(normMtx);
+        vec3 n = norm3d * localNormal;
+        vec2 uv = n.xy * 0.5 + 0.5;
+        float brighten = 1.0 + (gradientAmount / 3.0);
+        vec3 mc_rgb = texture(matcap, uv).rgb * brighten;
+        vec3 shade = mix(vec3(1.0), mc_rgb, gradientAmount);
+        // result.color is premultiplied (rgb = actualColor * alpha).
+        // Clamp to alpha so the shade (which can exceed 1.0 via brighten)
+        // can't push rgb > alpha and break the premultiplied-alpha
+        // invariant that depthAwareMix and framebuffer blending assume.
+        result.color.rgb = min(result.color.rgb * shade, vec3(result.color.a));
+      }
+    }
     depthAwareMix(colAcc, result, backNearest, fragDepth, depthFactor);
   }
   // Final output

--- a/packages/niivue/src/wgpu/NVViewGPU.ts
+++ b/packages/niivue/src/wgpu/NVViewGPU.ts
@@ -25,6 +25,7 @@ import * as NVRuler from '@/view/NVRuler'
 import type { SliceTile } from '@/view/NVSliceLayout'
 import * as NVSliceLayout from '@/view/NVSliceLayout'
 import * as NVUILayout from '@/view/NVUILayout'
+import { WGPUBench } from './bench'
 import { ColorbarRenderer } from './colorbar'
 import { CrosshairRenderer } from './crosshair'
 import * as depthPick from './depthPick'
@@ -101,10 +102,28 @@ export default class NVView {
   private _msaaTextureView: GPUTextureView | null = null
   // Reusable scratch buffer for mesh uniform writes — avoids per-call Float32Array allocation
   private _uniformScratch = new Float32Array(mesh.MESH_UNIFORM_SIZE / 4)
-  // Benchmark-only: when non-null, render() writes here instead of the canvas swap chain
-  private _benchTargetOverride: GPUTexture | null = null
-  private _benchOffscreenTexture: GPUTexture | null = null
-  private _benchInProgress = false
+  // Narrow public getters for bench.ts to read current render-area size
+  // without making the backing fields public or mutable.
+  get boundsWidth(): number {
+    return this._boundsWidth
+  }
+  get boundsHeight(): number {
+    return this._boundsHeight
+  }
+  /**
+   * Benchmark-only helper: force _isSubCanvasBounds to false (so render()
+   * writes directly to the bench override target rather than copying
+   * through _boundsColorTexture) and return a restore function.
+   */
+  suppressSubCanvasBounds(): () => void {
+    const saved = this._isSubCanvasBounds
+    this._isSubCanvasBounds = false
+    return () => {
+      this._isSubCanvasBounds = saved
+    }
+  }
+  // Lazily created on first `view.bench` access; see ./bench.ts.
+  private _bench: WGPUBench | null = null
 
   constructor(
     canvas: HTMLCanvasElement,
@@ -582,7 +601,7 @@ export default class NVView {
     }
     // Determine render targets based on bounds mode
     const canvasTexture =
-      this._benchTargetOverride ?? this.context.getCurrentTexture()
+      this._bench?.targetOverride ?? this.context.getCurrentTexture()
     const bw = this._boundsWidth
     const bh = this._boundsHeight
     const isSub = this._isSubCanvasBounds && this._boundsColorTexture
@@ -1369,90 +1388,20 @@ export default class NVView {
     device.queue.submit([commandEncoder.finish()])
   }
 
-  /**
-   * Wait until render() would not early-return via RAF. Needed so benchmarks
-   * don't measure a no-op when the view is transiently busy (e.g. uploading
-   * bind groups) or the font atlas is still loading.
-   */
-  private async _waitForBenchReady(): Promise<void> {
-    const MAX_WAIT_FRAMES = 300
-    let tries = 0
-    while (
-      (this.isBusy || !this.fontRenderer.isReady) &&
-      tries < MAX_WAIT_FRAMES
-    ) {
-      await new Promise<void>((r) => requestAnimationFrame(() => r()))
-      tries++
-    }
-    if (this.isBusy || !this.fontRenderer.isReady) {
-      throw new Error(
-        'renderAndFlush: view not ready (isBusy or font atlas not loaded)',
-      )
-    }
+  /** Lazy bench harness. Not for production use. See ./bench.ts. */
+  get bench(): WGPUBench {
+    if (!this._bench) this._bench = new WGPUBench(this)
+    return this._bench
   }
 
-  /**
-   * Render one frame and wait for the GPU to finish executing it.
-   * Not for production use — `render()` is fire-and-forget by design.
-   * This helper exists so benchmarks can measure true CPU+GPU wall-clock
-   * per frame via `await view.renderAndFlush()`.
-   */
-  async renderAndFlush(): Promise<void> {
-    if (this._benchInProgress) {
-      throw new Error('renderAndFlush: concurrent call not allowed')
-    }
-    this._benchInProgress = true
-    try {
-      if (this._boundsWidth === 0 || this._boundsHeight === 0) this.resize()
-      await this._waitForBenchReady()
-      this.render()
-      if (this.device) await this.device.queue.onSubmittedWorkDone()
-    } finally {
-      this._benchInProgress = false
-    }
+  /** Benchmark-only: render to canvas and await GPU completion. */
+  renderAndFlush(): Promise<void> {
+    return this.bench.renderAndFlush()
   }
 
-  /**
-   * Render one frame to an offscreen texture (bypassing the canvas swap chain)
-   * and wait for the GPU to finish. Removes compositor / present-time coupling
-   * so benchmarks measure pure render cost. Benchmark-only.
-   */
-  async renderAndFlushOffscreen(): Promise<void> {
-    if (!this.device) return
-    if (this._benchInProgress) {
-      throw new Error('renderAndFlushOffscreen: concurrent call not allowed')
-    }
-    this._benchInProgress = true
-    try {
-      if (this._boundsWidth === 0 || this._boundsHeight === 0) this.resize()
-      await this._waitForBenchReady()
-      const w = this._boundsWidth
-      const h = this._boundsHeight
-      const existing = this._benchOffscreenTexture
-      if (!existing || existing.width !== w || existing.height !== h) {
-        existing?.destroy()
-        this._benchOffscreenTexture = this.device.createTexture({
-          size: { width: w, height: h },
-          format: this.preferredCanvasFormat,
-          usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_DST,
-        })
-      }
-      // Suppress sub-canvas mode during bench so render() writes directly
-      // to the override texture rather than through _boundsColorTexture +
-      // _copyBoundsToCanvas (which would copy into the FBO at an offset).
-      const wasSubCanvas = this._isSubCanvasBounds
-      this._isSubCanvasBounds = false
-      this._benchTargetOverride = this._benchOffscreenTexture
-      try {
-        this.render()
-        await this.device.queue.onSubmittedWorkDone()
-      } finally {
-        this._benchTargetOverride = null
-        this._isSubCanvasBounds = wasSubCanvas
-      }
-    } finally {
-      this._benchInProgress = false
-    }
+  /** Benchmark-only: render to an offscreen texture and await GPU completion. */
+  renderAndFlushOffscreen(): Promise<void> {
+    return this.bench.renderAndFlushOffscreen()
   }
 
   /** Copy this view's intermediate texture and all siblings' to the canvas */
@@ -2134,12 +2083,9 @@ export default class NVView {
       this.orientCubeGpu = null
     }
 
-    // Destroy benchmark-only offscreen texture
-    if (this._benchOffscreenTexture) {
-      this._benchOffscreenTexture.destroy()
-      this._benchOffscreenTexture = null
-    }
-    this._benchTargetOverride = null
+    // Release benchmark resources (owned by bench module)
+    this._bench?.destroy()
+    this._bench = null
 
     // Destroy MSAA, bounds color, and depth textures
     if (this.msaaTexture) {

--- a/packages/niivue/src/wgpu/NVViewGPU.ts
+++ b/packages/niivue/src/wgpu/NVViewGPU.ts
@@ -101,6 +101,10 @@ export default class NVView {
   private _msaaTextureView: GPUTextureView | null = null
   // Reusable scratch buffer for mesh uniform writes — avoids per-call Float32Array allocation
   private _uniformScratch = new Float32Array(mesh.MESH_UNIFORM_SIZE / 4)
+  // Benchmark-only: when non-null, render() writes here instead of the canvas swap chain
+  private _benchTargetOverride: GPUTexture | null = null
+  private _benchOffscreenTexture: GPUTexture | null = null
+  private _benchInProgress = false
 
   constructor(
     canvas: HTMLCanvasElement,
@@ -577,7 +581,8 @@ export default class NVView {
       return
     }
     // Determine render targets based on bounds mode
-    const canvasTexture = this.context.getCurrentTexture()
+    const canvasTexture =
+      this._benchTargetOverride ?? this.context.getCurrentTexture()
     const bw = this._boundsWidth
     const bh = this._boundsHeight
     const isSub = this._isSubCanvasBounds && this._boundsColorTexture
@@ -1364,6 +1369,92 @@ export default class NVView {
     device.queue.submit([commandEncoder.finish()])
   }
 
+  /**
+   * Wait until render() would not early-return via RAF. Needed so benchmarks
+   * don't measure a no-op when the view is transiently busy (e.g. uploading
+   * bind groups) or the font atlas is still loading.
+   */
+  private async _waitForBenchReady(): Promise<void> {
+    const MAX_WAIT_FRAMES = 300
+    let tries = 0
+    while (
+      (this.isBusy || !this.fontRenderer.isReady) &&
+      tries < MAX_WAIT_FRAMES
+    ) {
+      await new Promise<void>((r) => requestAnimationFrame(() => r()))
+      tries++
+    }
+    if (this.isBusy || !this.fontRenderer.isReady) {
+      throw new Error(
+        'renderAndFlush: view not ready (isBusy or font atlas not loaded)',
+      )
+    }
+  }
+
+  /**
+   * Render one frame and wait for the GPU to finish executing it.
+   * Not for production use — `render()` is fire-and-forget by design.
+   * This helper exists so benchmarks can measure true CPU+GPU wall-clock
+   * per frame via `await view.renderAndFlush()`.
+   */
+  async renderAndFlush(): Promise<void> {
+    if (this._benchInProgress) {
+      throw new Error('renderAndFlush: concurrent call not allowed')
+    }
+    this._benchInProgress = true
+    try {
+      if (this._boundsWidth === 0 || this._boundsHeight === 0) this.resize()
+      await this._waitForBenchReady()
+      this.render()
+      if (this.device) await this.device.queue.onSubmittedWorkDone()
+    } finally {
+      this._benchInProgress = false
+    }
+  }
+
+  /**
+   * Render one frame to an offscreen texture (bypassing the canvas swap chain)
+   * and wait for the GPU to finish. Removes compositor / present-time coupling
+   * so benchmarks measure pure render cost. Benchmark-only.
+   */
+  async renderAndFlushOffscreen(): Promise<void> {
+    if (!this.device) return
+    if (this._benchInProgress) {
+      throw new Error('renderAndFlushOffscreen: concurrent call not allowed')
+    }
+    this._benchInProgress = true
+    try {
+      if (this._boundsWidth === 0 || this._boundsHeight === 0) this.resize()
+      await this._waitForBenchReady()
+      const w = this._boundsWidth
+      const h = this._boundsHeight
+      const existing = this._benchOffscreenTexture
+      if (!existing || existing.width !== w || existing.height !== h) {
+        existing?.destroy()
+        this._benchOffscreenTexture = this.device.createTexture({
+          size: { width: w, height: h },
+          format: this.preferredCanvasFormat,
+          usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_DST,
+        })
+      }
+      // Suppress sub-canvas mode during bench so render() writes directly
+      // to the override texture rather than through _boundsColorTexture +
+      // _copyBoundsToCanvas (which would copy into the FBO at an offset).
+      const wasSubCanvas = this._isSubCanvasBounds
+      this._isSubCanvasBounds = false
+      this._benchTargetOverride = this._benchOffscreenTexture
+      try {
+        this.render()
+        await this.device.queue.onSubmittedWorkDone()
+      } finally {
+        this._benchTargetOverride = null
+        this._isSubCanvasBounds = wasSubCanvas
+      }
+    } finally {
+      this._benchInProgress = false
+    }
+  }
+
   /** Copy this view's intermediate texture and all siblings' to the canvas */
   private _copyBoundsToCanvas(
     commandEncoder: GPUCommandEncoder,
@@ -2042,6 +2133,13 @@ export default class NVView {
       mesh.destroyMesh(this.orientCubeGpu)
       this.orientCubeGpu = null
     }
+
+    // Destroy benchmark-only offscreen texture
+    if (this._benchOffscreenTexture) {
+      this._benchOffscreenTexture.destroy()
+      this._benchOffscreenTexture = null
+    }
+    this._benchTargetOverride = null
 
     // Destroy MSAA, bounds color, and depth textures
     if (this.msaaTexture) {

--- a/packages/niivue/src/wgpu/bench.ts
+++ b/packages/niivue/src/wgpu/bench.ts
@@ -1,0 +1,118 @@
+import type NVView from './NVViewGPU'
+
+/**
+ * Benchmark harness for the WebGPU backend. Not for production use —
+ * `view.render()` is fire-and-forget by design. This helper exists so
+ * benchmarks can measure true CPU+GPU wall-clock per frame.
+ *
+ * Lazily constructed on first access via `view.bench`. Kept in a
+ * separate module so bench-only state (offscreen target, concurrent-call
+ * guard) does not pollute the hot-path view class.
+ */
+export class WGPUBench {
+  /**
+   * When non-null, view.render() writes to this texture instead of the
+   * canvas swap chain. Set transiently by renderAndFlushOffscreen().
+   */
+  targetOverride: GPUTexture | null = null
+  private _offscreen: GPUTexture | null = null
+  private _inProgress = false
+  // Set by destroy(). Checked after every await so a bench call that was
+  // mid-await when the view tore down its bench exits cleanly rather than
+  // allocating orphan GPU resources on a disposed view.
+  private _disposed = false
+
+  constructor(private view: NVView) {}
+
+  /** Render to the canvas and await GPU completion. */
+  async renderAndFlush(): Promise<void> {
+    if (this._disposed) return
+    if (this._inProgress) {
+      throw new Error('renderAndFlush: concurrent call not allowed')
+    }
+    this._inProgress = true
+    try {
+      const view = this.view
+      if (view.boundsWidth === 0 || view.boundsHeight === 0) view.resize()
+      await this._waitForReady()
+      if (this._disposed) return
+      view.render()
+      if (view.device) await view.device.queue.onSubmittedWorkDone()
+    } finally {
+      this._inProgress = false
+    }
+  }
+
+  /**
+   * Render to an offscreen texture (bypassing the canvas swap chain) and
+   * await GPU completion. Removes compositor / present-time coupling so
+   * benchmarks measure pure render cost.
+   */
+  async renderAndFlushOffscreen(): Promise<void> {
+    if (this._disposed) return
+    const view = this.view
+    if (!view.device) return
+    if (this._inProgress) {
+      throw new Error('renderAndFlushOffscreen: concurrent call not allowed')
+    }
+    this._inProgress = true
+    try {
+      if (view.boundsWidth === 0 || view.boundsHeight === 0) view.resize()
+      await this._waitForReady()
+      if (this._disposed) return
+      const w = view.boundsWidth
+      const h = view.boundsHeight
+      if (
+        !this._offscreen ||
+        this._offscreen.width !== w ||
+        this._offscreen.height !== h
+      ) {
+        this._offscreen?.destroy()
+        this._offscreen = view.device.createTexture({
+          size: { width: w, height: h },
+          format: view.preferredCanvasFormat,
+          usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_DST,
+        })
+      }
+      // Suppress sub-canvas mode so render() writes directly to the override
+      // texture rather than through _boundsColorTexture + copy-to-canvas.
+      const restoreSubCanvas = view.suppressSubCanvasBounds()
+      this.targetOverride = this._offscreen
+      try {
+        view.render()
+        await view.device.queue.onSubmittedWorkDone()
+      } finally {
+        this.targetOverride = null
+        restoreSubCanvas()
+      }
+    } finally {
+      this._inProgress = false
+    }
+  }
+
+  /** Release all GPU resources owned by this bench. */
+  destroy(): void {
+    this._disposed = true
+    if (this._offscreen) this._offscreen.destroy()
+    this._offscreen = null
+    this.targetOverride = null
+  }
+
+  private async _waitForReady(): Promise<void> {
+    const view = this.view
+    const MAX_WAIT_FRAMES = 300
+    let tries = 0
+    while (
+      (view.isBusy || !view.fontRenderer.isReady) &&
+      tries < MAX_WAIT_FRAMES
+    ) {
+      await new Promise<void>((r) => requestAnimationFrame(() => r()))
+      tries++
+    }
+    if (view.isBusy || !view.fontRenderer.isReady) {
+      throw new Error(
+        'renderAndFlush: view not ready (isBusy or font atlas not loaded)',
+      )
+    }
+  }
+}

--- a/packages/niivue/src/wgpu/render.wgsl
+++ b/packages/niivue/src/wgpu/render.wgsl
@@ -1,5 +1,21 @@
 // Render-specific functions (preamble is prepended by render.ts from volumeShaderLib)
 
+// Drawing-gradient tuning constants. Shader authoring choices, not runtime
+// uniforms. Offset widens vs sharpens the gradient stencil; non-integer
+// exploits the linear sampler for Gaussian-like free smoothing. Epsilon
+// below which gradient normalization is unreliable.
+const DRAW_GRAD_OFFSET: f32 = 1.5;
+const DRAW_GRAD_EPSILON: f32 = 1e-6;
+
+// Weighted scalar projection of drawing RGBA. Luminance weights on RGB
+// distinguish distinct label colors; heavy alpha weight (2.0) makes
+// background→drawing transitions dominate. Switched from length(rgba) which
+// missed label-to-label boundaries when two labels had similar-magnitude
+// RGBA vectors (common when labels share alpha=255 and differ only in hue).
+fn drawScalar(c: vec4f) -> f32 {
+    return dot(c, vec4f(0.299, 0.587, 0.114, 2.0));
+}
+
 struct RayMarchResult {
     color: vec4f,
     firstHit: vec4f,
@@ -288,8 +304,7 @@ fn fragment_main(in: VertexOutput) -> FragmentOutput {
 					}
 					let gradRaw = textureSampleLevel(volumeGradient, tex_sampler, samplePos.xyz, 0.0).rgb;
 					let localNormal = normalize(gradRaw * 2.0 - 1.0);
-					var n = norm3 * localNormal;
-					n.y = -n.y; // Match the WebGL coordinate flip
+					let n = norm3 * localNormal;
 					let uv = n.xy * 0.5 + 0.5;
 					let mc_rgb = textureSampleLevel(matcap, tex_sampler, uv, 0.0).rgb * brighten;
 					let blendedRGB = mix(vec3f(1.0), mc_rgb, localGradientAmount);
@@ -351,9 +366,42 @@ fn fragment_main(in: VertexOutput) -> FragmentOutput {
 		let result = rayMarchPaqd(paqd, paqdLut, origStart, dir, origLen, deltaDir, deltaDirFast, ran, earlyTermination, params.paqdUniforms);
 		depthAwareMix(&colAcc, result, backNearest, &fragDepth, depthFactor);
 	}
-	// Drawing pass (nearest-neighbor sampling)
+	// Drawing pass (nearest-neighbor sampling for ray-march, linear for gradient)
 	if (textureDimensions(drawing, 0).x > 2) {
-		let result = rayMarchPass(drawing, nearest_sampler, origStart, dir, origLen, deltaDir, deltaDirFast, ran, earlyTermination);
+		var result = rayMarchPass(drawing, nearest_sampler, origStart, dir, origLen, deltaDir, deltaDirFast, ran, earlyTermination);
+		// Matcap lighting at first hit. 6-tap central-difference gradient
+		// sampled at 1.5 voxels out through the filtering sampler — each
+		// tap is a trilinear blend of 8 texels ("Gaussian for free"),
+		// which smooths away ray-march step jitter without any
+		// precomputed drawingGradient texture. Sign: value(+X) - value(-X)
+		// matches the volume gradient's inward-pointing convention.
+		if (result.color.a > 0.001 && params.gradientAmount > 0.0) {
+			let dv = DRAW_GRAD_OFFSET / vec3f(textureDimensions(drawing, 0));
+			let hp = result.firstHit.xyz;
+			let vXp = drawScalar(textureSampleLevel(drawing, tex_sampler, hp + vec3f(dv.x, 0.0, 0.0), 0.0));
+			let vXm = drawScalar(textureSampleLevel(drawing, tex_sampler, hp - vec3f(dv.x, 0.0, 0.0), 0.0));
+			let vYp = drawScalar(textureSampleLevel(drawing, tex_sampler, hp + vec3f(0.0, dv.y, 0.0), 0.0));
+			let vYm = drawScalar(textureSampleLevel(drawing, tex_sampler, hp - vec3f(0.0, dv.y, 0.0), 0.0));
+			let vZp = drawScalar(textureSampleLevel(drawing, tex_sampler, hp + vec3f(0.0, 0.0, dv.z), 0.0));
+			let vZm = drawScalar(textureSampleLevel(drawing, tex_sampler, hp - vec3f(0.0, 0.0, dv.z), 0.0));
+			let grad = vec3f(vXp - vXm, vYp - vYm, vZp - vZm);
+			if (length(grad) > DRAW_GRAD_EPSILON) {
+				let localNormal = normalize(grad);
+				let norm3 = mat3x3f(params.normMtx[0].xyz, params.normMtx[1].xyz, params.normMtx[2].xyz);
+				let n = norm3 * localNormal;
+				let uv = n.xy * 0.5 + 0.5;
+				let brighten = 1.0 + (params.gradientAmount / 3.0);
+				let mc_rgb = textureSampleLevel(matcap, tex_sampler, uv, 0.0).rgb * brighten;
+				let shade = mix(vec3f(1.0), mc_rgb, params.gradientAmount);
+				// result.color is premultiplied (rgb = actualColor * alpha).
+				// Clamp to alpha so the shade (which can exceed 1.0 via
+				// brighten) can't push rgb > alpha and break the
+				// premultiplied-alpha invariant that depthAwareMix and
+				// framebuffer blending assume.
+				let shadedRgb = min(result.color.rgb * shade, vec3f(result.color.a));
+				result.color = vec4f(shadedRgb, result.color.a);
+			}
+		}
 		depthAwareMix(&colAcc, result, backNearest, &fragDepth, depthFactor);
 	}
 	// Final output

--- a/packages/niivue/src/wgpu/sobel.wgsl
+++ b/packages/niivue/src/wgpu/sobel.wgsl
@@ -27,10 +27,16 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
     let BPR = sample_voxel(x+1, y-1, z-1, size, inputTex);
     let BPL = sample_voxel(x-1, y-1, z-1, size, inputTex);
 
+    // Standard Sobel convention: gradient = intensity(+axis) - intensity(-axis).
+    // T/B = Top/Bottom = ±Z, A/P = Anterior/Posterior = ±Y, R/L = Right/Left = ±X.
+    // Previously these were inverted (all three axes), which forced
+    // render.wgsl's volume path to carry an `n.y = -n.y` band-aid that
+    // only partially compensated for the full 3-axis flip. Restoring
+    // standard convention here lets that band-aid go away too.
     var grad: vec3<f32>;
-    grad.x = (TAL + TPL + BAL + BPL) - (TAR + TPR + BAR + BPR);
-    grad.y = (TPR + TPL + BPR + BPL) - (TAR + TAL + BAR + BAL);
-    grad.z = (BAR + BAL + BPR + BPL) - (TAR + TAL + TPR + TPL);
+    grad.x = (TAR + TPR + BAR + BPR) - (TAL + TPL + BAL + BPL);
+    grad.y = (TAR + TAL + BAR + BAL) - (TPR + TPL + BPR + BPL);
+    grad.z = (TAR + TAL + TPR + TPL) - (BAR + BAL + BPR + BPL);
 
     let magnitude = (abs(grad.x) + abs(grad.y) + abs(grad.z)) * 0.29;
     let dirColor = normalize(grad + 0.00001) * 0.5 + 0.5; // Avoid div by zero


### PR DESCRIPTION
This PR adds two features, both showcased by a new live demo named `vox.torso.html`.
 - Fixes [vox.draw.html)](https://niivue.github.io/mono/examples/vox.draw.html) live demo to resolve error `loadDrawing failed: Error: loadDrawing: expected typed array, got ArrayBuffer`
 - Provides benchmarking for render loop.
 - Provides a quick and dirty gradient estimation for drawings, inspired by @aarmea's smoothing described in [legacy PR1591](https://github.com/niivue/niivue/pull/1591).

<img width="1056" height="341" alt="matcap" src="https://github.com/user-attachments/assets/330bfbac-780f-49f1-9aea-64ddb79d6779" />
