### PR TITLE
ci: publish prereleases with next dist tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,4 +152,26 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
-        run: bunx nx release publish --groups typescript --verbose
+        run: |
+          set -euo pipefail
+          for tag in $(git tag --points-at HEAD); do
+            project="${tag%@*}"
+            version="${tag##*@}"
+
+            # Only publish npm packages from the TypeScript release group.
+            case "$project" in
+              niivue|nv-*) ;;
+              *) continue ;;
+            esac
+
+            npm_tag="latest"
+            if [[ "$version" == *-* ]]; then
+              npm_tag="next"
+            fi
+
+            echo "Publishing $project@$version to npm with dist-tag '$npm_tag'"
+            bunx nx release publish \
+              --projects "$project" \
+              --tag "$npm_tag" \
+              --verbose
+          done


### PR DESCRIPTION
Link to any related issues present on GitHub or Linear.

None found.

## Context & Motivation

- RC npm releases were published with the `latest` dist-tag.
- Prerelease packages should use `next` while stable packages continue to use `latest`.

## Changes

- Publish each release tag individually from the GitHub release workflow.
- Detect prerelease versions by the presence of a semver prerelease suffix.
- Pass `--tag next` for prereleases and `--tag latest` otherwise.

### Interface Delta

- Release workflow npm publishing now applies dist-tags based on version type.

## Alternatives Explored

- Publishing the whole TypeScript release group in one command; this cannot vary the npm dist-tag per package version.

## Validation

- `git diff --check`
- `bash -n` on the release workflow publish script
- `bunx nx release publish --projects niivue --tag next --dry-run --verbose`
