### PR TITLE
ci: publish to npm and create GitHub Releases on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ jobs:
   release:
     name: nx release
     runs-on: ubuntu-latest
+    # workflow_dispatch can be triggered from any branch. Guard against
+    # accidentally force-pushing a feature branch to main.
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -71,42 +74,71 @@ jobs:
         if: ${{ !inputs.dry_run }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # For each tag Nx created at HEAD, create a matching GitHub Release
-        # whose body is the project's newly-written CHANGELOG.md top section.
+        # For each tag Nx created at HEAD, create (or update, if rerunning) a
+        # matching GitHub Release whose body is the project's freshly-written
+        # CHANGELOG.md top section.
         run: |
           set -euo pipefail
+          sha=$(git rev-parse HEAD)
           for tag in $(git tag --points-at HEAD); do
-            # Tag format is "{projectName}@{version}" where projectName may be
-            # scoped ("@scope/name@1.2.3"). Split on the LAST '@'.
-            version="${tag##*@}"
+            # Nx tag format is "{projectName}@{version}"; projectName is the
+            # Nx project name (e.g. "niivue"), which may differ from the
+            # published package.json "name" (e.g. "@niivue/niivue").
             project="${tag%@*}"
 
-            # Find the package directory by matching package.json "name".
+            # Resolve the project directory. Match project.json "name" first
+            # (authoritative for Nx tags), then fall back to package.json
+            # "name" for packages without a project.json entry.
             pkg_dir=""
             for d in packages/*; do
-              [ -f "$d/package.json" ] || continue
-              name=$(node -p "require('./$d/package.json').name")
-              if [ "$name" = "$project" ]; then
-                pkg_dir="$d"
-                break
+              if [ -f "$d/project.json" ]; then
+                nx_name=$(node -p "require('./$d/project.json').name || ''")
+                if [ "$nx_name" = "$project" ]; then
+                  pkg_dir="$d"
+                  break
+                fi
+              fi
+              if [ -f "$d/package.json" ]; then
+                pkg_name=$(node -p "require('./$d/package.json').name || ''")
+                if [ "$pkg_name" = "$project" ]; then
+                  pkg_dir="$d"
+                  break
+                fi
               fi
             done
 
-            if [ -z "$pkg_dir" ] || [ ! -f "$pkg_dir/CHANGELOG.md" ]; then
-              echo "No CHANGELOG.md found for $project; creating release with auto-generated notes."
-              gh release create "$tag" --title "$tag" --generate-notes --target "$(git rev-parse HEAD)"
-              continue
+            # Prefer the package's CHANGELOG top section as the release body.
+            notes_file=""
+            if [ -n "$pkg_dir" ] && [ -f "$pkg_dir/CHANGELOG.md" ]; then
+              notes_file=$(mktemp)
+              awk '/^## /{if(seen)exit; seen=1; next} seen' \
+                "$pkg_dir/CHANGELOG.md" > "$notes_file"
             fi
 
-            # Extract the top-most version section from CHANGELOG.md (until the
-            # next top-level heading).
-            notes=$(awk '/^## /{if(seen)exit; seen=1; next} seen' "$pkg_dir/CHANGELOG.md")
-
-            echo "Creating GitHub Release for $tag"
-            printf '%s\n' "$notes" | gh release create "$tag" \
-              --title "$tag" \
-              --target "$(git rev-parse HEAD)" \
-              --notes-file -
+            if gh release view "$tag" >/dev/null 2>&1; then
+              echo "Updating existing GitHub Release for $tag"
+              if [ -n "$notes_file" ]; then
+                # `gh release edit` has no --generate-notes, so only update
+                # notes when we have a CHANGELOG-derived body.
+                gh release edit "$tag" --title "$tag" --notes-file "$notes_file"
+              else
+                gh release edit "$tag" --title "$tag"
+              fi
+            else
+              echo "Creating GitHub Release for $tag"
+              if [ -n "$notes_file" ]; then
+                gh release create "$tag" \
+                  --title "$tag" \
+                  --target "$sha" \
+                  --notes-file "$notes_file"
+              else
+                echo "No CHANGELOG.md found for $project; using auto-generated notes."
+                gh release create "$tag" \
+                  --title "$tag" \
+                  --target "$sha" \
+                  --generate-notes
+              fi
+            fi
           done
 
       - name: Publish to npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,11 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+
       - run: bun install
 
       - name: Configure git identity
@@ -38,6 +43,9 @@ jobs:
 
       - name: Release (dry run)
         if: ${{ inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -o pipefail
           {
@@ -50,8 +58,60 @@ jobs:
 
       - name: Release
         if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bunx nx release --skip-publish --verbose
 
       - name: Push release commit and tags
         if: ${{ !inputs.dry_run }}
         run: git push --follow-tags origin HEAD:main
+
+      - name: Create GitHub Releases
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # For each tag Nx created at HEAD, create a matching GitHub Release
+        # whose body is the project's newly-written CHANGELOG.md top section.
+        run: |
+          set -euo pipefail
+          for tag in $(git tag --points-at HEAD); do
+            # Tag format is "{projectName}@{version}" where projectName may be
+            # scoped ("@scope/name@1.2.3"). Split on the LAST '@'.
+            version="${tag##*@}"
+            project="${tag%@*}"
+
+            # Find the package directory by matching package.json "name".
+            pkg_dir=""
+            for d in packages/*; do
+              [ -f "$d/package.json" ] || continue
+              name=$(node -p "require('./$d/package.json').name")
+              if [ "$name" = "$project" ]; then
+                pkg_dir="$d"
+                break
+              fi
+            done
+
+            if [ -z "$pkg_dir" ] || [ ! -f "$pkg_dir/CHANGELOG.md" ]; then
+              echo "No CHANGELOG.md found for $project; creating release with auto-generated notes."
+              gh release create "$tag" --title "$tag" --generate-notes --target "$(git rev-parse HEAD)"
+              continue
+            fi
+
+            # Extract the top-most version section from CHANGELOG.md (until the
+            # next top-level heading).
+            notes=$(awk '/^## /{if(seen)exit; seen=1; next} seen' "$pkg_dir/CHANGELOG.md")
+
+            echo "Creating GitHub Release for $tag"
+            printf '%s\n' "$notes" | gh release create "$tag" \
+              --title "$tag" \
+              --target "$(git rev-parse HEAD)" \
+              --notes-file -
+          done
+
+      - name: Publish to npm
+        if: ${{ !inputs.dry_run }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: bunx nx release publish --verbose

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
 
       - run: bun install


### PR DESCRIPTION
## Summary

Extends the release workflow to fully automate publishing.

After `nx release` bumps versions, writes changelogs, and tags the workspace, the workflow now:

1. Pushes the release commit and tags to `origin/main`.
2. Creates a GitHub Release per tag, using each package's freshly-written `CHANGELOG.md` section as the release body (falls back to `gh release --generate-notes` if no changelog is found).
3. Publishes all versioned packages to npm using the `NPM_TOKEN` secret, with auth wired via `actions/setup-node`'s `registry-url` plus `NODE_AUTH_TOKEN` / `NPM_CONFIG_TOKEN` env vars.

Also fixes a noisy error from the previous run: the changelog renderer shells out to `gh` to resolve commit authors to GitHub usernames and needs `GH_TOKEN` in the environment. Both `GH_TOKEN` and `GITHUB_TOKEN` are now exposed to the `nx release` steps.

## Why not `createRelease: "github"` in `nx.json`?

Nx creates the GitHub Release while tags are still local, so the release would be pinned to whatever commit GitHub resolves at that moment (typically the pre-release `main` HEAD). Creating releases explicitly after the push — with `--target "$(git rev-parse HEAD)"` — guarantees each release points at the correct commit.

## Prerequisites

- Add `NPM_TOKEN` as an Actions secret (recommend an npm **Automation** token so it bypasses 2FA).
- Repo `contents: write` permission is already granted at the job level; no additional permissions required for `gh release create`.

## Testing

Run the workflow from the Actions tab with `dry_run: true` first — it still only prints the plan, no commits / tags / releases / publishes are created.
