### PR TITLE
feat(nv-ext-dcm2niix): add DICOM-to-NIfTI extension and demo

### DIFF
--- a/.github/build-pages.sh
+++ b/.github/build-pages.sh
@@ -18,7 +18,7 @@ BASE_PATH="${BASE_PATH:-/mono/}"
 echo "==> Building with BASE_PATH=$BASE_PATH"
 
 # Demo apps to include (folder names under apps/)
-APPS=(demo-ext-drawing demo-ext-image-processing demo-ext-save-html)
+APPS=(demo-ext-drawing demo-ext-image-processing demo-ext-save-html demo-ext-dcm2niix)
 
 # 1. Build the niivue library (required by all apps)
 echo "==> Building niivue library"

--- a/.github/pages/index.html
+++ b/.github/pages/index.html
@@ -140,6 +140,14 @@
             >Save as HTML</a
           >
         </li>
+        <li>
+          <a
+            href="./demo-ext-dcm2niix/index.html"
+            target="_blank"
+            rel="noopener noreferrer"
+            >DICOM to NIfTI (dcm2niix)</a
+          >
+        </li>
       </ul>
     </main>
   </body>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,13 +27,15 @@ niivue/mono/
 ├── apps/
 │   ├── demo-ext-drawing/        Drawing extension demo
 │   ├── demo-ext-image-processing/ Image processing extension demo
-│   └── demo-ext-save-html/      Save-to-HTML extension demo
+│   ├── demo-ext-save-html/      Save-to-HTML extension demo
+│   └── demo-ext-dcm2niix/       DICOM-to-NIfTI extension demo
 ├── packages/
 │   ├── niivue/          @niivue/niivue — Core WebGPU/WebGL2 viewer
 │   ├── nv-react/        @niivue/nvreact — React bindings
 │   ├── nv-ext-drawing/      @niivue/nv-ext-drawing — Drawing & segmentation tools
 │   ├── nv-ext-image-processing/ @niivue/nv-ext-image-processing — Image processing
 │   ├── nv-ext-save-html/    @niivue/nv-ext-save-html — Export scene as HTML
+│   ├── nv-ext-dcm2niix/     @niivue/nv-ext-dcm2niix — DICOM-to-NIfTI via WASM
 │   └── dev-images/      @niivue/dev-images — Shared test images (Git LFS)
 ├── nx-tools/
 │   ├── nx-pixi-plugin.js       Local NX plugin for Python dependency inference
@@ -64,6 +66,7 @@ NX tracks project dependencies to run tasks in the correct order:
 demo-ext-drawing ──→ nv-ext-drawing ──→ niivue
 demo-ext-image-processing ──→ nv-ext-image-processing ──→ niivue
 demo-ext-save-html ──→ nv-ext-save-html ──→ niivue
