### PR TITLE
Fix npm release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: 'Dry run (print the plan without creating commits or tags)'
+        description: "Dry run (print the plan without creating commits or tags)"
         type: boolean
         default: false
 
@@ -14,6 +14,7 @@ concurrency:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:
@@ -23,7 +24,7 @@ jobs:
     # accidentally force-pushing a feature branch to main.
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           lfs: true
@@ -37,7 +38,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
 
       # Pixi env for ipyniivue's `build` target (hatchling / python-build).
       # Required because `nx-release-publish` depends on `build`, and
@@ -159,4 +160,5 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
         run: bunx nx release publish --verbose

--- a/packages/niivue/package.json
+++ b/packages/niivue/package.json
@@ -81,5 +81,8 @@
     "typescript": "^5.6.3",
     "vite": "^7.3.1",
     "vite-plugin-dts": "^4.5.4"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/nv-ext-dcm2niix/package.json
+++ b/packages/nv-ext-dcm2niix/package.json
@@ -30,5 +30,8 @@
   "scripts": {
     "build": "npx vite build",
     "typecheck": "bunx tsc --noEmit"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/nv-ext-drawing/package.json
+++ b/packages/nv-ext-drawing/package.json
@@ -27,5 +27,8 @@
   "scripts": {
     "build": "npx vite build",
     "typecheck": "bunx tsc --noEmit"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/nv-ext-image-processing/package.json
+++ b/packages/nv-ext-image-processing/package.json
@@ -31,5 +31,8 @@
   "dependencies": {
     "gl-matrix": "^3.4.4",
     "nifti-reader-js": "^0.8.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/nv-ext-save-html/package.json
+++ b/packages/nv-ext-save-html/package.json
@@ -27,5 +27,8 @@
   "scripts": {
     "build": "npx vite build",
     "typecheck": "bunx tsc --noEmit"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
Link to any related issues present on GitHub or Linear.

None found.

## Context & Motivation

- npm publishing from the Nx release workflow was not working reliably for scoped packages.
- Nx and npm docs require provenance permissions/config when publishing with provenance enabled.

## Changes

- Add public npm publish access to publishable scoped `@niivue/*` packages.
- Enable npm provenance in the release publishing step.
- Keep the documented `secrets.GITHUB_TOKEN` fallback for GitHub Actions auth.

### Interface Delta

- CI/package publishing configuration only.

## Alternatives Explored

- Verified `github.token` vs `secrets.GITHUB_TOKEN`; kept the documented existing `secrets.GITHUB_TOKEN` usage.

## Validation

- `bunx biome check .github/workflows/release.yml packages/niivue/package.json packages/nv-ext-dcm2niix/package.json packages/nv-ext-drawing/package.json packages/nv-ext-image-processing/package.json packages/nv-ext-save-html/package.json` passed.
