### PR TITLE
ci: use admin RELEASE_TOKEN PAT to bypass main ruleset on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,19 @@ jobs:
     # accidentally force-pushing a feature branch to main.
     if: github.ref == 'refs/heads/main'
     steps:
+      - name: Mint release bot token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use the App token so subsequent `git push` is performed as the
+          # App (which must be added as a bypass actor on the main ruleset).
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: oven-sh/setup-bun@v2
 
@@ -38,17 +47,22 @@ jobs:
       - run: bun install
 
       - name: Configure git identity
-        # Uses the official github-actions[bot] noreply address (user id 41898282).
-        # This attributes release commits to the bot in the GitHub UI with its avatar.
+        # Attribute release commits to the GitHub App bot user. The bot user
+        # is "<app-slug>[bot]"; we look up its user id to build a noreply
+        # email of the form "{id}+{slug}[bot]@users.noreply.github.com".
+        env:
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          user_id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${user_id}+${APP_SLUG}[bot]@users.noreply.github.com"
 
       - name: Release (dry run)
         if: ${{ inputs.dry_run }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -o pipefail
           {
@@ -62,8 +76,8 @@ jobs:
       - name: Release
         if: ${{ !inputs.dry_run }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: bunx nx release --skip-publish --verbose
 
       - name: Push release commit and tags
@@ -73,7 +87,7 @@ jobs:
       - name: Create GitHub Releases
         if: ${{ !inputs.dry_run }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         # For each tag Nx created at HEAD, create (or update, if rerunning) a
         # matching GitHub Release whose body is the project's freshly-written
         # CHANGELOG.md top section.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,19 +23,13 @@ jobs:
     # accidentally force-pushing a feature branch to main.
     if: github.ref == 'refs/heads/main'
     steps:
-      - name: Mint release bot token
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
-          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
-
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # Use the App token so subsequent `git push` is performed as the
-          # App (which must be added as a bypass actor on the main ruleset).
-          token: ${{ steps.app-token.outputs.token }}
+          # Use an admin PAT so `git push` can bypass the main ruleset
+          # (repo admins are listed as bypass actors). Falls back to the
+          # workflow-scoped GITHUB_TOKEN if the secret is unset.
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - uses: oven-sh/setup-bun@v2
 
@@ -47,22 +41,17 @@ jobs:
       - run: bun install
 
       - name: Configure git identity
-        # Attribute release commits to the GitHub App bot user. The bot user
-        # is "<app-slug>[bot]"; we look up its user id to build a noreply
-        # email of the form "{id}+{slug}[bot]@users.noreply.github.com".
-        env:
-          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        # Uses the official github-actions[bot] noreply address (user id 41898282).
+        # This attributes release commits to the bot in the GitHub UI with its avatar.
         run: |
-          user_id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)
-          git config user.name "${APP_SLUG}[bot]"
-          git config user.email "${user_id}+${APP_SLUG}[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Release (dry run)
         if: ${{ inputs.dry_run }}
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -o pipefail
           {
@@ -76,8 +65,8 @@ jobs:
       - name: Release
         if: ${{ !inputs.dry_run }}
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
         run: bunx nx release --skip-publish --verbose
 
       - name: Push release commit and tags
@@ -87,7 +76,7 @@ jobs:
       - name: Create GitHub Releases
         if: ${{ !inputs.dry_run }}
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
         # For each tag Nx created at HEAD, create (or update, if rerunning) a
         # matching GitHub Release whose body is the project's freshly-written
         # CHANGELOG.md top section.


### PR DESCRIPTION
## Summary

Fixes the release workflow failure:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
```

The default `GITHUB_TOKEN` isn't in the ruleset bypass list. Since repo admins are listed as bypass actors, use a personal access token from an admin account instead.

## What changed

- `actions/checkout`, `nx release` (for the changelog author lookup), `git push`, and the `gh release` steps all now use `secrets.RELEASE_TOKEN`.
- Every reference falls back to `secrets.GITHUB_TOKEN` so dry runs still work even before the secret is configured.

## Required one-time repo setup

Add an Actions secret `RELEASE_TOKEN`:

- **Fine-grained PAT (preferred):** scoped to `niivue/mono`, with repo permissions `Contents: Read and write`, `Metadata: Read`, and (for the GitHub Releases step) `Administration` is not required — `Contents: Read and write` covers release creation. Generate from an account with admin on the repo so the ruleset bypass applies.
- **Classic PAT:** `repo` scope.

`NPM_TOKEN` stays as-is.

## Cleanup before re-running

The previous failed run left 5 orphaned tags on origin. Before the next release:

```bash
git push origin \
  :refs/tags/niivue@1.0.0-rc.2 \
  :refs/tags/nv-ext-drawing@1.0.0-rc.2 \
  :refs/tags/nv-ext-image-processing@1.0.0-rc.2 \
  :refs/tags/nv-ext-save-html@1.0.0-rc.2 \
  :refs/tags/nv-react@1.0.0-rc.3
```

Keep `nv-react@1.0.0-rc.2` — that's from an earlier successful release.

## Testing

Run with `dry_run: true` first — no git writes, publishes, or GitHub Releases will be made.