+demo-ext-dcm2niix ──→ nv-ext-dcm2niix ──→ niivue
 nv-react ──→ niivue
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Monorepo for the [NiiVue](https://github.com/niivue) ecosystem — browser-based
 | [`@niivue/nv-ext-drawing`](packages/nv-ext-drawing) | Drawing interpolation and segmentation tools | [![npm](https://img.shields.io/npm/v/@niivue/nv-ext-drawing/next)](https://www.npmjs.com/package/@niivue/nv-ext-drawing) |
 | [`@niivue/nv-ext-image-processing`](packages/nv-ext-image-processing) | Image processing (Otsu thresholding, haze removal, etc.) | [![npm](https://img.shields.io/npm/v/@niivue/nv-ext-image-processing/next)](https://www.npmjs.com/package/@niivue/nv-ext-image-processing) |
 | [`@niivue/nv-ext-save-html`](packages/nv-ext-save-html) | Export a NiiVue scene as a self-contained HTML file | [![npm](https://img.shields.io/npm/v/@niivue/nv-ext-save-html/next)](https://www.npmjs.com/package/@niivue/nv-ext-save-html) |
+| [`@niivue/nv-ext-dcm2niix`](packages/nv-ext-dcm2niix) | DICOM-to-NIfTI conversion in the browser via the dcm2niix WASM build | [![npm](https://img.shields.io/npm/v/@niivue/nv-ext-dcm2niix/next)](https://www.npmjs.com/package/@niivue/nv-ext-dcm2niix) |
 | [`@niivue/dev-images`](packages/dev-images) | Shared test volumes, meshes, and tractography files (Git LFS) | — |
 
 ## Apps
@@ -20,6 +21,7 @@ Monorepo for the [NiiVue](https://github.com/niivue) ecosystem — browser-based
 | [`demo-ext-drawing`](apps/demo-ext-drawing) | Demo app for the drawing extension |
 | [`demo-ext-image-processing`](apps/demo-ext-image-processing) | Demo app for the image processing extension |
 | [`demo-ext-save-html`](apps/demo-ext-save-html) | Demo app for the save-to-HTML extension |
+| [`demo-ext-dcm2niix`](apps/demo-ext-dcm2niix) | Demo app for the dcm2niix DICOM-to-NIfTI extension |
 | [`medgfx`](apps/medgfx) | Native macOS/iOS SwiftUI app embedding NiiVue in a WebView |
 
 ## Getting Started

--- a/apps/demo-ext-dcm2niix/README.md
+++ b/apps/demo-ext-dcm2niix/README.md
@@ -1,0 +1,24 @@
+# demo-ext-dcm2niix
+
+Demo app for [`@niivue/nv-ext-dcm2niix`](../../packages/nv-ext-dcm2niix) — convert a folder of DICOM files to NIfTI in the browser via the dcm2niix WASM build, then view the result with NiiVue. No data leaves the browser.
+
+Three input paths are wired up:
+
+1. **Folder picker** — `<input type="file" webkitdirectory>`.
+2. **Drag-and-drop** — drop a folder of DICOMs onto the header.
+3. **Demo manifest** — fetches a public DICOM series listed in a newline-delimited manifest, then runs the same conversion pipeline.
+
+## Getting Started
+
+```bash
+bun install                       # From monorepo root
+bunx nx dev demo-ext-dcm2niix     # Start dev server (port 8086)
+```
+
+## Build
+
+```bash
+bunx nx build demo-ext-dcm2niix
+```
+
+## Part of the [NiiVue](https://github.com/niivue) ecosystem

--- a/apps/demo-ext-dcm2niix/index.html
+++ b/apps/demo-ext-dcm2niix/index.html
@@ -1,0 +1,109 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>NiiVue — dcm2niix DICOM to NIfTI</title>
+    <link rel="icon" href="data:," />
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      html, body { height: 100%; }
+      body {
+        display: flex;
+        flex-direction: column;
+        font-family: system-ui, Arial, Helvetica, sans-serif;
+        color: #eee;
+        background: #303030;
+        user-select: none;
+      }
+      header {
+        background: #333;
+        padding: 0.75rem 1rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+      .row {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+        font-size: 0.9rem;
+      }
+      .drop-target {
+        padding: 0.75rem;
+        border: 2px dashed #888;
+        border-radius: 5px;
+        text-align: center;
+        background-color: #000;
+        color: #ccc;
+        font-size: 0.9rem;
+      }
+      .drop-target.dragover {
+        background-color: #222;
+        border-color: #fff;
+        color: #fff;
+      }
+      button, select, label.file-input-label {
+        font-size: 0.85rem;
+        cursor: pointer;
+        padding: 0.3rem 0.75rem;
+        background: #555;
+        color: #eee;
+        border: 1px solid #777;
+        border-radius: 3px;
+      }
+      button:hover, label.file-input-label:hover { background: #666; }
+      button:disabled { opacity: 0.5; cursor: not-allowed; }
+      input[type="file"] { display: none; }
+      main { flex: 1; background: #000; position: relative; min-height: 0; }
+      canvas { width: 100%; height: 100%; cursor: crosshair; }
+      canvas:focus { outline: 0; }
+      footer {
+        background: #333;
+        padding: 0.4rem 1rem;
+        font-size: 0.85rem;
+        min-height: 1.6rem;
+      }
+      .loading {
+        display: inline-block;
+        width: 14px;
+        height: 14px;
+        border: 2px solid rgba(255, 255, 255, 0.3);
+        border-radius: 50%;
+        border-top-color: #fff;
+        animation: spin 1s ease-in-out infinite;
+        vertical-align: middle;
+      }
+      @keyframes spin { to { transform: rotate(360deg); } }
+      .hidden { display: none; }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div id="dropTarget" class="drop-target">
+        Drop a folder of DICOM files here, or use the controls below.
+      </div>
+      <div class="row">
+        <label for="fileInput" class="file-input-label">Choose DICOM folder</label>
+        <input type="file" id="fileInput" webkitdirectory multiple />
+
+        <button type="button" id="loadManifestBtn">Load demo DICOM series</button>
+
+        <select id="fileSelect" class="hidden"></select>
+
+        <button type="button" id="saveButton" class="hidden">Save selected file</button>
+
+        <span id="loadingCircle" class="loading hidden"></span>
+      </div>
+    </header>
+
+    <main>
+      <canvas id="gl1"></canvas>
+    </main>
+
+    <footer id="status">&nbsp;</footer>
+
+    <script type="module" src="src/main.ts"></script>
+  </body>
+</html>

--- a/apps/demo-ext-dcm2niix/package.json
+++ b/apps/demo-ext-dcm2niix/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "demo-ext-dcm2niix",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "bunx --bun vite --open /index.html",
+    "build": "bunx --bun vite build"
+  },
+  "dependencies": {
+    "@niivue/niivue": "workspace:*",
+    "@niivue/nv-ext-dcm2niix": "workspace:*"
+  },
+  "devDependencies": {
+    "vite": "^6.3.2"
+  }
+}

--- a/apps/demo-ext-dcm2niix/project.json
+++ b/apps/demo-ext-dcm2niix/project.json
@@ -1,0 +1,38 @@
+{
+  "name": "demo-ext-dcm2niix",
+  "projectType": "application",
+  "tags": ["type:app", "lang:typescript"],
+  "targets": {
+    "dev": {
+      "command": "bunx --bun vite --open /index.html",
+      "options": { "cwd": "{projectRoot}" }
+    },
+    "build": {
+      "command": "bunx --bun vite build",
+      "options": { "cwd": "{projectRoot}" },
+      "dependsOn": ["^build"],
+      "inputs": [
+        "typescript",
+        "{projectRoot}/vite.config.js",
+        "{projectRoot}/src/**/*",
+        "{projectRoot}/*.html",
+        { "env": "VITE_BASE" }
+      ],
+      "outputs": ["{projectRoot}/dist"]
+    },
+    "typecheck": {
+      "command": "bunx tsc --noEmit",
+      "options": { "cwd": "{projectRoot}" },
+      "dependsOn": ["^build"],
+      "inputs": ["typescript"]
+    },
+    "lint": {
+      "command": "bunx biome check {projectRoot}",
+      "inputs": ["typescript"]
+    },
+    "format": {
+      "command": "bunx biome format {projectRoot} --write",
+      "inputs": ["typescript"]
+    }
+  }
+}

--- a/apps/demo-ext-dcm2niix/src/main.ts
+++ b/apps/demo-ext-dcm2niix/src/main.ts
@@ -187,10 +187,15 @@ async function fetchDemoManifest(manifestUrl: string): Promise<File[]> {
       const filename = url.pathname.split('/').pop() ?? 'dicom'
       // dcm2niix groups by webkitRelativePath; standard webkitRelativePath
       // is read-only, so stamp the underscore-prefixed form it also reads.
+      // Preserve any folder hierarchy the manifest specifies so nested
+      // studies/series don't collapse and collide; bare filenames get a
+      // synthetic "series/" prefix so dcm2niix treats them as adjacent.
       const file = new File([buffer], filename) as File & {
         _webkitRelativePath?: string
       }
-      file._webkitRelativePath = `series/${filename}`
+      file._webkitRelativePath = relativePath.includes('/')
+        ? relativePath
+        : `series/${filename}`
       return file
     }),
   )

--- a/apps/demo-ext-dcm2niix/src/main.ts
+++ b/apps/demo-ext-dcm2niix/src/main.ts
@@ -1,0 +1,238 @@
+/**
+ * Demo: convert a folder of DICOM files to NIfTI in the browser via
+ * the dcm2niix WASM build, then view the result with NiiVue.
+ *
+ * Three input paths:
+ *   1. <input webkitdirectory>            → runDcm2niix(input.files)
+ *   2. drag-drop a folder onto the page   → traverseDataTransferItems → runDcm2niix
+ *   3. "Load demo" button                 → fetchDemoManifest → runDcm2niix
+ */
+import NiiVueGPU, {
+  DRAG_MODE,
+  MULTIPLANAR_TYPE,
+  SHOW_RENDER,
+  SLICE_TYPE,
+} from '@niivue/niivue'
+import { runDcm2niix, traverseDataTransferItems } from '@niivue/nv-ext-dcm2niix'
+
+const DEMO_MANIFEST_URL =
+  'https://niivue.github.io/niivue-demo-images/dicom/niivue-manifest.txt'
+
+function $<T extends HTMLElement>(id: string): T {
+  const el = document.getElementById(id)
+  if (!el) throw new Error(`Element #${id} not found`)
+  return el as T
+}
+
+const status = $('status')
+const dropTarget = $('dropTarget')
+const fileInput = $<HTMLInputElement>('fileInput')
+const fileSelect = $<HTMLSelectElement>('fileSelect')
+const saveButton = $<HTMLButtonElement>('saveButton')
+const loadManifestBtn = $<HTMLButtonElement>('loadManifestBtn')
+const loadingCircle = $('loadingCircle')
+
+let convertedFiles: File[] = []
+let currentFile: File | null = null
+let isConverting = false
+
+// We handle the drop ourselves on the header drop-target div, so prevent
+// the canvas from intercepting drops with its own (NIfTI-only) handler.
+const nv = new NiiVueGPU({ isDragDropEnabled: false })
+await nv.attachTo('gl1')
+nv.crosshairGap = 5
+nv.multiplanarType = MULTIPLANAR_TYPE.GRID
+nv.sliceType = SLICE_TYPE.MULTIPLANAR
+nv.showRender = SHOW_RENDER.ALWAYS
+nv.primaryDragMode = DRAG_MODE.slicer3D
+nv.addEventListener('locationChange', (e) => {
+  status.textContent = e.detail.string
+})
+
+setStatus('Drop a DICOM folder, choose one, or load the demo series.')
+
+// --- File picker (webkitdirectory) ---
+fileInput.addEventListener('change', async () => {
+  if (!fileInput.files || fileInput.files.length === 0) return
+  try {
+    await convertAndDisplay(fileInput.files)
+  } catch (err) {
+    handleError('Conversion failed', err)
+  }
+})
+
+// --- Drag-and-drop folders ---
+dropTarget.addEventListener('dragover', (e) => {
+  e.preventDefault()
+  dropTarget.classList.add('dragover')
+})
+dropTarget.addEventListener('dragleave', () => {
+  dropTarget.classList.remove('dragover')
+})
+dropTarget.addEventListener('drop', async (e) => {
+  e.preventDefault()
+  dropTarget.classList.remove('dragover')
+  const items = e.dataTransfer?.items
+  if (!items || items.length === 0) return
+  try {
+    showLoading('Reading dropped folder…')
+    const files = await traverseDataTransferItems(items)
+    await convertAndDisplay(files)
+  } catch (err) {
+    handleError('Drop failed', err)
+  }
+})
+
+// --- Demo manifest button ---
+loadManifestBtn.addEventListener('click', async () => {
+  try {
+    showLoading('Fetching demo DICOM series…')
+    const dicomFiles = await fetchDemoManifest(DEMO_MANIFEST_URL)
+    await convertAndDisplay(dicomFiles)
+  } catch (err) {
+    handleError('Failed to load demo series', err)
+  }
+})
+
+// --- File select dropdown (multiple outputs from one conversion) ---
+fileSelect.addEventListener('change', async () => {
+  const idx = Number(fileSelect.value)
+  if (Number.isNaN(idx) || idx < 0) return
+  await viewFile(convertedFiles[idx])
+})
+
+// --- Save the currently-viewed file ---
+saveButton.addEventListener('click', () => {
+  if (!currentFile) return
+  const url = URL.createObjectURL(currentFile)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = currentFile.name
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
+})
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function convertAndDisplay(files: FileList | File[]): Promise<void> {
+  if (isConverting) {
+    setStatus('Conversion already in progress — please wait.')
+    return
+  }
+  isConverting = true
+  setInputsDisabled(true)
+  hide(saveButton)
+  hide(fileSelect)
+  showLoading('Converting DICOM to NIfTI…')
+  try {
+    const t0 = performance.now()
+    const niftiFiles = await runDcm2niix(files)
+    const elapsed = ((performance.now() - t0) / 1000).toFixed(2)
+
+    if (niftiFiles.length === 0) {
+      hideLoading()
+      setStatus('No NIfTI output produced. Are these DICOM images?')
+      return
+    }
+
+    convertedFiles = niftiFiles
+    populateFileSelect(niftiFiles)
+    show(fileSelect)
+    show(saveButton)
+    hideLoading()
+    setStatus(`Converted ${niftiFiles.length} file(s) in ${elapsed} s`)
+
+    fileSelect.value = '0'
+    await viewFile(niftiFiles[0])
+  } finally {
+    isConverting = false
+    setInputsDisabled(false)
+  }
+}
+
+/**
+ * Fetch a newline-delimited manifest of relative DICOM URLs and return
+ * them as `File`s ready for `runDcm2niix`. Demo-only — the manifest
+ * URL must be trusted (each line is treated as a fetchable URL).
+ */
+async function fetchDemoManifest(manifestUrl: string): Promise<File[]> {
+  const baseUrl = new URL(manifestUrl, window.location.href)
+  const text = await (await fetch(baseUrl)).text()
+  const relativePaths = text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+
+  return Promise.all(
+    relativePaths.map(async (relativePath) => {
+      const url = new URL(relativePath, baseUrl)
+      const res = await fetch(url)
+      if (!res.ok) {
+        throw new Error(`Failed to fetch DICOM ${url}: ${res.status}`)
+      }
+      const buffer = await res.arrayBuffer()
+      const filename = url.pathname.split('/').pop() ?? 'dicom'
+      // dcm2niix groups by webkitRelativePath; standard webkitRelativePath
+      // is read-only, so stamp the underscore-prefixed form it also reads.
+      const file = new File([buffer], filename) as File & {
+        _webkitRelativePath?: string
+      }
+      file._webkitRelativePath = `series/${filename}`
+      return file
+    }),
+  )
+}
+
+function setInputsDisabled(disabled: boolean): void {
+  fileInput.disabled = disabled
+  loadManifestBtn.disabled = disabled
+}
+
+async function viewFile(file: File): Promise<void> {
+  currentFile = file
+  if (!/\.nii(\.gz)?$/i.test(file.name)) {
+    // Non-image (e.g. BIDS sidecar) — keep it available for download but
+    // don't try to render.
+    return
+  }
+  await nv.loadVolumes([{ url: file, name: file.name }])
+}
+
+function populateFileSelect(files: File[]): void {
+  fileSelect.innerHTML = ''
+  for (let i = 0; i < files.length; i++) {
+    const option = document.createElement('option')
+    option.value = String(i)
+    option.text = files[i].name
+    fileSelect.appendChild(option)
+  }
+}
+
+function setStatus(text: string): void {
+  status.textContent = text
+}
+function showLoading(text: string): void {
+  setStatus(text)
+  show(loadingCircle)
+}
+function hideLoading(): void {
+  hide(loadingCircle)
+}
+function show(el: HTMLElement): void {
+  el.classList.remove('hidden')
+}
+function hide(el: HTMLElement): void {
+  el.classList.add('hidden')
+}
+function handleError(prefix: string, err: unknown): void {
+  hideLoading()
+  hide(fileSelect)
+  hide(saveButton)
+  const msg = err instanceof Error ? err.message : String(err)
+  setStatus(`${prefix}: ${msg}`)
+  console.error(prefix, err)
+}

--- a/apps/demo-ext-dcm2niix/src/main.ts
+++ b/apps/demo-ext-dcm2niix/src/main.ts
@@ -120,6 +120,9 @@ saveButton.addEventListener('click', () => {
 
 async function convertAndDisplay(files: FileList | File[]): Promise<void> {
   if (isConverting) {
+    // Drop and manifest paths call showLoading() before us, so any
+    // in-progress spinner from this rejected attempt must be cleared.
+    hideLoading()
     setStatus('Conversion already in progress — please wait.')
     return
   }
@@ -161,7 +164,13 @@ async function convertAndDisplay(files: FileList | File[]): Promise<void> {
  */
 async function fetchDemoManifest(manifestUrl: string): Promise<File[]> {
   const baseUrl = new URL(manifestUrl, window.location.href)
-  const text = await (await fetch(baseUrl)).text()
+  const manifestRes = await fetch(baseUrl)
+  if (!manifestRes.ok) {
+    throw new Error(
+      `Failed to fetch manifest ${baseUrl}: ${manifestRes.status}`,
+    )
+  }
+  const text = await manifestRes.text()
   const relativePaths = text
     .split('\n')
     .map((line) => line.trim())

--- a/apps/demo-ext-dcm2niix/tsconfig.json
+++ b/apps/demo-ext-dcm2niix/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/apps/demo-ext-dcm2niix/vite.config.js
+++ b/apps/demo-ext-dcm2niix/vite.config.js
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vite'
+
+// VITE_BASE: the app's own base path on GitHub Pages (e.g. /mono/demo-ext-dcm2niix/)
+const ghBase = process.env.VITE_BASE ?? ''
+
+export default defineConfig({
+  base: ghBase || '/',
+  server: {
+    port: 8086,
+  },
+  // dcm2niix's worker uses dynamic-import resolution that
+  // chokes when prebundled. Defer it to runtime.
+  optimizeDeps: {
+    exclude: ['@niivue/dcm2niix'],
+  },
+  build: {
+    outDir: 'dist',
+    target: 'esnext',
+    rollupOptions: {
+      input: 'index.html',
+    },
+  },
+})

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "nx-mono-repo-test",
@@ -10,6 +9,16 @@
         "@nx/js": "^22.6.3",
         "@types/bun": "^1.3.12",
         "nx": "latest",
+      },
+    },
+    "apps/demo-ext-dcm2niix": {
+      "name": "demo-ext-dcm2niix",
+      "dependencies": {
+        "@niivue/niivue": "workspace:*",
+        "@niivue/nv-ext-dcm2niix": "workspace:*",
+      },
+      "devDependencies": {
+        "vite": "^6.3.2",
       },
     },
     "apps/demo-ext-drawing": {
@@ -80,6 +89,22 @@
         "typescript": "^5.6.3",
         "vite": "^7.3.1",
         "vite-plugin-dts": "^4.5.4",
+      },
+    },
+    "packages/nv-ext-dcm2niix": {
+      "name": "@niivue/nv-ext-dcm2niix",
+      "version": "1.0.0-rc.1",
+      "dependencies": {
+        "@niivue/dcm2niix": "^1.2.0",
+      },
+      "devDependencies": {
+        "@niivue/niivue": "workspace:*",
+        "typescript": "~5.8.3",
+        "vite": "^6.3.2",
+        "vite-plugin-dts": "^4.5.4",
+      },
+      "peerDependencies": {
+        "@niivue/niivue": "workspace:*",
       },
     },
     "packages/nv-ext-drawing": {
@@ -465,9 +490,13 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.4", "", { "dependencies": { "@emnapi/core": "^1.1.0", "@emnapi/runtime": "^1.1.0", "@tybys/wasm-util": "^0.9.0" } }, "sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ=="],
 
+    "@niivue/dcm2niix": ["@niivue/dcm2niix@1.2.0", "", {}, "sha512-wGontzVdVvLzeptZvJCcCQfpneoCme+9oCl82USjWMuer048+ZByO3b4FhbGnyEVQPh7hVgDA7A2+l6vW29bDg=="],
+
     "@niivue/dev-images": ["@niivue/dev-images@workspace:packages/dev-images"],
 
     "@niivue/niivue": ["@niivue/niivue@workspace:packages/niivue"],
+
+    "@niivue/nv-ext-dcm2niix": ["@niivue/nv-ext-dcm2niix@workspace:packages/nv-ext-dcm2niix"],
 
     "@niivue/nv-ext-drawing": ["@niivue/nv-ext-drawing@workspace:packages/nv-ext-drawing"],
 
@@ -774,6 +803,8 @@
     "define-lazy-prop": ["define-lazy-prop@2.0.0", "", {}, "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="],
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
+    "demo-ext-dcm2niix": ["demo-ext-dcm2niix@workspace:apps/demo-ext-dcm2niix"],
 
     "demo-ext-drawing": ["demo-ext-drawing@workspace:apps/demo-ext-drawing"],
 
@@ -1238,6 +1269,8 @@
     "@niivue/niivue/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@niivue/niivue/vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
+
+    "@niivue/nv-ext-dcm2niix/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 
     "@niivue/nv-ext-drawing/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 

--- a/nx.json
+++ b/nx.json
@@ -51,7 +51,8 @@
           "pattern": "{projectName}@{version}"
         },
         "version": {
-          "conventionalCommits": true
+          "conventionalCommits": true,
+          "fallbackCurrentVersionResolver": "disk"
         },
         "changelog": true
       }

--- a/packages/niivue/AGENTS.md
+++ b/packages/niivue/AGENTS.md
@@ -389,6 +389,8 @@ Configurable drag interactions on 2D slices. `interaction.primaryDragMode` (defa
 
 `DRAG_MODE` enum: `none`(0), `contrast`(1), `measurement`(2), `pan`(3), `slicer3D`(4), `callbackOnly`(5), `roiSelection`(6), `angle`(7), `crosshair`(8), `windowing`(9).
 
+Public enum exports from the package root (alongside `DRAG_MODE`): `SLICE_TYPE` (axial/coronal/sagittal/multiplanar/render), `MULTIPLANAR_TYPE` (auto/column/grid/row), `SHOW_RENDER`, and `NiiDataType`.
+
 **Overlay rendering:** Selection boxes use GlyphBatch panels (`_dragOverlay.rect`). Measurement/angle lines use line renderer (`_dragOverlay.lines`). Overlay state lives on `model._dragOverlay` (transient, not serialized).
 
 **Drawing priority:** When `draw.isEnabled && drawingVolume`, drawing intercepts left-button before drag mode dispatch.

--- a/packages/niivue/FEATURE_PARITY.md
+++ b/packages/niivue/FEATURE_PARITY.md
@@ -430,10 +430,11 @@ Tracking which features from the old `niivue` package exist in the new rewrite.
 | Feature | Status | Notes |
 |---------|--------|-------|
 | `DRAG_MODE` | ✅ | |
-| `SLICE_TYPE` | ❌ | Not exported (set via property) |
-| `MULTIPLANAR_TYPE` | ❌ | Not exported |
-| `SHOW_RENDER` | ❌ | Not exported |
-| `NiiDataType` / `NiiIntentCode` | ✅ | In NVConstants (not exported from index) |
+| `SLICE_TYPE` | ✅ | |
+| `MULTIPLANAR_TYPE` | ✅ | |
+| `SHOW_RENDER` | ✅ | |
+| `NiiDataType` | ✅ | |
+| `NiiIntentCode` | ❌ | In NVConstants (not exported from index) |
 
 ## 33. Miscellaneous
 
@@ -480,7 +481,7 @@ Tracking which features from the old `niivue` package exist in the new rewrite.
 21. **`colormapInvert`**
 22. **Mesh utilities**: `decimateFaces`, `linesToCylinders`, `createFiberDensityMap`, `reverseFaces`
 23. **Missing events**: `locationChange`, `intensityChange`, `dragRelease`, `measurementCompleted`, `angleCompleted`, `documentLoaded`, `volumeOrderChanged`
-24. **Enum exports**: `SLICE_TYPE`, `MULTIPLANAR_TYPE`, `SHOW_RENDER`
+24. **Enum exports**: `NiiIntentCode`
 25. **AFNI .niml.tract** tractography format
 26. **Legacy callback properties**
 27. **`watchOptsChanges`** (replaced by `propertyChange` event)

--- a/packages/niivue/src/index.ts
+++ b/packages/niivue/src/index.ts
@@ -20,7 +20,13 @@ export type { LogLevel } from './logger'
 // Mesh writer types
 export type { WriteOptions } from './mesh/writers'
 // Enums
-export { DRAG_MODE, NiiDataType, SHOW_RENDER, SLICE_TYPE } from './NVConstants'
+export {
+  DRAG_MODE,
+  MULTIPLANAR_TYPE,
+  NiiDataType,
+  SHOW_RENDER,
+  SLICE_TYPE,
+} from './NVConstants'
 export { default, default as NiiVueGPU } from './NVControl'
 // Event types
 export type {

--- a/packages/nv-ext-dcm2niix/README.md
+++ b/packages/nv-ext-dcm2niix/README.md
@@ -1,0 +1,69 @@
+# @niivue/nv-ext-dcm2niix
+
+Browser-side DICOM-to-NIfTI conversion for [NiiVue](https://github.com/niivue), wrapping the [`@niivue/dcm2niix`](https://www.npmjs.com/package/@niivue/dcm2niix) WebAssembly build of Chris Rorden's [`dcm2niix`](https://github.com/rordenlab/dcm2niix). No data leaves the browser.
+
+## Installation
+
+```bash
+bun add @niivue/nv-ext-dcm2niix
+```
+
+Requires `@niivue/niivue` as a peer dependency.
+
+## Usage
+
+### Folder picker
+
+```ts
+import NiiVueGPU from '@niivue/niivue'
+import { runDcm2niix } from '@niivue/nv-ext-dcm2niix'
+
+const nv = new NiiVueGPU()
+await nv.attachTo('gl1')
+
+const input = document.querySelector<HTMLInputElement>('#dicomFolder')!
+input.addEventListener('change', async () => {
+  const niftiFiles = await runDcm2niix(input.files)
+  await nv.loadVolumes([{ url: niftiFiles[0] }])
+})
+```
+
+The input should declare `webkitdirectory` so the browser exposes folder structure:
+
+```html
+<input id="dicomFolder" type="file" webkitdirectory multiple />
+```
+
+### Drag-and-drop folders
+
+```ts
+import { runDcm2niix, traverseDataTransferItems } from '@niivue/nv-ext-dcm2niix'
+
+dropTarget.addEventListener('drop', async (e) => {
+  e.preventDefault()
+  const files = await traverseDataTransferItems(e.dataTransfer!.items)
+  const niftiFiles = await runDcm2niix(files)
+  await nv.loadVolumes([{ url: niftiFiles[0] }])
+})
+```
+
+### Power users
+
+The underlying `Dcm2niix` class is re-exported for callers that need full control over dcm2niix command-line flags (compression level, BIDS sidecars, etc.):
+
+```ts
+import { Dcm2niix } from '@niivue/nv-ext-dcm2niix'
+
+const dcm2niix = new Dcm2niix()
+await dcm2niix.init()
+const result = await dcm2niix.input(files).compressionLevel(9).bids('n').run()
+```
+
+## Development
+
+```bash
+bunx nx build nv-ext-dcm2niix
+bunx nx typecheck nv-ext-dcm2niix
+```
+
+## Part of the [NiiVue](https://github.com/niivue) ecosystem

--- a/packages/nv-ext-dcm2niix/package.json
+++ b/packages/nv-ext-dcm2niix/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@niivue/nv-ext-dcm2niix",
+  "version": "1.0.0-rc.1",
+  "type": "module",
+  "description": "DICOM-to-NIfTI conversion in the browser via the dcm2niix WASM build, packaged for NiiVue",
+  "main": "./dist/nv-ext-dcm2niix.js",
+  "module": "./dist/nv-ext-dcm2niix.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/nv-ext-dcm2niix.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "peerDependencies": {
+    "@niivue/niivue": "workspace:*"
+  },
+  "dependencies": {
+    "@niivue/dcm2niix": "^1.2.0"
+  },
+  "devDependencies": {
+    "@niivue/niivue": "workspace:*",
+    "typescript": "~5.8.3",
+    "vite": "^6.3.2",
+    "vite-plugin-dts": "^4.5.4"
+  },
+  "scripts": {
+    "build": "npx vite build",
+    "typecheck": "bunx tsc --noEmit"
+  }
+}

--- a/packages/nv-ext-dcm2niix/project.json
+++ b/packages/nv-ext-dcm2niix/project.json
@@ -1,0 +1,32 @@
+{
+  "name": "nv-ext-dcm2niix",
+  "projectType": "library",
+  "tags": ["type:lib", "lang:typescript"],
+  "targets": {
+    "build": {
+      "command": "bunx --bun vite build",
+      "options": { "cwd": "{projectRoot}" },
+      "dependsOn": ["^build"],
+      "inputs": [
+        "typescript",
+        "{projectRoot}/vite.config.ts",
+        "{projectRoot}/src/**/*"
+      ],
+      "outputs": ["{projectRoot}/dist"]
+    },
+    "typecheck": {
+      "command": "bunx tsc --noEmit",
+      "options": { "cwd": "{projectRoot}" },
+      "dependsOn": ["^build"],
+      "inputs": ["typescript"]
+    },
+    "lint": {
+      "command": "bunx biome check {projectRoot}",
+      "inputs": ["typescript"]
+    },
+    "format": {
+      "command": "bunx biome format {projectRoot} --write",
+      "inputs": ["typescript"]
+    }
+  }
+}

--- a/packages/nv-ext-dcm2niix/src/dcm2niix.d.ts
+++ b/packages/nv-ext-dcm2niix/src/dcm2niix.d.ts
@@ -1,0 +1,31 @@
+/**
+ * Ambient types for `@niivue/dcm2niix` (no `.d.ts` shipped upstream).
+ *
+ * Covers the surface this wrapper actually uses. The full Processor
+ * has dozens of chainable command setters — they all share the same
+ * signature, so we model that with an index signature.
+ */
+declare module '@niivue/dcm2niix' {
+  export interface Dcm2niixProcessor {
+    /** Run the conversion and resolve to the output files. */
+    run(): Promise<File[]>
+    /** Any chainable dcm2niix command flag (`compressionLevel`, `bids`, ...). */
+    [command: string]: (
+      ...args: unknown[]
+    ) => Dcm2niixProcessor | Promise<File[]>
+  }
+
+  export class Dcm2niix {
+    constructor()
+    /** Underlying Web Worker. Null before {@link init}; available after. */
+    worker: Worker | null
+    /** Boot the WebAssembly worker. Resolves when ready. */
+    init(): Promise<true>
+    /** Standard `<input webkitdirectory>` `FileList` or `File[]`. */
+    input(files: FileList | File[]): Dcm2niixProcessor
+    /** Alias for {@link input}, for clarity at the call site. */
+    inputFromWebkitDirectory(files: FileList | File[]): Dcm2niixProcessor
+    /** Files harvested from a drop event (see `traverseDataTransferItems`). */
+    inputFromDropItems(files: File[]): Dcm2niixProcessor
+  }
+}

--- a/packages/nv-ext-dcm2niix/src/index.ts
+++ b/packages/nv-ext-dcm2niix/src/index.ts
@@ -1,0 +1,149 @@
+/**
+ * @niivue/nv-ext-dcm2niix
+ *
+ * Browser-side DICOM-to-NIfTI conversion for NiiVue, wrapping the
+ * `@niivue/dcm2niix` WebAssembly build of Chris Rorden's dcm2niix.
+ *
+ * Two pieces of glue cover the common integration paths:
+ *
+ *   - {@link runDcm2niix}              — `<input webkitdirectory>` → File[]
+ *   - {@link traverseDataTransferItems} — drop-event folders → File[]
+ *
+ * The underlying `Dcm2niix` class is re-exported for callers that need
+ * full control over the command-line flags exposed by dcm2niix.
+ *
+ * Usage:
+ * ```ts
+ * import NiiVueGPU from '@niivue/niivue'
+ * import { runDcm2niix } from '@niivue/nv-ext-dcm2niix'
+ *
+ * const nv = new NiiVueGPU()
+ * await nv.attachTo('gl1')
+ *
+ * input.addEventListener('change', async () => {
+ *   const niftiFiles = await runDcm2niix(input.files)
+ *   await nv.loadVolumes([{ url: niftiFiles[0] }])
+ * })
+ * ```
+ */
+
+import { Dcm2niix } from '@niivue/dcm2niix'
+
+// Re-export so callers can drop down to the raw API when they need flags
+// like compression level, BIDS sidecars, etc.
+export { Dcm2niix }
+
+/**
+ * Drop items expose a non-standard `_webkitRelativePath` that dcm2niix
+ * uses to group images by series. Standard `webkitRelativePath` is
+ * read-only on `File`, so we attach our own and dcm2niix reads either.
+ */
+type FileWithRelativePath = File & { _webkitRelativePath?: string }
+
+/** Options for {@link runDcm2niix}. */
+export interface RunDcm2niixOptions {
+  /**
+   * Filter the result list down to NIfTI outputs (`.nii` and `.nii.gz`).
+   * BIDS sidecars and other dcm2niix outputs are dropped. Default: `true`.
+   */
+  niftiOnly?: boolean
+}
+
+/**
+ * Convert DICOM files to NIfTI by spinning up a fresh dcm2niix worker,
+ * feeding it the files, waiting for the result, then terminating the
+ * worker so the WASM heap is released.
+ *
+ * Each call boots its own worker — fine for one-off conversions; for
+ * batch workflows, instantiate `Dcm2niix` once and reuse it (and call
+ * `worker?.terminate()` yourself when finished).
+ *
+ * @param files       FileList from `<input webkitdirectory>` or File[]
+ *                    from a drop event (see {@link traverseDataTransferItems}).
+ * @param options     See {@link RunDcm2niixOptions}.
+ * @returns           Converted output files (NIfTI by default).
+ */
+export async function runDcm2niix(
+  files: FileList | File[] | null | undefined,
+  options: RunDcm2niixOptions = {},
+): Promise<File[]> {
+  const { niftiOnly = true } = options
+  if (!files || files.length === 0) return []
+
+  const dcm2niix = new Dcm2niix()
+  try {
+    await dcm2niix.init()
+    const result = (await dcm2niix.input(files).run()) as File[]
+    return niftiOnly
+      ? result.filter((f) => /\.nii(\.gz)?$/i.test(f.name))
+      : result
+  } finally {
+    dcm2niix.worker?.terminate()
+  }
+}
+
+/**
+ * Walk a drop event's `DataTransferItemList`, recurse into directories,
+ * and stamp `_webkitRelativePath` on each file so dcm2niix can group by
+ * series.
+ *
+ * The browser exposes folder structure on drop only via the
+ * `webkitGetAsEntry()` API; this helper runs that traversal for you.
+ *
+ * @example
+ * ```ts
+ * dropTarget.addEventListener('drop', async (e) => {
+ *   e.preventDefault()
+ *   const files = await traverseDataTransferItems(e.dataTransfer!.items)
+ *   const niftiFiles = await runDcm2niix(files)
+ * })
+ * ```
+ */
+export async function traverseDataTransferItems(
+  items: DataTransferItemList,
+): Promise<File[]> {
+  const files: File[] = []
+  const entries: FileSystemEntry[] = []
+  for (let i = 0; i < items.length; i++) {
+    const entry = items[i].webkitGetAsEntry()
+    if (entry) entries.push(entry)
+  }
+  await Promise.all(entries.map((entry) => walkEntry(entry, '', files)))
+  return files
+}
+
+function walkEntry(
+  entry: FileSystemEntry,
+  path: string,
+  out: File[],
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (entry.isFile) {
+      ;(entry as FileSystemFileEntry).file((file) => {
+        const tagged = file as FileWithRelativePath
+        tagged._webkitRelativePath = path + file.name
+        out.push(tagged)
+        resolve()
+      }, reject)
+      return
+    }
+    if (entry.isDirectory) {
+      const reader = (entry as FileSystemDirectoryEntry).createReader()
+      const childPath = `${path}${entry.name}/`
+      const readBatch = () => {
+        reader.readEntries((batch) => {
+          if (batch.length === 0) {
+            resolve()
+            return
+          }
+          Promise.all(batch.map((child) => walkEntry(child, childPath, out)))
+            .then(readBatch)
+            .catch(reject)
+        }, reject)
+      }
+      readBatch()
+      return
+    }
+    resolve()
+  })
+}

--- a/packages/nv-ext-dcm2niix/tsconfig.json
+++ b/packages/nv-ext-dcm2niix/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "target": "ESNext",
+    "useDefineForClassFields": false,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/nv-ext-dcm2niix/vite.config.ts
+++ b/packages/nv-ext-dcm2niix/vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vite'
+import dts from 'vite-plugin-dts'
+
+export default defineConfig({
+  plugins: [dts({ tsconfigPath: './tsconfig.json' })],
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    lib: {
+      entry: 'src/index.ts',
+      formats: ['es'],
+      fileName: 'nv-ext-dcm2niix',
+    },
+    rollupOptions: {
+      external: ['@niivue/niivue', '@niivue/dcm2niix'],
+    },
+  },
+})


### PR DESCRIPTION
Lean wrapper around the @niivue/dcm2niix WASM build, exposing runDcm2niix and traverseDataTransferItems plus a re-export of the underlying Dcm2niix class for advanced use. The runner terminates its worker in a finally block so the WASM heap is reclaimed after each conversion. Demo on port 8086 wires three input paths: folder picker, drag-drop, and a public DICOM manifest. MULTIPLANAR_TYPE is now part of @niivue/niivue's public exports so the demo can use the named enum instead of an inlined integer.