### PR TITLE
fix(ci): build release packages before publishing

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -34,6 +34,9 @@
     },
     "test": {
       "cache": true
+    },
+    "nx-release-publish": {
+      "dependsOn": ["build"]
     }
   },
   "release": {


### PR DESCRIPTION
## What went wrong

The `niivue:nx-release-publish` task failed because the workflow never builds before publishing.

Every publishable package has `"files": ["dist"]` and all `main` / `module` / `exports` entries pointing into `./dist/*`, but `nx release publish` only runs `npm publish` — it does not invoke `build`. On a fresh CI checkout, `dist/` doesn't exist yet, so npm either errors on the missing main entry or publishes an empty tarball.

## Fix

Add an `nx-release-publish` entry to `targetDefaults` that depends on `build`. Nx then chains each project's `build` (which itself depends on `^build`) ahead of publish.

```json
"nx-release-publish": {
  "dependsOn": ["build"]
}
```

Verified with `bunx nx release publish --dry-run`:

```
NX   Successfully ran target nx-release-publish for 5 projects and 5 tasks they depend on
```

The "5 tasks they depend on" is the new build chain.

## Recovering the current release

The version bump, tags, and GitHub Releases for `1.0.0-rc.2` / `nv-react@1.0.0-rc.3` are already pushed. Only the npm publish step failed. Two options:

**Option A (recommended): re-run just the publish locally** after merging this PR.

```bash
git checkout main && git pull
bun install
export NPM_TOKEN=...   # an npm Automation token
export NODE_AUTH_TOKEN=$NPM_TOKEN
export NPM_CONFIG_TOKEN=$NPM_TOKEN
echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
bunx nx release publish --verbose
```

This builds + publishes exactly what's already tagged, without re-versioning.

**Option B: re-run the Release workflow.** This will version-bump again (rc.2 → rc.3) and publish the new versions. Previous tags/releases remain valid but never make it to npm.

After this PR merges, future runs will be fully automated end-to-end.
