### PR TITLE
niimath edge and cloud demos

### DIFF
--- a/.github/build-pages.sh
+++ b/.github/build-pages.sh
@@ -23,6 +23,7 @@ APPS=(
   demo-ext-image-processing
   demo-ext-save-html
   demo-ext-dcm2niix
+  demo-ext-niimath
   demo-nv-web-component
 )
 

--- a/.github/pages/index.html
+++ b/.github/pages/index.html
@@ -160,6 +160,14 @@
             >DICOM to NIfTI (dcm2niix)</a
           >
         </li>
+        <li>
+          <a
+            href="./demo-ext-niimath/index.html"
+            target="_blank"
+            rel="noopener noreferrer"
+            >niimath (WASM)</a
+          >
+        </li>
       </ul>
     </main>
   </body>

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Monorepo for the [NiiVue](https://github.com/niivue) ecosystem — browser-based
 | [`@niivue/nv-ext-image-processing`](packages/nv-ext-image-processing) | Image processing (Otsu thresholding, haze removal, etc.) | [![npm](https://img.shields.io/npm/v/@niivue/nv-ext-image-processing/next)](https://www.npmjs.com/package/@niivue/nv-ext-image-processing) |
 | [`@niivue/nv-ext-save-html`](packages/nv-ext-save-html) | Export a NiiVue scene as a self-contained HTML file | [![npm](https://img.shields.io/npm/v/@niivue/nv-ext-save-html/next)](https://www.npmjs.com/package/@niivue/nv-ext-save-html) |
 | [`@niivue/nv-ext-dcm2niix`](packages/nv-ext-dcm2niix) | DICOM-to-NIfTI conversion in the browser via the dcm2niix WASM build | [![npm](https://img.shields.io/npm/v/@niivue/nv-ext-dcm2niix/next)](https://www.npmjs.com/package/@niivue/nv-ext-dcm2niix) |
+| [`@niivue/nv-ext-niimath`](packages/nv-ext-niimath) | niimath pipelines in the browser via the niimath WASM build | [![npm](https://img.shields.io/npm/v/@niivue/nv-ext-niimath/next)](https://www.npmjs.com/package/@niivue/nv-ext-niimath) |
 | [`@niivue/web-bridge`](packages/niivue-web-bridge) | Typed two-way JSON-envelope bridge between a NiiVue web view and a native (WKWebView) host | — |
 | [`NiiVueKit`](packages/niivue-swift) | Swift package (`BridgeCore` + `NiiVueKit`) pairing with `@niivue/web-bridge` to embed NiiVue in SwiftUI apps via `WKWebView` | — |
 | [`@niivue/dev-images`](packages/dev-images) | Shared test volumes, meshes, and tractography files (Git LFS) | — |
@@ -27,6 +28,7 @@ Monorepo for the [NiiVue](https://github.com/niivue) ecosystem — browser-based
 | [`demo-ext-save-html`](apps/demo-ext-save-html) | Demo app for the save-to-HTML extension |
 | [`demo-ext-dcm2niix`](apps/demo-ext-dcm2niix) | Demo app for the dcm2niix DICOM-to-NIfTI extension |
 | [`demo-ext-fullstack`](apps/demo-ext-fullstack) | Fullstack demo wiring NiiVue to a Bun server that runs the `niimath` native binary |
+| [`demo-ext-niimath`](apps/demo-ext-niimath) | Browser-only demo running niimath as WASM via [`@niivue/niimath`](https://www.npmjs.com/package/@niivue/niimath) |
 | [`demo-nv-web-component`](apps/demo-nv-web-component) | Demo app for the Web Components package |
 | [`medgfx`](apps/medgfx) | Native macOS/iOS SwiftUI app embedding NiiVue in a WebView |
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Monorepo for the [NiiVue](https://github.com/niivue) ecosystem — browser-based
 | [`demo-ext-image-processing`](apps/demo-ext-image-processing) | Demo app for the image processing extension |
 | [`demo-ext-save-html`](apps/demo-ext-save-html) | Demo app for the save-to-HTML extension |
 | [`demo-ext-dcm2niix`](apps/demo-ext-dcm2niix) | Demo app for the dcm2niix DICOM-to-NIfTI extension |
+| [`demo-ext-fullstack`](apps/demo-ext-fullstack) | Fullstack demo wiring NiiVue to a Bun server that runs the `niimath` native binary |
 | [`demo-nv-web-component`](apps/demo-nv-web-component) | Demo app for the Web Components package |
 | [`medgfx`](apps/medgfx) | Native macOS/iOS SwiftUI app embedding NiiVue in a WebView |
 

--- a/apps/demo-ext-fullstack/.gitignore
+++ b/apps/demo-ext-fullstack/.gitignore
@@ -1,0 +1,1 @@
+server/bin/

--- a/apps/demo-ext-fullstack/README.md
+++ b/apps/demo-ext-fullstack/README.md
@@ -1,0 +1,129 @@
+# demo-ext-fullstack
+
+Minimal full-stack demo showing how to combine NiiVue (in the browser) with niimath (a portable, server-side native binary) for image processing. While niimath itself can run in WASM (see https://niivue.github.io/niivue-niimath/), this example intentionally uses a backend to mirror how users typically integrate platform-specific neuroimaging tools (e.g., FSL, FreeSurfer) that run in Unix-based cloud environments rather than on local machines.
+
+Because niimath is cross-platform (Windows, macOS, Linux), this demo runs anywhere while illustrating the pattern: offload processing to a server you control and tune for your own cloud or HPC setup.
+
+Select a built-in sample volume or upload your own NIfTI file, construct a niimath pipeline (e.g., -s 3 -thr 0.5 -bin), reorder operations via drag-and-drop, and click Run on server. The processed output is returned and displayed in the viewer as a preview. To continue building on the result, use Apply result as input in the Current Image panel to chain additional processing steps.
+
+The whole stack is two processes:
+
+| Process    | Port | What it does                                                      |
+|------------|------|-------------------------------------------------------------------|
+| Vite       | 8088 | Serves the frontend + `@niivue/dev-images` sample volumes         |
+| Bun server | 8087 | Receives uploads, spawns `niimath`, returns the processed file    |
+
+No database, no auth, no Docker. Runs on macOS, Linux, and Windows from a
+single Bun command. Job history is in-memory and cleared on server restart.
+
+## One-time setup
+
+The server uses the prebuilt `niimath` binary from the
+[rordenlab/niimath releases](https://github.com/rordenlab/niimath/releases).
+Fetch it for your platform:
+
+```bash
+bunx nx run demo-ext-fullstack:setup
+```
+
+That downloads the right zip (`niimath_macos.zip` / `niimath_lnx.zip` /
+`niimath_win.zip`), extracts the binary into
+`apps/demo-ext-fullstack/server/bin/`, and writes a small `manifest.json`
+recording which release was installed. The directory is gitignored.
+
+## Run
+
+```bash
+bunx nx dev demo-ext-fullstack
+```
+
+Starts both the Bun API server (port 8087) and the Vite dev server (port 8088,
+auto-opens). Vite proxies `/api/*` to the backend so the frontend uses a single
+origin. The dev script tears down both children if either one crashes, so you
+won't end up with an orphan process bound to either port.
+
+To run them separately:
+
+```bash
+bunx nx run demo-ext-fullstack:server      # API only
+bunx nx run demo-ext-fullstack:frontend    # Vite only — `bun run frontend`
+```
+
+## How it works
+
+1. Frontend builds an array of niimath args (e.g. `["-s", "3", "-bin"]`)
+   from the sidebar UI. Operations can be reordered by drag-and-drop and the
+   generated command is displayed live above the **Run** button (click either
+   the command or the status bar to copy).
+2. On **Run**, the current volume is sent as a raw body to `POST /api/process`
+   with `X-Niimath-Filename` and `X-Niimath-Args` headers (see API below for
+   why this isn't multipart).
+3. The server writes the upload to `os.tmpdir()/niivue-fullstack-demo/`, spawns
+   `niimath <input> <args...> <output>` with `FSLOUTPUTTYPE=NIFTI_GZ`, and
+   returns `{id, resultUrl, command, durationMs}`.
+4. The frontend points NiiVue at `resultUrl` and shows the result as a
+   *preview* — `currentSource` (the input runs operate on) stays unchanged,
+   so reordering or editing pipeline steps re-runs against the same source
+   instead of chaining onto the previous result. Click **Apply result as
+   input** on the Current Image panel to promote the preview to the working
+   input. Subsequent runs then re-fetch from the server rather than
+   re-uploading the in-browser blob, which keeps chains byte-stable
+   (NiiVue's loader can detach the Blob's backing buffer on worker transfer).
+5. The **Save to disk** button on the Current Image panel triggers a normal
+   browser download for whatever's currently displayed (sample, upload, or
+   the latest server result).
+
+## API
+
+| Method | Path                  | Purpose                                       |
+|--------|-----------------------|-----------------------------------------------|
+| GET    | `/api/health`         | Server status + which niimath release is in use |
+| POST   | `/api/process`        | Raw NIfTI body, headers `X-Niimath-Filename` (URL-encoded) and `X-Niimath-Args` (JSON string array). Runs niimath. |
+| GET    | `/api/result/:id`     | Streams the processed NIfTI back              |
+| GET    | `/api/jobs`           | In-memory history `{jobs: Job[]}`             |
+
+The upload endpoint deliberately avoids `multipart/form-data`. Bun's
+`req.formData()` intermittently rejects browser-built multipart bodies as
+"missing final boundary" on larger files; raw body + headers is a much smaller
+surface to break and lets `fetch` stream the Blob rather than buffer the whole
+thing in JS. The Bun server sets `idleTimeout: 240` (Bun's default of 10s
+drops slow ops; 255s is the cap) and the Vite proxy disables its own timeout
+so heavy pipelines don't get hung up at either hop.
+
+## Security note
+
+This demo runs niimath with caller-supplied argument arrays. A handful of
+cheap defences are in place so a malicious page in another tab — or another
+machine on the same Wi-Fi — can't abuse the running dev server:
+
+- **Loopback bind.** The Bun server listens on `127.0.0.1:8087`, not
+  `0.0.0.0`, so the API isn't reachable from the LAN even when the laptop
+  is on a coffee-shop network. Override with `FULLSTACK_SERVER_HOST` if you
+  really do need to expose it.
+- **No CORS headers.** The Vite dev server proxies `/api/*` so the frontend
+  hits the API same-origin; cross-origin requests from other tabs get no
+  `Access-Control-Allow-Origin` back, so browsers won't let scripts read
+  `/api/jobs` or `/api/result/<id>`.
+- **Argument validator.** Every entry in `X-Niimath-Args` must be either a
+  niimath flag (`-foo`) or a plain number. Stops `["-add","/etc/passwd"]`
+  style attacks where a niimath operator that accepts "value or filename"
+  gets steered into reading off-disk files.
+- **Body size cap.** Uploads larger than 2 GiB are rejected with `413`.
+  Checked twice — once against `Content-Length` before reading, once
+  against the buffered size after, so chunked uploads can't slip past.
+- **Input cleanup.** Each upload is unlinked from the work dir as soon as
+  niimath returns. Outputs stick around so `/api/result/:id` and the
+  history reload button keep working until the server restarts.
+
+It is still a **localhost convenience** — don't expose the API to an
+untrusted network without adding auth, request limits, and persistent
+output cleanup.
+
+## What's deliberately missing
+
+This demo intentionally drops most of what a "real" fullstack app needs, so the
+plumbing between NiiVue and a native processing binary is the only thing on
+display: no database, no users/auth, no scenes table, no history persistence,
+no Docker, no nginx, no migration tooling. The
+[`fullstack-niivue-demo`](https://github.com/niivue/niivue-fullstack-demo)
+showcases those pieces.

--- a/apps/demo-ext-fullstack/index.html
+++ b/apps/demo-ext-fullstack/index.html
@@ -1,0 +1,101 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>NiiVue — niimath fullstack demo</title>
+    <link rel="icon" href="data:," />
+    <link rel="stylesheet" href="src/style.css" />
+  </head>
+  <body>
+    <header>
+      <h1>NiiVue · niimath fullstack demo</h1>
+      <span id="health" class="health">checking server…</span>
+    </header>
+
+    <main>
+      <canvas id="gl1"></canvas>
+    </main>
+
+    <aside>
+      <div class="tabs">
+        <button type="button" class="tab-btn active" data-tab="image">Image</button>
+        <button type="button" class="tab-btn" data-tab="tools">Processing</button>
+        <button type="button" class="tab-btn" data-tab="history">History</button>
+      </div>
+
+      <div id="tab-image" class="tab-panel active">
+        <div class="section">
+          <h2>Sample volumes</h2>
+          <p>Pick a built-in volume from <code>@niivue/dev-images</code>.</p>
+          <div class="row">
+            <select id="sampleSelect" class="grow"></select>
+            <button type="button" id="loadSampleBtn">Load</button>
+          </div>
+        </div>
+
+        <div class="section">
+          <h2>Upload</h2>
+          <p>Or load a NIfTI from disk.</p>
+          <label for="fileInput" class="file-label">Choose .nii / .nii.gz</label>
+          <input id="fileInput" type="file" accept=".nii,.nii.gz,application/gzip" />
+        </div>
+
+        <div class="section">
+          <h2>Current image</h2>
+          <p id="currentImage">none</p>
+          <div class="row">
+            <button type="button" id="saveBtn" disabled>Save to disk</button>
+            <button type="button" id="applyBtn" disabled title="Use the most recent processing result as the input for further pipelines">Apply result as input</button>
+          </div>
+        </div>
+      </div>
+
+      <div id="tab-tools" class="tab-panel">
+        <div class="card">
+          <h3>Add Operation</h3>
+          <p class="desc">Pick a niimath operator to append to the pipeline.</p>
+          <div class="row">
+            <select id="operatorSelect" class="grow">
+              <option value="">Select operator…</option>
+            </select>
+            <button type="button" id="addOperatorBtn" disabled>+</button>
+          </div>
+        </div>
+
+        <div class="card" id="pipelineCard">
+          <h3>Processing Pipeline</h3>
+          <p class="desc">Operations applied in order, server-side via niimath.</p>
+          <div id="pipeline"></div>
+          <p id="emptyPipeline" class="desc">No operations yet.</p>
+        </div>
+
+        <div class="card">
+          <h3>Generated Command</h3>
+          <p class="desc">Preview of the niimath invocation.</p>
+          <pre class="command" id="commandPreview">niimath input.nii output.nii</pre>
+        </div>
+
+        <button type="button" id="runBtn" class="primary" style="width: 100%" disabled>
+          Run on server
+        </button>
+      </div>
+
+      <div id="tab-history" class="tab-panel">
+        <div class="section">
+          <h2>Processing history</h2>
+          <p>Recent jobs from this server (in-memory; cleared on restart).</p>
+          <div id="historyList"></div>
+          <p id="emptyHistory" class="desc">No jobs yet.</p>
+        </div>
+      </div>
+    </aside>
+
+    <footer>
+      <span id="spinner" class="spinner hidden"></span>
+      <span id="status">Ready.</span>
+    </footer>
+
+    <script type="module" src="src/main.ts"></script>
+  </body>
+</html>

--- a/apps/demo-ext-fullstack/package.json
+++ b/apps/demo-ext-fullstack/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "demo-ext-fullstack",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "setup": "bun server/fetch-niimath.ts",
+    "server": "bun server/server.ts",
+    "frontend": "bunx --bun vite --open /index.html",
+    "dev": "bun server/dev.ts",
+    "build": "bunx --bun vite build"
+  },
+  "dependencies": {
+    "@niivue/dev-images": "workspace:*",
+    "@niivue/niivue": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.1.0",
+    "vite": "^6.3.2"
+  }
+}

--- a/apps/demo-ext-fullstack/project.json
+++ b/apps/demo-ext-fullstack/project.json
@@ -1,0 +1,49 @@
+{
+  "name": "demo-ext-fullstack",
+  "projectType": "application",
+  "tags": ["type:app", "lang:typescript"],
+  "targets": {
+    "setup": {
+      "command": "bun server/fetch-niimath.ts",
+      "options": { "cwd": "{projectRoot}" }
+    },
+    "server": {
+      "command": "bun server/server.ts",
+      "options": { "cwd": "{projectRoot}" }
+    },
+    "frontend": {
+      "command": "bunx --bun vite --open /index.html",
+      "options": { "cwd": "{projectRoot}" }
+    },
+    "dev": {
+      "command": "bun server/dev.ts",
+      "options": { "cwd": "{projectRoot}" }
+    },
+    "build": {
+      "command": "bunx --bun vite build",
+      "options": { "cwd": "{projectRoot}" },
+      "dependsOn": ["^build"],
+      "inputs": [
+        "typescript",
+        "{projectRoot}/vite.config.js",
+        "{projectRoot}/src/**/*",
+        "{projectRoot}/*.html"
+      ],
+      "outputs": ["{projectRoot}/dist"]
+    },
+    "typecheck": {
+      "command": "bunx tsc --noEmit",
+      "options": { "cwd": "{projectRoot}" },
+      "dependsOn": ["^build"],
+      "inputs": ["typescript"]
+    },
+    "lint": {
+      "command": "bunx biome check {projectRoot}",
+      "inputs": ["typescript"]
+    },
+    "format": {
+      "command": "bunx biome format {projectRoot} --write",
+      "inputs": ["typescript"]
+    }
+  }
+}

--- a/apps/demo-ext-fullstack/project.json
+++ b/apps/demo-ext-fullstack/project.json
@@ -5,19 +5,24 @@
   "targets": {
     "setup": {
       "command": "bun server/fetch-niimath.ts",
-      "options": { "cwd": "{projectRoot}" }
+      "options": { "cwd": "{projectRoot}" },
+      "inputs": ["{projectRoot}/server/fetch-niimath.ts"],
+      "outputs": ["{projectRoot}/server/bin"]
     },
     "server": {
       "command": "bun server/server.ts",
-      "options": { "cwd": "{projectRoot}" }
+      "options": { "cwd": "{projectRoot}" },
+      "dependsOn": ["setup"]
     },
     "frontend": {
       "command": "bunx --bun vite --open /index.html",
-      "options": { "cwd": "{projectRoot}" }
+      "options": { "cwd": "{projectRoot}" },
+      "dependsOn": ["^build"]
     },
     "dev": {
       "command": "bun server/dev.ts",
-      "options": { "cwd": "{projectRoot}" }
+      "options": { "cwd": "{projectRoot}" },
+      "dependsOn": ["setup", "^build"]
     },
     "build": {
       "command": "bunx --bun vite build",

--- a/apps/demo-ext-fullstack/server/dev.ts
+++ b/apps/demo-ext-fullstack/server/dev.ts
@@ -1,0 +1,54 @@
+/**
+ * Run the niimath server and the Vite dev server together.
+ *
+ * If either child exits, take the other down with it before exiting
+ * ourselves — otherwise an early crash (e.g. EADDRINUSE) leaves an
+ * orphaned vite/bun bound to a port and the next `bun server/dev.ts`
+ * will fail mysteriously.
+ */
+import { type ChildProcess, spawn } from 'node:child_process'
+
+const children = new Map<string, ChildProcess>()
+let shuttingDown = false
+
+function start(name: string, cmd: string, args: string[]): ChildProcess {
+  const child = spawn(cmd, args, {
+    stdio: 'inherit',
+    env: { ...process.env, FORCE_COLOR: '1' },
+  })
+  children.set(name, child)
+  child.on('exit', (code, signal) => {
+    children.delete(name)
+    console.log(
+      `[${name}] exited (code=${code ?? 'null'}, signal=${signal ?? 'null'})`,
+    )
+    if (!shuttingDown) shutdown(code ?? 0)
+  })
+  return child
+}
+
+function shutdown(code = 0): void {
+  if (shuttingDown) return
+  shuttingDown = true
+  for (const [name, c] of children) {
+    if (!c.killed) {
+      try {
+        c.kill('SIGTERM')
+      } catch (err) {
+        console.error(`[${name}] kill failed:`, err)
+      }
+    }
+  }
+  // Give children a beat to flush, then exit. If they refuse to die in
+  // 2s, force-kill them and leave.
+  setTimeout(() => {
+    for (const [, c] of children) if (!c.killed) c.kill('SIGKILL')
+    process.exit(code)
+  }, 2000).unref()
+}
+
+start('server', 'bun', ['server/server.ts'])
+start('vite', 'bunx', ['--bun', 'vite', '--open', '/index.html'])
+
+process.on('SIGINT', () => shutdown(0))
+process.on('SIGTERM', () => shutdown(0))

--- a/apps/demo-ext-fullstack/server/fetch-niimath.ts
+++ b/apps/demo-ext-fullstack/server/fetch-niimath.ts
@@ -1,0 +1,133 @@
+/**
+ * Download the niimath binary for the host platform from the latest GitHub release.
+ *
+ * Usage:
+ *   bun server/fetch-niimath.ts            # latest release
+ *   bun server/fetch-niimath.ts v1.0.20250804  # specific tag
+ *
+ * Writes to apps/demo-ext-fullstack/server/bin/niimath{,.exe}.
+ */
+import { spawn } from 'node:child_process'
+import { existsSync, mkdirSync, readFileSync, unlinkSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const REPO = 'rordenlab/niimath'
+
+type Asset = { name: string; browser_download_url: string }
+type Release = { tag_name: string; assets: Asset[] }
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const binDir = resolve(__dirname, 'bin')
+
+function pickAssetName(): string {
+  switch (process.platform) {
+    case 'darwin':
+      return 'niimath_macos.zip'
+    case 'linux':
+      return 'niimath_lnx.zip'
+    case 'win32':
+      return 'niimath_win.zip'
+    default:
+      throw new Error(`Unsupported platform: ${process.platform}`)
+  }
+}
+
+function binaryName(): string {
+  return process.platform === 'win32' ? 'niimath.exe' : 'niimath'
+}
+
+async function fetchRelease(tag: string | undefined): Promise<Release> {
+  const url = tag
+    ? `https://api.github.com/repos/${REPO}/releases/tags/${tag}`
+    : `https://api.github.com/repos/${REPO}/releases/latest`
+  const res = await fetch(url, {
+    headers: { Accept: 'application/vnd.github+json' },
+  })
+  if (!res.ok) {
+    throw new Error(`GitHub API ${res.status}: ${await res.text()}`)
+  }
+  return res.json() as Promise<Release>
+}
+
+async function unzipTo(zipPath: string, destDir: string): Promise<void> {
+  // macOS/Linux ship `unzip`; Windows ships `tar` (with libarchive) which
+  // can extract zips. Pick whichever is present.
+  const cmd =
+    process.platform === 'win32'
+      ? { bin: 'tar', args: ['-xf', zipPath, '-C', destDir] }
+      : { bin: 'unzip', args: ['-o', zipPath, '-d', destDir] }
+  await new Promise<void>((resolveP, rejectP) => {
+    const child = spawn(cmd.bin, cmd.args, { stdio: 'inherit' })
+    child.on('error', rejectP)
+    child.on('exit', (code) => {
+      if (code === 0) resolveP()
+      else rejectP(new Error(`${cmd.bin} exited with ${code}`))
+    })
+  })
+}
+
+async function main(): Promise<void> {
+  const tag = process.argv[2]
+  const release = await fetchRelease(tag)
+  const wantedName = pickAssetName()
+  const asset = release.assets.find((a) => a.name === wantedName)
+  if (!asset) {
+    throw new Error(
+      `Asset ${wantedName} not found in release ${release.tag_name}`,
+    )
+  }
+
+  mkdirSync(binDir, { recursive: true })
+  const zipPath = join(binDir, asset.name)
+  console.log(`Downloading ${asset.name} from ${release.tag_name}...`)
+  const dl = await fetch(asset.browser_download_url)
+  if (!dl.ok) throw new Error(`Download failed: ${dl.status}`)
+  await Bun.write(zipPath, dl)
+
+  console.log(`Extracting to ${binDir}...`)
+  await unzipTo(zipPath, binDir)
+  unlinkSync(zipPath)
+
+  const binPath = join(binDir, binaryName())
+  if (!existsSync(binPath)) {
+    throw new Error(`Expected ${binPath} after extraction, not found`)
+  }
+  if (process.platform !== 'win32') {
+    // chmod +x — extracted files from `unzip` should already preserve
+    // permissions, but be defensive.
+    const { chmodSync } = await import('node:fs')
+    chmodSync(binPath, 0o755)
+  }
+  console.log(`Installed ${binPath}`)
+
+  // Drop a tiny manifest so the server can show what it has.
+  const manifest = {
+    tag: release.tag_name,
+    asset: asset.name,
+    platform: process.platform,
+    installedAt: new Date().toISOString(),
+  }
+  await Bun.write(
+    join(binDir, 'manifest.json'),
+    JSON.stringify(manifest, null, 2),
+  )
+}
+
+// If invoked as a script (not imported), run main().
+if (import.meta.main) {
+  main().catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })
+}
+
+export function niimathBinaryPath(): string {
+  return join(binDir, binaryName())
+}
+
+export function niimathManifest(): { tag: string; installedAt: string } | null {
+  const path = join(binDir, 'manifest.json')
+  if (!existsSync(path)) return null
+  return JSON.parse(readFileSync(path, 'utf8'))
+}

--- a/apps/demo-ext-fullstack/server/server.ts
+++ b/apps/demo-ext-fullstack/server/server.ts
@@ -1,0 +1,384 @@
+/**
+ * Minimal niimath HTTP server.
+ *
+ * Endpoints:
+ *   POST /api/process       body: raw NIfTI bytes (any Content-Type)
+ *                           headers: X-Niimath-Filename (URL-encoded),
+ *                                    X-Niimath-Args     (JSON string array)
+ *                           runs `niimath <input> <...args> <output>`,
+ *                           returns { id, status, resultUrl, durationMs, command }
+ *
+ *                           We deliberately skip multipart/form-data — Bun's
+ *                           `req.formData()` parser intermittently rejects
+ *                           browser-built bodies as "missing final boundary"
+ *                           on larger files. Raw body + headers sidesteps it.
+ *   GET  /api/result/:id    streams the processed NIfTI back as application/gzip
+ *   GET  /api/jobs          { jobs: Job[] } from in-memory history
+ *   GET  /api/health        { ok, niimath: <manifest|null> }
+ *
+ * No auth, no DB. The Vite dev server proxies /api/* so the frontend hits
+ * the API same-origin; we deliberately send no CORS headers so a malicious
+ * page in another tab can't read /api/jobs or /api/result/<id> while the
+ * dev server is running. curl/Bun callers don't care about CORS.
+ */
+import { spawn } from 'node:child_process'
+import { existsSync, mkdirSync } from 'node:fs'
+import { unlink } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { niimathBinaryPath, niimathManifest } from './fetch-niimath'
+
+const PORT = Number(process.env.FULLSTACK_SERVER_PORT ?? 8087)
+// Bun.serve defaults hostname to 0.0.0.0 — i.e. reachable from anything on
+// the LAN. Pin to loopback so this unauthenticated, native-binary-spawning
+// API isn't sitting on the wire when a developer takes their laptop to a
+// coffee shop.
+const HOST = process.env.FULLSTACK_SERVER_HOST ?? '127.0.0.1'
+const WORK_DIR = join(tmpdir(), 'niivue-fullstack-demo')
+mkdirSync(WORK_DIR, { recursive: true })
+
+// Reject uploads bigger than this before reading them into memory. Even a
+// localhost demo shouldn't OOM on a single misbehaving client.
+const MAX_BODY_BYTES = 2 * 1024 * 1024 * 1024 // 2 GiB
+
+type JobStatus = 'running' | 'completed' | 'failed'
+
+/**
+ * Reject anything that isn't either a niimath flag (`-foo`) or a plain
+ * number. Stops `["-add","/etc/passwd"]` style attacks where a niimath
+ * operator that accepts "value or filename" is steered into reading an
+ * arbitrary file off the server's disk.
+ */
+function validateArgs(args: string[]): string | null {
+  const flag = /^-[a-zA-Z][a-zA-Z0-9_]*$/
+  const num = /^-?\d+(\.\d+)?([eE][+-]?\d+)?$/
+  for (const a of args) {
+    if (!flag.test(a) && !num.test(a)) return `Disallowed argument: ${a}`
+  }
+  return null
+}
+
+interface Job {
+  id: string
+  status: JobStatus
+  inputName: string
+  args: string[]
+  command: string
+  outputPath?: string
+  error?: string
+  startedAt: number
+  finishedAt?: number
+  durationMs?: number
+}
+
+const jobs = new Map<string, Job>()
+
+function json(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(init.headers ?? {}),
+    },
+  })
+}
+
+function inferOutputName(inputName: string): string {
+  const lower = inputName.toLowerCase()
+  let stem = inputName
+  if (lower.endsWith('.nii.gz')) stem = inputName.slice(0, -7)
+  else if (lower.endsWith('.nii')) stem = inputName.slice(0, -4)
+  // Idempotent: chained runs against an already-processed name don't keep
+  // appending `_processed`.
+  const suffix = stem.endsWith('_processed') ? '' : '_processed'
+  return `${stem}${suffix}.nii.gz`
+}
+
+function safeFilename(name: string): string {
+  // Strip path components and characters niimath / shells dislike. Keep only
+  // alphanumerics, dots, dashes, underscores; replace others with `_`.
+  const base = name.split(/[\\/]/).pop() ?? 'input.nii.gz'
+  return base.replace(/[^A-Za-z0-9._-]/g, '_')
+}
+
+async function runNiimath(
+  binary: string,
+  inputPath: string,
+  args: string[],
+  outputPath: string,
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  return new Promise((resolveP, rejectP) => {
+    // Pin the output extension to .nii.gz regardless of the host's
+    // FSLOUTPUTTYPE — niimath / fslmaths add a default extension to whatever
+    // we pass when this isn't set, and that has bitten enough users to be
+    // worth defending against.
+    const child = spawn(binary, [inputPath, ...args, outputPath], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, FSLOUTPUTTYPE: 'NIFTI_GZ' },
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (d) => {
+      stdout += d.toString()
+    })
+    child.stderr.on('data', (d) => {
+      stderr += d.toString()
+    })
+    child.on('error', rejectP)
+    child.on('exit', (code) => {
+      resolveP({ stdout, stderr, code: code ?? -1 })
+    })
+  })
+}
+
+async function handleProcess(req: Request): Promise<Response> {
+  const binary = niimathBinaryPath()
+  if (!existsSync(binary)) {
+    return json(
+      {
+        error:
+          'niimath binary not found. Run `bun run setup` (or `bunx nx run demo-ext-fullstack:setup`) first.',
+      },
+      { status: 503 },
+    )
+  }
+
+  const rawFilename = req.headers.get('x-niimath-filename')
+  if (!rawFilename) {
+    return json({ error: 'Missing X-Niimath-Filename header' }, { status: 400 })
+  }
+  let inputName: string
+  try {
+    inputName = safeFilename(decodeURIComponent(rawFilename))
+  } catch (err) {
+    return json(
+      { error: `Bad X-Niimath-Filename: ${String(err)}` },
+      { status: 400 },
+    )
+  }
+
+  const argsHeader = req.headers.get('x-niimath-args')
+  if (!argsHeader) {
+    return json(
+      { error: 'Missing X-Niimath-Args header (JSON string array)' },
+      { status: 400 },
+    )
+  }
+  let args: string[]
+  try {
+    const parsed = JSON.parse(argsHeader)
+    if (!Array.isArray(parsed) || !parsed.every((a) => typeof a === 'string')) {
+      return json(
+        { error: 'X-Niimath-Args must be a JSON array of strings' },
+        { status: 400 },
+      )
+    }
+    args = parsed
+  } catch (err) {
+    return json(
+      { error: `Invalid X-Niimath-Args JSON: ${String(err)}` },
+      { status: 400 },
+    )
+  }
+
+  if (args.length === 0) {
+    return json(
+      { error: '`args` must contain at least one operator' },
+      { status: 400 },
+    )
+  }
+  const argError = validateArgs(args)
+  if (argError) return json({ error: argError }, { status: 400 })
+
+  const cl = Number(req.headers.get('content-length') ?? 0)
+  if (cl > MAX_BODY_BYTES) {
+    return json(
+      { error: `Body too large: ${cl} > ${MAX_BODY_BYTES} bytes` },
+      { status: 413 },
+    )
+  }
+
+  let body: ArrayBuffer
+  try {
+    body = await req.arrayBuffer()
+  } catch (err) {
+    return json(
+      { error: `Could not read body: ${String(err)}` },
+      { status: 400 },
+    )
+  }
+  if (body.byteLength === 0) {
+    return json({ error: 'Empty request body' }, { status: 400 })
+  }
+  // Re-check after reading: chunked uploads carry no Content-Length, so the
+  // pre-read header check above lets them through. We still buffered the
+  // body, but at least don't kick off niimath and disk I/O on it.
+  if (body.byteLength > MAX_BODY_BYTES) {
+    return json(
+      { error: `Body too large: ${body.byteLength} > ${MAX_BODY_BYTES} bytes` },
+      { status: 413 },
+    )
+  }
+
+  const id = crypto.randomUUID()
+  const outputName = inferOutputName(inputName)
+  const inputPath = join(WORK_DIR, `${id}_${inputName}`)
+  const outputPath = join(WORK_DIR, `${id}_${outputName}`)
+
+  await Bun.write(inputPath, body)
+
+  const command = `niimath ${inputName} ${args.join(' ')} ${outputName}`
+  const job: Job = {
+    id,
+    status: 'running',
+    inputName,
+    args,
+    command,
+    startedAt: Date.now(),
+  }
+  jobs.set(id, job)
+
+  let result: Awaited<ReturnType<typeof runNiimath>>
+  try {
+    result = await runNiimath(binary, inputPath, args, outputPath)
+  } finally {
+    // Inputs are scratch — outputs need to stick around for /api/result/:id
+    // and the history reload button. Without this every job permanently
+    // doubles its disk footprint.
+    await unlink(inputPath).catch(() => {})
+  }
+  job.finishedAt = Date.now()
+  job.durationMs = job.finishedAt - job.startedAt
+
+  if (result.code !== 0 || !existsSync(outputPath)) {
+    job.status = 'failed'
+    job.error = (
+      result.stderr ||
+      result.stdout ||
+      `niimath exited ${result.code}`
+    ).trim()
+    return json(
+      {
+        id,
+        status: job.status,
+        error: job.error,
+        command,
+        durationMs: job.durationMs,
+      },
+      { status: 500 },
+    )
+  }
+
+  job.status = 'completed'
+  job.outputPath = outputPath
+  return json({
+    id,
+    status: 'completed',
+    resultUrl: `/api/result/${id}`,
+    command,
+    durationMs: job.durationMs,
+    outputName,
+  })
+}
+
+function handleResult(id: string): Response {
+  const job = jobs.get(id)
+  if (!job?.outputPath || !existsSync(job.outputPath)) {
+    return json({ error: 'Result not found' }, { status: 404 })
+  }
+  const file = Bun.file(job.outputPath)
+  return new Response(file, {
+    headers: {
+      'Content-Type': 'application/gzip',
+      'Content-Disposition': `attachment; filename="${inferOutputName(job.inputName)}"`,
+    },
+  })
+}
+
+function handleJobs(): Response {
+  const list = [...jobs.values()]
+    .sort((a, b) => b.startedAt - a.startedAt)
+    .map(({ outputPath: _outputPath, ...rest }) => rest)
+  return json({ jobs: list })
+}
+
+function handleHealth(): Response {
+  return json({
+    ok: true,
+    niimath: niimathManifest(),
+    workDir: WORK_DIR,
+    jobs: jobs.size,
+  })
+}
+
+const server = Bun.serve({
+  hostname: HOST,
+  port: PORT,
+  // Bun.serve defaults idleTimeout to 10 seconds. Heavy niimath operations
+  // (large smoothing kernels, 4D timeseries) can run longer; the upstream
+  // socket goes "idle" while the subprocess works, the server drops the
+  // connection, and the Vite proxy returns 500 with an empty body to the
+  // browser. Bun caps idleTimeout at 255s — pick the maximum.
+  idleTimeout: 240,
+  async fetch(req) {
+    const url = new URL(req.url)
+    const t0 = Date.now()
+    const log = (status: number): void => {
+      console.log(
+        `${req.method} ${url.pathname} -> ${status} (${Date.now() - t0}ms)`,
+      )
+    }
+    try {
+      if (url.pathname === '/api/health') {
+        const res = handleHealth()
+        log(res.status)
+        return res
+      }
+      if (url.pathname === '/api/jobs' && req.method === 'GET') {
+        const res = handleJobs()
+        log(res.status)
+        return res
+      }
+      if (url.pathname === '/api/process' && req.method === 'POST') {
+        const res = await handleProcess(req)
+        log(res.status)
+        return res
+      }
+      const resultMatch = url.pathname.match(
+        /^\/api\/result\/([0-9a-f-]{36})$/i,
+      )
+      if (resultMatch && req.method === 'GET') {
+        const res = handleResult(resultMatch[1])
+        log(res.status)
+        return res
+      }
+      log(404)
+      return json({ error: 'Not found' }, { status: 404 })
+    } catch (err) {
+      const msg = err instanceof Error ? err.stack || err.message : String(err)
+      console.error(`${req.method} ${url.pathname} threw:`, msg)
+      log(500)
+      return json({ error: `Server exception: ${msg}` }, { status: 500 })
+    }
+  },
+  error(err) {
+    console.error('Bun.serve error:', err)
+    return json(
+      {
+        error: `Server error: ${err instanceof Error ? err.message : String(err)}`,
+      },
+      { status: 500 },
+    )
+  },
+})
+
+console.log(
+  `niimath server listening on http://${server.hostname}:${server.port}`,
+)
+console.log(`work dir: ${WORK_DIR}`)
+const manifest = niimathManifest()
+if (manifest) {
+  console.log(`niimath: ${manifest.tag} (installed ${manifest.installedAt})`)
+} else {
+  console.log('niimath: NOT INSTALLED — run `bun run setup` to download.')
+}

--- a/apps/demo-ext-fullstack/server/server.ts
+++ b/apps/demo-ext-fullstack/server/server.ts
@@ -73,11 +73,38 @@ interface Job {
 
 const jobs = new Map<string, Job>()
 
-function json(body: unknown, init: ResponseInit = {}): Response {
+function corsHeaders(req: Request): HeadersInit {
+  const origin = req.headers.get('origin')
+  if (
+    origin === 'http://localhost:8088' ||
+    origin === 'http://127.0.0.1:8088'
+  ) {
+    return {
+      'Access-Control-Allow-Origin': origin,
+      Vary: 'Origin',
+    }
+  }
+  return {}
+}
+
+function withCors(res: Response, req: Request): Response {
+  const headers = new Headers(res.headers)
+  for (const [key, value] of Object.entries(corsHeaders(req))) {
+    headers.set(key, value)
+  }
+  return new Response(res.body, {
+    status: res.status,
+    statusText: res.statusText,
+    headers,
+  })
+}
+
+function json(body: unknown, init: ResponseInit = {}, req?: Request): Response {
   return new Response(JSON.stringify(body), {
     ...init,
     headers: {
       'Content-Type': 'application/json',
+      ...(req ? corsHeaders(req) : {}),
       ...(init.headers ?? {}),
     },
   })
@@ -281,7 +308,7 @@ async function handleProcess(req: Request): Promise<Response> {
   })
 }
 
-function handleResult(id: string): Response {
+function handleResult(id: string, req: Request): Response {
   const job = jobs.get(id)
   if (!job?.outputPath || !existsSync(job.outputPath)) {
     return json({ error: 'Result not found' }, { status: 404 })
@@ -290,25 +317,30 @@ function handleResult(id: string): Response {
   return new Response(file, {
     headers: {
       'Content-Type': 'application/gzip',
+      ...corsHeaders(req),
       'Content-Disposition': `attachment; filename="${inferOutputName(job.inputName)}"`,
     },
   })
 }
 
-function handleJobs(): Response {
+function handleJobs(req: Request): Response {
   const list = [...jobs.values()]
     .sort((a, b) => b.startedAt - a.startedAt)
     .map(({ outputPath: _outputPath, ...rest }) => rest)
-  return json({ jobs: list })
+  return json({ jobs: list }, {}, req)
 }
 
-function handleHealth(): Response {
-  return json({
-    ok: true,
-    niimath: niimathManifest(),
-    workDir: WORK_DIR,
-    jobs: jobs.size,
-  })
+function handleHealth(req: Request): Response {
+  return json(
+    {
+      ok: true,
+      niimath: niimathManifest(),
+      workDir: WORK_DIR,
+      jobs: jobs.size,
+    },
+    {},
+    req,
+  )
 }
 
 const server = Bun.serve({
@@ -329,36 +361,52 @@ const server = Bun.serve({
       )
     }
     try {
-      if (url.pathname === '/api/health') {
-        const res = handleHealth()
+      if (req.method === 'OPTIONS' && url.pathname.startsWith('/api/')) {
+        const res = new Response(null, {
+          status: 204,
+          headers: {
+            ...corsHeaders(req),
+            'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+            'Access-Control-Allow-Headers':
+              'Content-Type,X-Niimath-Filename,X-Niimath-Args',
+          },
+        })
         log(res.status)
         return res
       }
-      if (url.pathname === '/api/jobs' && req.method === 'GET') {
-        const res = handleJobs()
+      if (url.pathname === '/api/health') {
+        const res = handleHealth(req)
         log(res.status)
-        return res
+        return withCors(res, req)
+      }
+      if (url.pathname === '/api/jobs' && req.method === 'GET') {
+        const res = handleJobs(req)
+        log(res.status)
+        return withCors(res, req)
       }
       if (url.pathname === '/api/process' && req.method === 'POST') {
         const res = await handleProcess(req)
         log(res.status)
-        return res
+        return withCors(res, req)
       }
       const resultMatch = url.pathname.match(
         /^\/api\/result\/([0-9a-f-]{36})$/i,
       )
       if (resultMatch && req.method === 'GET') {
-        const res = handleResult(resultMatch[1])
+        const res = handleResult(resultMatch[1], req)
         log(res.status)
-        return res
+        return withCors(res, req)
       }
       log(404)
-      return json({ error: 'Not found' }, { status: 404 })
+      return withCors(json({ error: 'Not found' }, { status: 404 }), req)
     } catch (err) {
       const msg = err instanceof Error ? err.stack || err.message : String(err)
       console.error(`${req.method} ${url.pathname} threw:`, msg)
       log(500)
-      return json({ error: `Server exception: ${msg}` }, { status: 500 })
+      return withCors(
+        json({ error: `Server exception: ${msg}` }, { status: 500 }),
+        req,
+      )
     }
   },
   error(err) {

--- a/apps/demo-ext-fullstack/src/main.ts
+++ b/apps/demo-ext-fullstack/src/main.ts
@@ -1,0 +1,610 @@
+/**
+ * NiiVue + niimath fullstack demo.
+ *
+ * Frontend (Vite, port 8088) talks to a Bun HTTP server (port 8087)
+ * that runs the `niimath` binary as a subprocess. Vite proxies /api/*
+ * to the server so the same origin works in dev.
+ */
+import NiiVueGPU, {
+  MULTIPLANAR_TYPE,
+  SHOW_RENDER,
+  SLICE_TYPE,
+} from '@niivue/niivue'
+import {
+  inferOutputName,
+  NIIMATH_OPERATORS,
+  type NiimathOperator,
+  SAMPLE_VOLUMES,
+} from './operators'
+
+interface PipelineStep {
+  operator: NiimathOperator
+  args: string[]
+}
+
+interface JobSummary {
+  id: string
+  status: 'running' | 'completed' | 'failed'
+  inputName: string
+  args: string[]
+  startedAt: number
+  finishedAt?: number
+  durationMs?: number
+  error?: string
+}
+
+function $<T extends HTMLElement>(id: string): T {
+  const el = document.getElementById(id)
+  if (!el) throw new Error(`Element #${id} not found`)
+  return el as T
+}
+
+const status = $('status')
+const spinner = $('spinner')
+const health = $('health')
+const sampleSelect = $<HTMLSelectElement>('sampleSelect')
+const loadSampleBtn = $<HTMLButtonElement>('loadSampleBtn')
+const fileInput = $<HTMLInputElement>('fileInput')
+const currentImageEl = $('currentImage')
+const saveBtn = $<HTMLButtonElement>('saveBtn')
+const applyBtn = $<HTMLButtonElement>('applyBtn')
+const operatorSelect = $<HTMLSelectElement>('operatorSelect')
+const addOperatorBtn = $<HTMLButtonElement>('addOperatorBtn')
+const pipelineEl = $('pipeline')
+const emptyPipeline = $('emptyPipeline')
+const commandPreview = $('commandPreview')
+const runBtn = $<HTMLButtonElement>('runBtn')
+const historyList = $('historyList')
+const emptyHistory = $('emptyHistory')
+
+const pipeline: PipelineStep[] = []
+// `currentSource` is the user's chosen input — runs always operate on it.
+// `displayedResult` is the most recent successful run's output, shown in the
+// viewer but NOT used as the next input until the user clicks "Apply" — that
+// way reordering pipeline steps re-runs against the same source rather than
+// chaining results.
+let currentSource:
+  | { kind: 'sample'; url: string; name: string }
+  | { kind: 'file'; file: File; name: string }
+  | null = null
+let displayedResult: { url: string; name: string } | null = null
+// Monotonic counter used to discard completions from runs the user has
+// already invalidated by loading another image, applying, or starting a
+// fresh run.
+let latestRunId = 0
+
+const nv = new NiiVueGPU({ isDragDropEnabled: false })
+await nv.attachTo('gl1')
+nv.multiplanarType = MULTIPLANAR_TYPE.GRID
+nv.sliceType = SLICE_TYPE.MULTIPLANAR
+nv.showRender = SHOW_RENDER.ALWAYS
+nv.crosshairGap = 5
+nv.addEventListener('locationChange', (e) => {
+  status.textContent = e.detail.string
+})
+
+// --- Tabs ---
+for (const btn of document.querySelectorAll<HTMLButtonElement>('.tab-btn')) {
+  btn.addEventListener('click', () => {
+    const target = btn.dataset.tab
+    if (!target) return
+    for (const b of document.querySelectorAll('.tab-btn'))
+      b.classList.remove('active')
+    for (const p of document.querySelectorAll('.tab-panel'))
+      p.classList.remove('active')
+    btn.classList.add('active')
+    $(`tab-${target}`).classList.add('active')
+    if (target === 'history') void refreshHistory()
+  })
+}
+
+// --- Populate sample selector ---
+for (const sample of SAMPLE_VOLUMES) {
+  const opt = document.createElement('option')
+  opt.value = sample.name
+  opt.textContent = sample.label
+  sampleSelect.appendChild(opt)
+}
+
+// --- Populate operator selector ---
+for (const op of NIIMATH_OPERATORS) {
+  const opt = document.createElement('option')
+  opt.value = op.name
+  opt.textContent = `${op.name} — ${op.description}`
+  operatorSelect.appendChild(opt)
+}
+operatorSelect.addEventListener('change', () => {
+  addOperatorBtn.disabled = !operatorSelect.value
+})
+
+// --- Click-to-copy: generated command and status bar ---
+attachClickToCopy(commandPreview)
+attachClickToCopy(status)
+
+function attachClickToCopy(el: HTMLElement): void {
+  el.classList.add('copyable')
+  el.addEventListener('click', async () => {
+    const text = el.textContent ?? ''
+    if (!text.trim()) return
+    await navigator.clipboard.writeText(text)
+    el.classList.add('copied')
+    setTimeout(() => el.classList.remove('copied'), 600)
+  })
+}
+
+// --- Sample load ---
+loadSampleBtn.addEventListener('click', async () => {
+  const name = sampleSelect.value
+  if (!name) return
+  await loadSample(name)
+})
+
+// --- File upload ---
+fileInput.addEventListener('change', async () => {
+  const file = fileInput.files?.[0]
+  if (!file) return
+  await loadFile(file)
+  fileInput.value = ''
+})
+
+// --- Add operator ---
+addOperatorBtn.addEventListener('click', () => {
+  const op = NIIMATH_OPERATORS.find((o) => o.name === operatorSelect.value)
+  if (!op) return
+  pipeline.push({
+    operator: op,
+    args: op.args.map((a) => a.default ?? ''),
+  })
+  operatorSelect.value = ''
+  addOperatorBtn.disabled = true
+  renderPipeline()
+})
+
+// --- Run ---
+runBtn.addEventListener('click', async () => {
+  if (!currentSource || pipeline.length === 0) return
+  await runPipeline()
+})
+
+// ---------------------------------------------------------------------------
+// Loading
+// ---------------------------------------------------------------------------
+
+async function loadSample(name: string): Promise<void> {
+  setStatus(`Loading ${name}…`, true)
+  latestRunId++
+  await nv.loadVolumes([{ url: `/volumes/${name}` }])
+  currentSource = { kind: 'sample', url: `/volumes/${name}`, name }
+  displayedResult = null
+  setStatus(`Loaded ${name}`)
+  updateCurrentImageDisplay()
+  updateCommandPreview()
+  updateButtons()
+}
+
+async function loadFile(file: File): Promise<void> {
+  setStatus(`Loading ${file.name}…`, true)
+  latestRunId++
+  await nv.loadVolumes([{ url: file, name: file.name }])
+  currentSource = { kind: 'file', file, name: file.name }
+  displayedResult = null
+  setStatus(`Loaded ${file.name}`)
+  updateCurrentImageDisplay()
+  updateCommandPreview()
+  updateButtons()
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline UI
+// ---------------------------------------------------------------------------
+
+let dragFromIdx: number | null = null
+
+function renderPipeline(): void {
+  pipelineEl.innerHTML = ''
+  emptyPipeline.classList.toggle('hidden', pipeline.length > 0)
+  pipeline.forEach((step, idx) => {
+    const item = document.createElement('div')
+    item.className = 'pipeline-item'
+    item.draggable = true
+    item.addEventListener('dragstart', (e) => {
+      dragFromIdx = idx
+      e.dataTransfer?.setData('text/plain', String(idx))
+      item.classList.add('dragging')
+    })
+    item.addEventListener('dragend', () => {
+      dragFromIdx = null
+      for (const el of pipelineEl.querySelectorAll('.drag-over, .dragging')) {
+        el.classList.remove('drag-over', 'dragging')
+      }
+    })
+    item.addEventListener('dragover', (e) => {
+      e.preventDefault()
+      if (dragFromIdx !== null && dragFromIdx !== idx)
+        item.classList.add('drag-over')
+    })
+    item.addEventListener('dragleave', () => item.classList.remove('drag-over'))
+    item.addEventListener('drop', (e) => {
+      e.preventDefault()
+      if (dragFromIdx === null || dragFromIdx === idx) return
+      const [moved] = pipeline.splice(dragFromIdx, 1)
+      pipeline.splice(idx, 0, moved)
+      renderPipeline()
+    })
+
+    const head = document.createElement('div')
+    head.className = 'head'
+    const left = document.createElement('div')
+    const badge = document.createElement('span')
+    badge.className = 'badge'
+    badge.textContent = step.operator.name
+    left.appendChild(badge)
+    head.appendChild(left)
+
+    const remove = document.createElement('button')
+    remove.className = 'remove'
+    remove.textContent = '×'
+    remove.title = 'Remove operation'
+    remove.addEventListener('click', () => {
+      pipeline.splice(idx, 1)
+      renderPipeline()
+    })
+    head.appendChild(remove)
+
+    item.appendChild(head)
+
+    const desc = document.createElement('div')
+    desc.className = 'desc'
+    desc.textContent = step.operator.description
+    item.appendChild(desc)
+
+    step.operator.args.forEach((argSpec, argIdx) => {
+      const row = document.createElement('div')
+      row.className = 'arg-row'
+      const label = document.createElement('label')
+      label.textContent = argSpec.name
+      label.title = argSpec.description
+      const input = document.createElement('input')
+      input.type = 'text'
+      input.placeholder = argSpec.description
+      input.value = step.args[argIdx] ?? ''
+      input.addEventListener('input', () => {
+        step.args[argIdx] = input.value
+        updateCommandPreview()
+      })
+      row.appendChild(label)
+      row.appendChild(input)
+      item.appendChild(row)
+    })
+
+    pipelineEl.appendChild(item)
+  })
+  updateCommandPreview()
+  updateButtons()
+}
+
+function flattenArgs(): string[] {
+  const out: string[] = []
+  for (const step of pipeline) {
+    out.push(step.operator.name)
+    for (const a of step.args) {
+      const trimmed = a.trim()
+      if (trimmed.length > 0) out.push(trimmed)
+    }
+  }
+  return out
+}
+
+function updateCommandPreview(): void {
+  const input = currentSource?.name ?? 'input.nii.gz'
+  const middle = pipeline.length === 0 ? '' : ` ${flattenArgs().join(' ')}`
+  commandPreview.textContent = `niimath ${input}${middle} ${inferOutputName(input)}`
+}
+
+function updateCurrentImageDisplay(): void {
+  if (!currentSource) {
+    currentImageEl.textContent = 'none'
+    return
+  }
+  currentImageEl.textContent = displayedResult
+    ? `${currentSource.name} → ${displayedResult.name} (preview, not yet applied)`
+    : currentSource.name
+}
+
+function updateButtons(): void {
+  runBtn.disabled = !currentSource || pipeline.length === 0
+  saveBtn.disabled = !currentSource && !displayedResult
+  applyBtn.disabled = !displayedResult
+}
+
+// Save whatever is in the viewer right now: the most recent server result
+// if there is one, otherwise the user's chosen source.
+saveBtn.addEventListener('click', () => {
+  let href: string
+  let download: string
+  let revoke = false
+  if (displayedResult) {
+    href = displayedResult.url
+    download = displayedResult.name
+  } else if (currentSource?.kind === 'sample') {
+    href = currentSource.url
+    download = currentSource.name
+  } else if (currentSource?.kind === 'file') {
+    href = URL.createObjectURL(currentSource.file)
+    download = currentSource.name
+    revoke = true
+  } else {
+    return
+  }
+  const a = document.createElement('a')
+  a.href = href
+  a.download = download
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+  if (revoke) URL.revokeObjectURL(href)
+})
+
+// Promote the most recent result to be the new working input. Lets the user
+// chain pipelines explicitly without auto-chaining on every successful run.
+applyBtn.addEventListener('click', () => {
+  if (!displayedResult) return
+  latestRunId++
+  currentSource = {
+    kind: 'sample',
+    url: displayedResult.url,
+    name: displayedResult.name,
+  }
+  displayedResult = null
+  updateCurrentImageDisplay()
+  updateCommandPreview()
+  updateButtons()
+  setStatus(`Applied: ${currentSource.name} is now the input.`)
+})
+
+// ---------------------------------------------------------------------------
+// Run pipeline (server round-trip)
+// ---------------------------------------------------------------------------
+
+async function runPipeline(): Promise<void> {
+  if (!currentSource) return
+  const args = flattenArgs()
+  if (args.length === 0) return
+
+  setStatus('Uploading + running niimath on server…', true)
+  runBtn.disabled = true
+
+  // Bump on every Run so any earlier in-flight job is invalidated. Each
+  // side-effect that mutates global state below is guarded with
+  // `if (myRun !== latestRunId) return`. The user clicking Run / loading a
+  // new image / applying a result also bumps latestRunId, so a slow job
+  // can't smear over user actions.
+  const myRun = ++latestRunId
+  // Snapshot the source so a mid-flight `currentSource` change doesn't make
+  // us re-fetch a different file or relabel the result with the new name.
+  const source = currentSource
+
+  try {
+    // Bun's req.formData() rejects browser-built multipart bodies on larger
+    // files ("missing final boundary"). We send raw bytes + headers instead.
+    // Pass `file` (a Blob) directly so fetch can stream rather than buffer
+    // the whole ArrayBuffer in JS first.
+    let file: File
+    if (source.kind === 'file') {
+      file = source.file
+    } else {
+      const srcRes = await fetch(source.url)
+      if (!srcRes.ok)
+        throw new Error(`Failed to fetch ${source.url}: ${srcRes.status}`)
+      file = new File([await srcRes.blob()], source.name, {
+        type: 'application/gzip',
+      })
+    }
+    const t0 = performance.now()
+    const res = await fetch('/api/process', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/octet-stream',
+        'X-Niimath-Filename': encodeURIComponent(file.name),
+        'X-Niimath-Args': JSON.stringify(args),
+      },
+      body: file,
+    })
+    const elapsed = ((performance.now() - t0) / 1000).toFixed(2)
+
+    // Read response as text first so a non-JSON body (proxy timeout HTML,
+    // empty 504, etc.) tells us what actually came back instead of throwing
+    // an opaque "Unexpected end of JSON input".
+    const text = await res.text()
+    if (myRun !== latestRunId) return // user moved on; don't smear over them
+    let body: {
+      id?: string
+      status?: string
+      resultUrl?: string
+      error?: string
+      durationMs?: number
+    } | null = null
+    if (text.length > 0) {
+      try {
+        body = JSON.parse(text)
+      } catch {
+        setStatus(
+          `Server returned non-JSON (status ${res.status} after ${elapsed}s): ${text.slice(0, 200)}`,
+        )
+        return
+      }
+    }
+    if (!res.ok || !body?.resultUrl) {
+      const detail =
+        body?.error ?? (text.length === 0 ? '(empty body)' : res.statusText)
+      setStatus(
+        `Server error (status ${res.status} after ${elapsed}s): ${detail}`,
+      )
+      return
+    }
+
+    // Don't pull the result into memory or overwrite currentSource — point
+    // at the server URL so reordering pipeline steps re-runs against the
+    // same input rather than chaining results. The user clicks "Apply" if
+    // they want to chain. (Bonus: avoids a niivue worker-transfer bug where
+    // a re-uploaded Blob can come up byte-short.)
+    const filename = inferOutputName(file.name)
+    // Guard before mutating global state: a stale completion shouldn't
+    // smear `displayedResult` or flash its volume into the viewer after
+    // the user has moved on. Re-check after `loadVolumes` too — the user
+    // may have started another run while it was decoding.
+    if (myRun !== latestRunId) return
+    displayedResult = { url: body.resultUrl, name: filename }
+    await nv.loadVolumes([{ url: body.resultUrl, name: filename }])
+    if (myRun !== latestRunId) return
+    updateCurrentImageDisplay()
+    const serverMs = body.durationMs
+      ? `${(body.durationMs / 1000).toFixed(2)}s server`
+      : ''
+    setStatus(`Done in ${elapsed}s${serverMs ? ` (${serverMs})` : ''}`)
+    void refreshHistory()
+  } catch (err) {
+    if (myRun !== latestRunId) return
+    const msg = err instanceof Error ? err.message : String(err)
+    // "Failed to fetch" is the canonical browser error for "the request never
+    // got a response" — usually the API server isn't running. Probe the
+    // health endpoint to confirm and give the user something actionable.
+    if (msg.toLowerCase().includes('failed to fetch')) {
+      const reachable = await fetch('/api/health')
+        .then((r) => r.ok)
+        .catch(() => false)
+      setStatus(
+        reachable
+          ? `Run failed: ${msg} (server reachable but request was dropped — check the server terminal).`
+          : 'Run failed: niimath server unreachable on :8087. Start it with `bunx nx dev demo-ext-fullstack` (or `bun run server`).',
+      )
+    } else {
+      setStatus(`Run failed: ${msg}`)
+    }
+  } finally {
+    // Only the live run owns the run button; otherwise a stale completion
+    // would re-enable Run while a fresh job is still in flight, letting the
+    // user double-submit.
+    if (myRun === latestRunId) {
+      runBtn.disabled = false
+      updateButtons()
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// History
+// ---------------------------------------------------------------------------
+
+async function refreshHistory(): Promise<void> {
+  try {
+    const res = await fetch('/api/jobs')
+    if (!res.ok) return
+    const { jobs } = (await res.json()) as { jobs: JobSummary[] }
+    historyList.innerHTML = ''
+    emptyHistory.classList.toggle('hidden', jobs.length > 0)
+    for (const job of jobs) renderHistoryItem(job)
+  } catch {
+    /* server not reachable — leave history empty */
+  }
+}
+
+function renderHistoryItem(job: JobSummary): void {
+  const item = document.createElement('div')
+  item.className = 'history-item'
+
+  const top = document.createElement('div')
+  top.className = 'top'
+  const cmd = document.createElement('code')
+  cmd.textContent = job.args.join(' ')
+  top.appendChild(cmd)
+  const statusSpan = document.createElement('span')
+  statusSpan.className = `status-${job.status}`
+  statusSpan.textContent = job.status
+  top.appendChild(statusSpan)
+  item.appendChild(top)
+
+  const meta = document.createElement('div')
+  meta.className = 'meta'
+  const when = new Date(job.startedAt).toLocaleTimeString()
+  const dur = job.durationMs ? `${(job.durationMs / 1000).toFixed(2)}s` : '—'
+  meta.textContent = `${job.inputName} · ${when} · ${dur}`
+  item.appendChild(meta)
+
+  if (job.error) {
+    const err = document.createElement('div')
+    err.className = 'meta status-failed'
+    err.textContent = job.error
+    item.appendChild(err)
+  }
+
+  if (job.status === 'completed') {
+    const reload = document.createElement('button')
+    reload.style.marginTop = '0.4rem'
+    reload.textContent = 'Reload result'
+    reload.addEventListener('click', async () => {
+      setStatus(`Reloading job ${job.id}…`, true)
+      latestRunId++
+      const url = `/api/result/${job.id}`
+      const filename = inferOutputName(job.inputName)
+      try {
+        await nv.loadVolumes([{ url, name: filename }])
+      } catch (err) {
+        setStatus(
+          `Reload failed (result may have been cleared on server restart): ${err instanceof Error ? err.message : String(err)}`,
+        )
+        return
+      }
+      currentSource = { kind: 'sample', url, name: filename }
+      displayedResult = null
+      updateCurrentImageDisplay()
+      updateCommandPreview()
+      updateButtons()
+      setStatus('Reloaded.')
+    })
+    item.appendChild(reload)
+  }
+
+  historyList.appendChild(item)
+}
+
+// ---------------------------------------------------------------------------
+// Health check
+// ---------------------------------------------------------------------------
+
+async function checkHealth(): Promise<void> {
+  try {
+    const res = await fetch('/api/health')
+    const body = (await res.json()) as {
+      ok: boolean
+      niimath: { tag: string } | null
+    }
+    if (body.niimath) {
+      health.textContent = `server ok · niimath ${body.niimath.tag}`
+      health.classList.remove('error')
+      health.classList.add('ok')
+    } else {
+      health.textContent =
+        'server up · niimath NOT installed (run `bun run setup`)'
+      health.classList.add('error')
+    }
+  } catch {
+    health.textContent = 'server unreachable'
+    health.classList.add('error')
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setStatus(text: string, busy = false): void {
+  status.textContent = text
+  spinner.classList.toggle('hidden', !busy)
+}
+
+renderPipeline()
+void checkHealth()
+void refreshHistory()
+sampleSelect.value = SAMPLE_VOLUMES[0].name
+void loadSample(SAMPLE_VOLUMES[0].name)

--- a/apps/demo-ext-fullstack/src/main.ts
+++ b/apps/demo-ext-fullstack/src/main.ts
@@ -125,7 +125,14 @@ function attachClickToCopy(el: HTMLElement): void {
   el.addEventListener('click', async () => {
     const text = el.textContent ?? ''
     if (!text.trim()) return
-    await navigator.clipboard.writeText(text)
+    try {
+      await navigator.clipboard.writeText(text)
+    } catch (err) {
+      // Permission denied, document not focused, etc. Don't show
+      // the "copied" flash — it'd be a lie.
+      console.warn('clipboard write failed:', err)
+      return
+    }
     el.classList.add('copied')
     setTimeout(() => el.classList.remove('copied'), 600)
   })

--- a/apps/demo-ext-fullstack/src/main.ts
+++ b/apps/demo-ext-fullstack/src/main.ts
@@ -2,8 +2,7 @@
  * NiiVue + niimath fullstack demo.
  *
  * Frontend (Vite, port 8088) talks to a Bun HTTP server (port 8087)
- * that runs the `niimath` binary as a subprocess. Vite proxies /api/*
- * to the server so the same origin works in dev.
+ * that runs the `niimath` binary as a subprocess.
  */
 import NiiVueGPU, {
   MULTIPLANAR_TYPE,
@@ -16,6 +15,8 @@ import {
   type NiimathOperator,
   SAMPLE_VOLUMES,
 } from './operators'
+
+const API_ORIGIN = `${location.protocol}//${location.hostname === 'localhost' ? '127.0.0.1' : location.hostname}:8087`
 
 interface PipelineStep {
   operator: NiimathOperator
@@ -396,8 +397,10 @@ async function runPipeline(): Promise<void> {
   try {
     // Bun's req.formData() rejects browser-built multipart bodies on larger
     // files ("missing final boundary"). We send raw bytes + headers instead.
-    // Pass `file` (a Blob) directly so fetch can stream rather than buffer
-    // the whole ArrayBuffer in JS first.
+    // Materialize the Blob before handing it to fetch: Chromium streams Blob
+    // request bodies through Vite's proxy with transfer-encoding: chunked,
+    // which can leave Bun's req.arrayBuffer() waiting indefinitely. An
+    // ArrayBuffer body gets a fixed Content-Length and completes reliably.
     let file: File
     if (source.kind === 'file') {
       file = source.file
@@ -410,14 +413,14 @@ async function runPipeline(): Promise<void> {
       })
     }
     const t0 = performance.now()
-    const res = await fetch('/api/process', {
+    const res = await fetch(`${API_ORIGIN}/api/process`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/octet-stream',
         'X-Niimath-Filename': encodeURIComponent(file.name),
         'X-Niimath-Args': JSON.stringify(args),
       },
-      body: file,
+      body: await file.arrayBuffer(),
     })
     const elapsed = ((performance.now() - t0) / 1000).toFixed(2)
 
@@ -463,8 +466,9 @@ async function runPipeline(): Promise<void> {
     // the user has moved on. Re-check after `loadVolumes` too — the user
     // may have started another run while it was decoding.
     if (myRun !== latestRunId) return
-    displayedResult = { url: body.resultUrl, name: filename }
-    await nv.loadVolumes([{ url: body.resultUrl, name: filename }])
+    const resultUrl = new URL(body.resultUrl, API_ORIGIN).href
+    displayedResult = { url: resultUrl, name: filename }
+    await nv.loadVolumes([{ url: resultUrl, name: filename }])
     if (myRun !== latestRunId) return
     updateCurrentImageDisplay()
     const serverMs = body.durationMs
@@ -479,7 +483,7 @@ async function runPipeline(): Promise<void> {
     // got a response" — usually the API server isn't running. Probe the
     // health endpoint to confirm and give the user something actionable.
     if (msg.toLowerCase().includes('failed to fetch')) {
-      const reachable = await fetch('/api/health')
+      const reachable = await fetch(`${API_ORIGIN}/api/health`)
         .then((r) => r.ok)
         .catch(() => false)
       setStatus(
@@ -507,7 +511,7 @@ async function runPipeline(): Promise<void> {
 
 async function refreshHistory(): Promise<void> {
   try {
-    const res = await fetch('/api/jobs')
+    const res = await fetch(`${API_ORIGIN}/api/jobs`)
     if (!res.ok) return
     const { jobs } = (await res.json()) as { jobs: JobSummary[] }
     historyList.innerHTML = ''
@@ -583,7 +587,7 @@ function renderHistoryItem(job: JobSummary): void {
 
 async function checkHealth(): Promise<void> {
   try {
-    const res = await fetch('/api/health')
+    const res = await fetch(`${API_ORIGIN}/api/health`)
     const body = (await res.json()) as {
       ok: boolean
       niimath: { tag: string } | null

--- a/apps/demo-ext-fullstack/src/operators.ts
+++ b/apps/demo-ext-fullstack/src/operators.ts
@@ -1,0 +1,96 @@
+/**
+ * Curated set of niimath operators exposed in the demo's "Add Operation"
+ * picker. Mirrors the list from the source fullstack-niivue-demo
+ * (frontend/src/components/niimath-config.tsx).
+ */
+export interface NiimathOperator {
+  name: string
+  description: string
+  args: { name: string; description: string; default?: string }[]
+}
+
+export const NIIMATH_OPERATORS: NiimathOperator[] = [
+  { name: '-ceil', description: 'Round up to nearest integer', args: [] },
+  { name: '-floor', description: 'Round down to nearest integer', args: [] },
+  { name: '-round', description: 'Round to nearest integer', args: [] },
+  { name: '-abs', description: 'Absolute value', args: [] },
+  {
+    name: '-bandpass',
+    description: 'Temporal bandpass filter',
+    args: [
+      { name: 'hp', description: 'High-pass cutoff (Hz)', default: '0.01' },
+      { name: 'lp', description: 'Low-pass cutoff (Hz)', default: '0.1' },
+      { name: 'tr', description: 'TR (seconds)', default: '2.0' },
+    ],
+  },
+  {
+    name: '-s',
+    description: 'Gaussian smoothing (sigma mm)',
+    args: [{ name: 'sigma', description: 'Sigma in mm', default: '3.0' }],
+  },
+  {
+    name: '-add',
+    description: 'Add constant value',
+    args: [{ name: 'value', description: 'Value to add', default: '100' }],
+  },
+  {
+    name: '-sub',
+    description: 'Subtract constant value',
+    args: [{ name: 'value', description: 'Value to subtract', default: '50' }],
+  },
+  {
+    name: '-mul',
+    description: 'Multiply by constant value',
+    args: [{ name: 'value', description: 'Multiplier', default: '2.0' }],
+  },
+  {
+    name: '-div',
+    description: 'Divide by constant value',
+    args: [{ name: 'value', description: 'Divisor', default: '1000' }],
+  },
+  {
+    name: '-thr',
+    description: 'Threshold (zero values below)',
+    args: [{ name: 'threshold', description: 'Threshold', default: '0.5' }],
+  },
+  {
+    name: '-uthr',
+    description: 'Upper threshold (zero values above)',
+    args: [
+      { name: 'threshold', description: 'Upper threshold', default: '1000' },
+    ],
+  },
+  {
+    name: '-bin',
+    description: 'Binarize (set non-zero values to 1)',
+    args: [],
+  },
+]
+
+/**
+ * Append `_processed` before the NIfTI extension. Mirrors the server logic so
+ * the displayed command matches what actually runs.
+ *
+ * niimath / fslmaths default to writing `.nii.gz` regardless of the requested
+ * extension unless `FSLOUTPUTTYPE` is set. The server pins
+ * `FSLOUTPUTTYPE=NIFTI_GZ` and asks for a `.nii.gz` output explicitly.
+ */
+export function inferOutputName(inputName: string): string {
+  const lower = inputName.toLowerCase()
+  let stem = inputName
+  if (lower.endsWith('.nii.gz')) stem = inputName.slice(0, -7)
+  else if (lower.endsWith('.nii')) stem = inputName.slice(0, -4)
+  // Idempotent: chained runs against an already-processed name don't keep
+  // appending `_processed`.
+  const suffix = stem.endsWith('_processed') ? '' : '_processed'
+  return `${stem}${suffix}.nii.gz`
+}
+
+/** Sample volumes shipped via @niivue/dev-images. Served at /volumes/<name>.nii.gz. */
+export const SAMPLE_VOLUMES = [
+  { name: 'mni152.nii.gz', label: 'MNI152 (T1 brain)' },
+  { name: 'FA.nii.gz', label: 'FA (fractional anisotropy)' },
+  { name: 'spmMotor.nii.gz', label: 'spmMotor (statistical map)' },
+  { name: 'visiblehuman.nii.gz', label: 'Visible Human (CT)' },
+  { name: 'torso.nii.gz', label: 'Torso (CT)' },
+] as const

--- a/apps/demo-ext-fullstack/src/style.css
+++ b/apps/demo-ext-fullstack/src/style.css
@@ -1,0 +1,454 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  grid-template-columns: 1fr 320px;
+  grid-template-areas:
+    "header header"
+    "main   sidebar"
+    "footer footer";
+  font-family:
+    system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #e8e8ea;
+  background: #1c1c1f;
+  user-select: none;
+}
+
+header {
+  grid-area: header;
+  background: #232327;
+  border-bottom: 1px solid #2f2f33;
+  padding: 0.75rem 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+header h1 {
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+header .health {
+  font-size: 0.75rem;
+  color: #9aa0a6;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+}
+
+header .health.ok {
+  color: #82d181;
+}
+
+header .health.error {
+  color: #ef6b6b;
+}
+
+main {
+  grid-area: main;
+  background: #000;
+  position: relative;
+  min-height: 0;
+  min-width: 0;
+}
+
+main canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+  cursor: crosshair;
+}
+
+main canvas:focus {
+  outline: 0;
+}
+
+aside {
+  grid-area: sidebar;
+  background: #1f1f23;
+  border-left: 1px solid #2f2f33;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.tabs {
+  display: flex;
+  border-bottom: 1px solid #2f2f33;
+}
+
+.tab-btn {
+  flex: 1;
+  background: transparent;
+  border: 0;
+  color: #9aa0a6;
+  padding: 0.65rem 0.5rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+}
+
+.tab-btn:hover {
+  color: #e8e8ea;
+}
+
+.tab-btn.active {
+  color: #e8e8ea;
+  border-bottom-color: #6c8cff;
+}
+
+.tab-panel {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.85rem;
+  display: none;
+}
+
+.tab-panel.active {
+  display: block;
+}
+
+.section {
+  margin-bottom: 1rem;
+}
+
+.section h2 {
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #9aa0a6;
+  margin-bottom: 0.4rem;
+}
+
+.section p {
+  font-size: 0.8rem;
+  color: #9aa0a6;
+  margin-bottom: 0.5rem;
+  line-height: 1.4;
+}
+
+.card {
+  background: #26262b;
+  border: 1px solid #2f2f33;
+  border-radius: 6px;
+  padding: 0.75rem;
+  margin-bottom: 0.65rem;
+}
+
+.card h3 {
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.card .desc {
+  font-size: 0.75rem;
+  color: #9aa0a6;
+  margin-bottom: 0.5rem;
+}
+
+button,
+select,
+input[type="text"],
+input[type="number"] {
+  font-family: inherit;
+  font-size: 0.85rem;
+  background: #2c2c31;
+  color: #e8e8ea;
+  border: 1px solid #3a3a3f;
+  border-radius: 4px;
+  padding: 0.4rem 0.6rem;
+}
+
+button {
+  cursor: pointer;
+}
+
+button:hover:not(:disabled) {
+  background: #34343a;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+button.primary {
+  background: #4a6dff;
+  border-color: #5b7bff;
+  color: #fff;
+  font-weight: 500;
+}
+
+button.primary:hover:not(:disabled) {
+  background: #5b7bff;
+}
+
+.row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.row > * {
+  min-width: 0;
+}
+
+.row > .grow {
+  flex: 1;
+}
+
+label.field {
+  display: block;
+  font-size: 0.75rem;
+  color: #9aa0a6;
+  margin-bottom: 0.2rem;
+}
+
+.pipeline-item {
+  background: #1c1c1f;
+  border: 1px solid #2f2f33;
+  border-radius: 4px;
+  padding: 0.5rem;
+  margin-bottom: 0.4rem;
+  cursor: grab;
+}
+
+.pipeline-item.dragging {
+  opacity: 0.4;
+  cursor: grabbing;
+}
+
+.pipeline-item.drag-over {
+  border-color: #6c8cff;
+  border-style: dashed;
+}
+
+.pipeline-item .head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.pipeline-item .badge {
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 0.75rem;
+  background: #2c2c31;
+  border: 1px solid #3a3a3f;
+  border-radius: 3px;
+  padding: 0.1rem 0.4rem;
+}
+
+.pipeline-item .desc {
+  font-size: 0.7rem;
+  color: #9aa0a6;
+  margin: 0.25rem 0 0.4rem;
+}
+
+.pipeline-item .arg-row {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: 0.4rem;
+  align-items: center;
+  margin-top: 0.25rem;
+}
+
+.pipeline-item .arg-row label {
+  font-size: 0.72rem;
+  color: #9aa0a6;
+}
+
+.pipeline-item .arg-row input {
+  width: 100%;
+  font-size: 0.8rem;
+  padding: 0.25rem 0.4rem;
+}
+
+.pipeline-item .remove {
+  background: transparent;
+  border: 0;
+  color: #9aa0a6;
+  font-size: 0.95rem;
+  padding: 0.1rem 0.4rem;
+  cursor: pointer;
+}
+
+.pipeline-item .remove:hover {
+  color: #ef6b6b;
+}
+
+code,
+pre {
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 0.75rem;
+}
+
+pre.command {
+  background: #1c1c1f;
+  border: 1px solid #2f2f33;
+  border-radius: 4px;
+  padding: 0.55rem 0.65rem;
+  word-break: break-all;
+  white-space: pre-wrap;
+  color: #c8d3e1;
+  cursor: copy;
+  position: relative;
+  transition:
+    border-color 0.15s,
+    background 0.15s;
+}
+
+pre.command:hover {
+  border-color: #4a6dff;
+}
+
+pre.command:hover::after {
+  content: "click to copy";
+  position: absolute;
+  top: 4px;
+  right: 6px;
+  font-size: 0.6rem;
+  color: #6c8cff;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+pre.command.copied {
+  border-color: #82d181;
+  background: #1c2a20;
+}
+
+pre.command.copied::after {
+  content: "copied";
+  position: absolute;
+  top: 4px;
+  right: 6px;
+  font-size: 0.6rem;
+  color: #82d181;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.history-item {
+  background: #1c1c1f;
+  border: 1px solid #2f2f33;
+  border-radius: 5px;
+  padding: 0.55rem 0.65rem;
+  margin-bottom: 0.45rem;
+  font-size: 0.78rem;
+}
+
+.history-item .top {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0.2rem;
+}
+
+.history-item .meta {
+  color: #9aa0a6;
+  font-size: 0.7rem;
+}
+
+.history-item .status-completed {
+  color: #82d181;
+}
+
+.history-item .status-failed {
+  color: #ef6b6b;
+}
+
+.history-item .status-running {
+  color: #f0c674;
+}
+
+footer {
+  grid-area: footer;
+  background: #232327;
+  border-top: 1px solid #2f2f33;
+  padding: 0.45rem 1rem;
+  font-size: 0.78rem;
+  color: #9aa0a6;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  min-height: 1.7rem;
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+footer #status {
+  flex: 1;
+  border-radius: 3px;
+  padding: 0.05rem 0.3rem;
+  margin: -0.05rem -0.3rem;
+  transition:
+    background 0.15s,
+    color 0.15s;
+}
+
+footer #status.copyable {
+  cursor: copy;
+}
+
+footer #status.copyable:hover {
+  background: #2c2c31;
+  color: #e8e8ea;
+}
+
+footer #status.copied {
+  background: #1c2a20;
+  color: #82d181;
+}
+
+footer .spinner {
+  width: 12px;
+  height: 12px;
+  border: 2px solid rgba(255, 255, 255, 0.15);
+  border-top-color: #6c8cff;
+  border-radius: 50%;
+  animation: spin 0.85s linear infinite;
+  display: inline-block;
+}
+
+footer .spinner.hidden {
+  display: none;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+[hidden],
+.hidden {
+  display: none;
+}
+
+input[type="file"] {
+  display: none;
+}
+
+.file-label {
+  display: inline-block;
+  background: #2c2c31;
+  border: 1px solid #3a3a3f;
+  border-radius: 4px;
+  padding: 0.4rem 0.6rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.file-label:hover {
+  background: #34343a;
+}

--- a/apps/demo-ext-fullstack/tsconfig.json
+++ b/apps/demo-ext-fullstack/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "types": ["vite/client", "bun"]
+  },
+  "include": ["src", "server"],
+  "exclude": ["dist", "node_modules", "server/bin"]
+}

--- a/apps/demo-ext-fullstack/vite.config.js
+++ b/apps/demo-ext-fullstack/vite.config.js
@@ -1,0 +1,45 @@
+import { devImagesPlugin } from '@niivue/dev-images/vite-plugin'
+import { defineConfig } from 'vite'
+
+const SERVER_PORT = Number(process.env.FULLSTACK_SERVER_PORT ?? 8087)
+const SERVER_HOST = process.env.FULLSTACK_SERVER_HOST ?? '127.0.0.1'
+
+export default defineConfig({
+  base: '/',
+  plugins: [devImagesPlugin()],
+  server: {
+    port: 8088,
+    proxy: {
+      '/api': {
+        target: `http://${SERVER_HOST}:${SERVER_PORT}`,
+        changeOrigin: false,
+        // No upstream timeout — niimath can take a while on big volumes /
+        // heavy operators, and the Bun server has its own idleTimeout cap.
+        timeout: 0,
+        proxyTimeout: 0,
+        configure(proxy) {
+          proxy.on('error', (err, _req, res) => {
+            console.error('[vite proxy] /api error:', err.message)
+            // Surface the error to the browser as JSON instead of letting
+            // http-proxy send an empty 500.
+            if (res && 'writeHead' in res && !res.headersSent) {
+              res.writeHead(502, { 'Content-Type': 'application/json' })
+              res.end(
+                JSON.stringify({
+                  error: `Proxy could not reach niimath server: ${err.message}`,
+                }),
+              )
+            }
+          })
+        },
+      },
+    },
+  },
+  build: {
+    outDir: 'dist',
+    target: 'esnext',
+    rollupOptions: {
+      input: 'index.html',
+    },
+  },
+})

--- a/apps/demo-ext-niimath/README.md
+++ b/apps/demo-ext-niimath/README.md
@@ -1,0 +1,29 @@
+# demo-ext-niimath
+
+Demo app for [`@niivue/nv-ext-niimath`](../../packages/nv-ext-niimath) — build a niimath pipeline (`-s 3 -thr 0.5 -bin`, etc.), drag-reorder the steps, and run it entirely in the browser via the niimath WASM build. No backend, no data leaves the page.
+
+Same UI shell as [`demo-ext-fullstack`](../demo-ext-fullstack), but with the server replaced by an in-browser Web Worker — handy if you want to compare the two transports side by side.
+
+## Getting Started
+
+```bash
+bun install                       # From monorepo root
+bunx nx dev demo-ext-niimath      # Start dev server (port 8089)
+```
+
+The dev server proxies the shared `@niivue/dev-images` sample volumes (mni152, FA, spmMotor, etc.), so you can pick a built-in volume from the Image tab without any setup. You can also upload your own NIfTI from disk via the file picker on the same tab.
+
+## Build
+
+```bash
+bunx nx build demo-ext-niimath
+```
+
+## What's wired up
+
+- **Image tab** — pick a built-in sample volume (loads on selection) or upload your own NIfTI. Save the currently-displayed volume to disk.
+- **Processing tab** — pick niimath operators from the catalog, drag-reorder the resulting pipeline cards, edit numeric arguments inline. The generated `niimath` command is shown live above the Run button (click to copy).
+- **History tab** — recent runs (capped at 20) with their args, duration, and a Reload-result button.
+- **Apply result as input** — by default each Run shows the result as a *preview* without overwriting the working source, so reordering steps re-runs against the same input. Click Apply when you want to chain.
+
+## Part of the [NiiVue](https://github.com/niivue) ecosystem

--- a/apps/demo-ext-niimath/index.html
+++ b/apps/demo-ext-niimath/index.html
@@ -3,14 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>NiiVue — niimath fullstack demo</title>
+    <title>NiiVue — niimath WASM demo</title>
     <link rel="icon" href="data:," />
     <link rel="stylesheet" href="src/style.css" />
   </head>
   <body>
     <header>
-      <h1>NiiVue · niimath fullstack demo</h1>
-      <span id="health" class="health">checking server…</span>
+      <h1>NiiVue · niimath WASM demo</h1>
+      <span id="health" class="health">loading WASM…</span>
     </header>
 
     <main>
@@ -62,7 +62,7 @@
 
         <div class="card" id="pipelineCard">
           <h3>Processing Pipeline</h3>
-          <p class="desc">Operations applied in order, server-side via niimath.</p>
+          <p class="desc">Operations applied in order via the niimath WASM worker.</p>
           <div id="pipeline"></div>
           <p id="emptyPipeline" class="desc">No operations yet.</p>
         </div>
@@ -74,14 +74,14 @@
         </div>
 
         <button type="button" id="runBtn" class="primary" style="width: 100%" disabled>
-          Run on server
+          Run pipeline
         </button>
       </div>
 
       <div id="tab-history" class="tab-panel">
         <div class="section">
           <h2>Processing history</h2>
-          <p>Recent jobs from this server (in-memory; cleared on restart).</p>
+          <p>Recent runs (in-memory; cleared on page reload).</p>
           <div id="historyList"></div>
           <p id="emptyHistory" class="desc">No jobs yet.</p>
         </div>

--- a/apps/demo-ext-niimath/package.json
+++ b/apps/demo-ext-niimath/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "demo-ext-niimath",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "bunx --bun vite --open /index.html",
+    "build": "bunx --bun vite build"
+  },
+  "dependencies": {
+    "@niivue/dev-images": "workspace:*",
+    "@niivue/niivue": "workspace:*",
+    "@niivue/nv-ext-niimath": "workspace:*"
+  },
+  "devDependencies": {
+    "vite": "^6.3.2"
+  }
+}

--- a/apps/demo-ext-niimath/project.json
+++ b/apps/demo-ext-niimath/project.json
@@ -1,0 +1,39 @@
+{
+  "name": "demo-ext-niimath",
+  "projectType": "application",
+  "tags": ["type:app", "lang:typescript"],
+  "targets": {
+    "dev": {
+      "command": "bunx --bun vite --open /index.html",
+      "options": { "cwd": "{projectRoot}" }
+    },
+    "build": {
+      "command": "bunx --bun vite build",
+      "options": { "cwd": "{projectRoot}" },
+      "dependsOn": ["^build"],
+      "inputs": [
+        "typescript",
+        "{projectRoot}/vite.config.js",
+        "{projectRoot}/src/**/*",
+        "{projectRoot}/*.html",
+        { "env": "VITE_BASE" },
+        { "env": "VITE_IMAGES_BASE" }
+      ],
+      "outputs": ["{projectRoot}/dist"]
+    },
+    "typecheck": {
+      "command": "bunx tsc --noEmit",
+      "options": { "cwd": "{projectRoot}" },
+      "dependsOn": ["^build"],
+      "inputs": ["typescript"]
+    },
+    "lint": {
+      "command": "bunx biome check {projectRoot}",
+      "inputs": ["typescript"]
+    },
+    "format": {
+      "command": "bunx biome format {projectRoot} --write",
+      "inputs": ["typescript"]
+    }
+  }
+}

--- a/apps/demo-ext-niimath/project.json
+++ b/apps/demo-ext-niimath/project.json
@@ -5,7 +5,8 @@
   "targets": {
     "dev": {
       "command": "bunx --bun vite --open /index.html",
-      "options": { "cwd": "{projectRoot}" }
+      "options": { "cwd": "{projectRoot}" },
+      "dependsOn": ["^build"]
     },
     "build": {
       "command": "bunx --bun vite build",

--- a/apps/demo-ext-niimath/src/main.ts
+++ b/apps/demo-ext-niimath/src/main.ts
@@ -89,6 +89,10 @@ let latestRunId = 0
 
 const niimath = new Niimath()
 const niimathReady = niimath.init()
+// Tracks whether the worker actually came up. The current upstream
+// rejects on failure, but defending against a future `resolve(false)`
+// is one boolean.
+let niimathOk = false
 
 const nv = new NiiVueGPU({ isDragDropEnabled: false })
 await nv.attachTo('gl1')
@@ -102,6 +106,7 @@ nv.addEventListener('locationChange', (e) => {
 
 niimathReady
   .then((ok) => {
+    niimathOk = ok
     if (ok) {
       health.textContent = 'niimath WASM ready'
       health.classList.add('ok')
@@ -109,6 +114,7 @@ niimathReady
       health.textContent = 'niimath WASM failed to initialize'
       health.classList.add('error')
     }
+    updateButtons() // reflect ok-state on the Run button
   })
   .catch((err: unknown) => {
     const msg = err instanceof Error ? err.message : String(err)
@@ -159,7 +165,14 @@ function attachClickToCopy(el: HTMLElement): void {
   el.addEventListener('click', async () => {
     const text = el.textContent ?? ''
     if (!text.trim()) return
-    await navigator.clipboard.writeText(text)
+    try {
+      await navigator.clipboard.writeText(text)
+    } catch (err) {
+      // Permission denied, document not focused, etc. Don't show
+      // the "copied" flash — it'd be a lie.
+      console.warn('clipboard write failed:', err)
+      return
+    }
     el.classList.add('copied')
     setTimeout(() => el.classList.remove('copied'), 600)
   })
@@ -348,7 +361,7 @@ function updateCurrentImageDisplay(): void {
 }
 
 function updateButtons(): void {
-  runBtn.disabled = !currentSource || pipeline.length === 0
+  runBtn.disabled = !currentSource || pipeline.length === 0 || !niimathOk
   saveBtn.disabled = !currentSource && !displayedResult
   applyBtn.disabled = !displayedResult
 }
@@ -418,6 +431,9 @@ async function runPipeline(): Promise<void> {
 
   try {
     await niimathReady
+    if (!niimathOk) {
+      throw new Error('niimath WASM failed to initialize — reload the page')
+    }
     const file = await sourceAsFile(source)
     const t0 = performance.now()
     const blob = await runNiimathPipeline(niimath, file, steps)

--- a/apps/demo-ext-niimath/src/main.ts
+++ b/apps/demo-ext-niimath/src/main.ts
@@ -1,15 +1,21 @@
 /**
- * NiiVue + niimath fullstack demo.
+ * NiiVue + niimath WASM demo.
  *
- * Frontend (Vite, port 8088) talks to a Bun HTTP server (port 8087)
- * that runs the `niimath` binary as a subprocess. Vite proxies /api/*
- * to the server so the same origin works in dev.
+ * Same UI as demo-ext-fullstack, but niimath runs in a Web Worker via the
+ * @niivue/niimath package — no backend, no HTTP, no auth, deployable as a
+ * static site to GitHub Pages.
  */
+
 import NiiVueGPU, {
   MULTIPLANAR_TYPE,
   SHOW_RENDER,
   SLICE_TYPE,
 } from '@niivue/niivue'
+import {
+  Niimath,
+  type NiimathStep,
+  runNiimathPipeline,
+} from '@niivue/nv-ext-niimath'
 import {
   inferOutputName,
   NIIMATH_OPERATORS,
@@ -22,16 +28,24 @@ interface PipelineStep {
   args: string[]
 }
 
-interface JobSummary {
+interface HistoryEntry {
   id: string
-  status: 'running' | 'completed' | 'failed'
-  inputName: string
   args: string[]
+  inputName: string
+  outputName: string
   startedAt: number
-  finishedAt?: number
-  durationMs?: number
+  durationMs: number
+  status: 'completed' | 'failed'
+  blob?: Blob
   error?: string
 }
+
+// Cap in-memory history. Each entry retains a result Blob, so user uploads
+// of hundreds of MB can blow through browser memory if we only count
+// entries. Apply both a count cap and a total-bytes cap; evict oldest
+// until both are satisfied.
+const HISTORY_CAP = 20
+const HISTORY_BYTE_CAP = 256 * 1024 * 1024 // 256 MB
 
 function $<T extends HTMLElement>(id: string): T {
   const el = document.getElementById(id)
@@ -58,19 +72,23 @@ const emptyHistory = $('emptyHistory')
 
 const pipeline: PipelineStep[] = []
 // `currentSource` is the user's chosen input — runs always operate on it.
-// `displayedResult` is the most recent successful run's output, shown in the
-// viewer but NOT used as the next input until the user clicks "Apply" — that
-// way reordering pipeline steps re-runs against the same source rather than
-// chaining results.
+// `displayedResult` is the most recent successful run's output, shown in
+// the viewer but NOT used as the next input until the user clicks Apply
+// — that way reordering pipeline steps re-runs against the same source
+// rather than chaining results.
 let currentSource:
   | { kind: 'sample'; url: string; name: string }
   | { kind: 'file'; file: File; name: string }
   | null = null
-let displayedResult: { url: string; name: string } | null = null
+let displayedResult: { blob: Blob; name: string } | null = null
+const history: HistoryEntry[] = []
 // Monotonic counter used to discard completions from runs the user has
 // already invalidated by loading another image, applying, or starting a
 // fresh run.
 let latestRunId = 0
+
+const niimath = new Niimath()
+const niimathReady = niimath.init()
 
 const nv = new NiiVueGPU({ isDragDropEnabled: false })
 await nv.attachTo('gl1')
@@ -81,6 +99,22 @@ nv.crosshairGap = 5
 nv.addEventListener('locationChange', (e) => {
   status.textContent = e.detail.string
 })
+
+niimathReady
+  .then((ok) => {
+    if (ok) {
+      health.textContent = 'niimath WASM ready'
+      health.classList.add('ok')
+    } else {
+      health.textContent = 'niimath WASM failed to initialize'
+      health.classList.add('error')
+    }
+  })
+  .catch((err: unknown) => {
+    const msg = err instanceof Error ? err.message : String(err)
+    health.textContent = `niimath WASM error: ${msg}`
+    health.classList.add('error')
+  })
 
 // --- Tabs ---
 for (const btn of document.querySelectorAll<HTMLButtonElement>('.tab-btn')) {
@@ -93,7 +127,7 @@ for (const btn of document.querySelectorAll<HTMLButtonElement>('.tab-btn')) {
       p.classList.remove('active')
     btn.classList.add('active')
     $(`tab-${target}`).classList.add('active')
-    if (target === 'history') void refreshHistory()
+    if (target === 'history') renderHistory()
   })
 }
 
@@ -326,8 +360,9 @@ saveBtn.addEventListener('click', () => {
   let download: string
   let revoke = false
   if (displayedResult) {
-    href = displayedResult.url
+    href = URL.createObjectURL(displayedResult.blob)
     download = displayedResult.name
+    revoke = true
   } else if (currentSource?.kind === 'sample') {
     href = currentSource.url
     download = currentSource.name
@@ -347,16 +382,14 @@ saveBtn.addEventListener('click', () => {
   if (revoke) URL.revokeObjectURL(href)
 })
 
-// Promote the most recent result to be the new working input. Lets the user
-// chain pipelines explicitly without auto-chaining on every successful run.
+// Promote the most recent result to be the new working input.
 applyBtn.addEventListener('click', () => {
   if (!displayedResult) return
   latestRunId++
-  currentSource = {
-    kind: 'sample',
-    url: displayedResult.url,
-    name: displayedResult.name,
-  }
+  const file = new File([displayedResult.blob], displayedResult.name, {
+    type: 'application/gzip',
+  })
+  currentSource = { kind: 'file', file, name: displayedResult.name }
   displayedResult = null
   updateCurrentImageDisplay()
   updateCommandPreview()
@@ -365,128 +398,64 @@ applyBtn.addEventListener('click', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Run pipeline (server round-trip)
+// Run pipeline (WASM in-browser)
 // ---------------------------------------------------------------------------
 
 async function runPipeline(): Promise<void> {
-  if (!currentSource) return
-  const args = flattenArgs()
-  if (args.length === 0) return
+  if (!currentSource || pipeline.length === 0) return
 
-  setStatus('Uploading + running niimath on server…', true)
+  setStatus('Running niimath WASM…', true)
   runBtn.disabled = true
-
-  // Bump on every Run so any earlier in-flight job is invalidated. Each
-  // side-effect that mutates global state below is guarded with
-  // `if (myRun !== latestRunId) return`. The user clicking Run / loading a
-  // new image / applying a result also bumps latestRunId, so a slow job
-  // can't smear over user actions.
   const myRun = ++latestRunId
-  // Snapshot the source so a mid-flight `currentSource` change doesn't make
-  // us re-fetch a different file or relabel the result with the new name.
   const source = currentSource
+  const steps: NiimathStep[] = pipeline.map((s) => ({
+    method: s.operator.name.slice(1), // drop leading '-'
+    args: s.args.map((a) => a.trim()).filter((a) => a.length > 0),
+  }))
+  // Reconstruct the dash-prefixed flat form for history display. Coerce
+  // numeric args back to strings — NiimathStep allows numbers.
+  const args = steps.flatMap((s) => [`-${s.method}`, ...s.args.map(String)])
 
   try {
-    // Bun's req.formData() rejects browser-built multipart bodies on larger
-    // files ("missing final boundary"). We send raw bytes + headers instead.
-    // Pass `file` (a Blob) directly so fetch can stream rather than buffer
-    // the whole ArrayBuffer in JS first.
-    let file: File
-    if (source.kind === 'file') {
-      file = source.file
-    } else {
-      const srcRes = await fetch(source.url)
-      if (!srcRes.ok)
-        throw new Error(`Failed to fetch ${source.url}: ${srcRes.status}`)
-      file = new File([await srcRes.blob()], source.name, {
-        type: 'application/gzip',
-      })
-    }
+    await niimathReady
+    const file = await sourceAsFile(source)
     const t0 = performance.now()
-    const res = await fetch('/api/process', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/octet-stream',
-        'X-Niimath-Filename': encodeURIComponent(file.name),
-        'X-Niimath-Args': JSON.stringify(args),
-      },
-      body: file,
-    })
+    const blob = await runNiimathPipeline(niimath, file, steps)
     const elapsed = ((performance.now() - t0) / 1000).toFixed(2)
-
-    // Read response as text first so a non-JSON body (proxy timeout HTML,
-    // empty 504, etc.) tells us what actually came back instead of throwing
-    // an opaque "Unexpected end of JSON input".
-    const text = await res.text()
-    if (myRun !== latestRunId) return // user moved on; don't smear over them
-    let body: {
-      id?: string
-      status?: string
-      resultUrl?: string
-      error?: string
-      durationMs?: number
-    } | null = null
-    if (text.length > 0) {
-      try {
-        body = JSON.parse(text)
-      } catch {
-        setStatus(
-          `Server returned non-JSON (status ${res.status} after ${elapsed}s): ${text.slice(0, 200)}`,
-        )
-        return
-      }
-    }
-    if (!res.ok || !body?.resultUrl) {
-      const detail =
-        body?.error ?? (text.length === 0 ? '(empty body)' : res.statusText)
-      setStatus(
-        `Server error (status ${res.status} after ${elapsed}s): ${detail}`,
-      )
-      return
-    }
-
-    // Don't pull the result into memory or overwrite currentSource — point
-    // at the server URL so reordering pipeline steps re-runs against the
-    // same input rather than chaining results. The user clicks "Apply" if
-    // they want to chain. (Bonus: avoids a niivue worker-transfer bug where
-    // a re-uploaded Blob can come up byte-short.)
-    const filename = inferOutputName(file.name)
-    // Guard before mutating global state: a stale completion shouldn't
-    // smear `displayedResult` or flash its volume into the viewer after
-    // the user has moved on. Re-check after `loadVolumes` too — the user
-    // may have started another run while it was decoding.
     if (myRun !== latestRunId) return
-    displayedResult = { url: body.resultUrl, name: filename }
-    await nv.loadVolumes([{ url: body.resultUrl, name: filename }])
+
+    const filename = inferOutputName(file.name)
+    displayedResult = { blob, name: filename }
+    const previewFile = new File([blob], filename, { type: 'application/gzip' })
+    await nv.loadVolumes([{ url: previewFile, name: filename }])
     if (myRun !== latestRunId) return
     updateCurrentImageDisplay()
-    const serverMs = body.durationMs
-      ? `${(body.durationMs / 1000).toFixed(2)}s server`
-      : ''
-    setStatus(`Done in ${elapsed}s${serverMs ? ` (${serverMs})` : ''}`)
-    void refreshHistory()
+    pushHistory({
+      id: crypto.randomUUID(),
+      args,
+      inputName: file.name,
+      outputName: filename,
+      startedAt: Date.now(),
+      durationMs: Number(elapsed) * 1000,
+      status: 'completed',
+      blob,
+    })
+    setStatus(`Done in ${elapsed}s`)
   } catch (err) {
     if (myRun !== latestRunId) return
     const msg = err instanceof Error ? err.message : String(err)
-    // "Failed to fetch" is the canonical browser error for "the request never
-    // got a response" — usually the API server isn't running. Probe the
-    // health endpoint to confirm and give the user something actionable.
-    if (msg.toLowerCase().includes('failed to fetch')) {
-      const reachable = await fetch('/api/health')
-        .then((r) => r.ok)
-        .catch(() => false)
-      setStatus(
-        reachable
-          ? `Run failed: ${msg} (server reachable but request was dropped — check the server terminal).`
-          : 'Run failed: niimath server unreachable on :8087. Start it with `bunx nx dev demo-ext-fullstack` (or `bun run server`).',
-      )
-    } else {
-      setStatus(`Run failed: ${msg}`)
-    }
+    pushHistory({
+      id: crypto.randomUUID(),
+      args,
+      inputName: source.name,
+      outputName: inferOutputName(source.name),
+      startedAt: Date.now(),
+      durationMs: 0,
+      status: 'failed',
+      error: msg,
+    })
+    setStatus(`Run failed: ${msg}`)
   } finally {
-    // Only the live run owns the run button; otherwise a stale completion
-    // would re-enable Run while a fresh job is still in flight, letting the
-    // user double-submit.
     if (myRun === latestRunId) {
       runBtn.disabled = false
       updateButtons()
@@ -494,70 +463,87 @@ async function runPipeline(): Promise<void> {
   }
 }
 
+async function sourceAsFile(
+  src: NonNullable<typeof currentSource>,
+): Promise<File> {
+  if (src.kind === 'file') return src.file
+  const res = await fetch(src.url)
+  if (!res.ok) throw new Error(`Failed to fetch ${src.url}: ${res.status}`)
+  const blob = await res.blob()
+  return new File([blob], src.name, { type: 'application/gzip' })
+}
+
 // ---------------------------------------------------------------------------
 // History
 // ---------------------------------------------------------------------------
 
-async function refreshHistory(): Promise<void> {
-  try {
-    const res = await fetch('/api/jobs')
-    if (!res.ok) return
-    const { jobs } = (await res.json()) as { jobs: JobSummary[] }
-    historyList.innerHTML = ''
-    emptyHistory.classList.toggle('hidden', jobs.length > 0)
-    for (const job of jobs) renderHistoryItem(job)
-  } catch {
-    /* server not reachable — leave history empty */
-  }
+function historyByteSize(): number {
+  let n = 0
+  for (const e of history) n += e.blob?.size ?? 0
+  return n
 }
 
-function renderHistoryItem(job: JobSummary): void {
+function pushHistory(entry: HistoryEntry): void {
+  history.unshift(entry)
+  // Evict oldest entries until both caps are satisfied. The just-pushed
+  // entry sits at index 0 and is never the eviction target.
+  while (
+    history.length > HISTORY_CAP ||
+    (history.length > 1 && historyByteSize() > HISTORY_BYTE_CAP)
+  ) {
+    history.pop()
+  }
+  renderHistory()
+}
+
+function renderHistory(): void {
+  historyList.innerHTML = ''
+  emptyHistory.classList.toggle('hidden', history.length > 0)
+  for (const entry of history) renderHistoryItem(entry)
+}
+
+function renderHistoryItem(entry: HistoryEntry): void {
   const item = document.createElement('div')
   item.className = 'history-item'
 
   const top = document.createElement('div')
   top.className = 'top'
   const cmd = document.createElement('code')
-  cmd.textContent = job.args.join(' ')
+  cmd.textContent = entry.args.join(' ')
   top.appendChild(cmd)
   const statusSpan = document.createElement('span')
-  statusSpan.className = `status-${job.status}`
-  statusSpan.textContent = job.status
+  statusSpan.className = `status-${entry.status}`
+  statusSpan.textContent = entry.status
   top.appendChild(statusSpan)
   item.appendChild(top)
 
   const meta = document.createElement('div')
   meta.className = 'meta'
-  const when = new Date(job.startedAt).toLocaleTimeString()
-  const dur = job.durationMs ? `${(job.durationMs / 1000).toFixed(2)}s` : '—'
-  meta.textContent = `${job.inputName} · ${when} · ${dur}`
+  const when = new Date(entry.startedAt).toLocaleTimeString()
+  const dur =
+    entry.durationMs > 0 ? `${(entry.durationMs / 1000).toFixed(2)}s` : '—'
+  meta.textContent = `${entry.inputName} · ${when} · ${dur}`
   item.appendChild(meta)
 
-  if (job.error) {
+  if (entry.error) {
     const err = document.createElement('div')
     err.className = 'meta status-failed'
-    err.textContent = job.error
+    err.textContent = entry.error
     item.appendChild(err)
   }
 
-  if (job.status === 'completed') {
+  if (entry.status === 'completed' && entry.blob) {
     const reload = document.createElement('button')
     reload.style.marginTop = '0.4rem'
     reload.textContent = 'Reload result'
     reload.addEventListener('click', async () => {
-      setStatus(`Reloading job ${job.id}…`, true)
+      if (!entry.blob) return
       latestRunId++
-      const url = `/api/result/${job.id}`
-      const filename = inferOutputName(job.inputName)
-      try {
-        await nv.loadVolumes([{ url, name: filename }])
-      } catch (err) {
-        setStatus(
-          `Reload failed (result may have been cleared on server restart): ${err instanceof Error ? err.message : String(err)}`,
-        )
-        return
-      }
-      currentSource = { kind: 'sample', url, name: filename }
+      const file = new File([entry.blob], entry.outputName, {
+        type: 'application/gzip',
+      })
+      await nv.loadVolumes([{ url: file, name: entry.outputName }])
+      currentSource = { kind: 'file', file, name: entry.outputName }
       displayedResult = null
       updateCurrentImageDisplay()
       updateCommandPreview()
@@ -571,32 +557,6 @@ function renderHistoryItem(job: JobSummary): void {
 }
 
 // ---------------------------------------------------------------------------
-// Health check
-// ---------------------------------------------------------------------------
-
-async function checkHealth(): Promise<void> {
-  try {
-    const res = await fetch('/api/health')
-    const body = (await res.json()) as {
-      ok: boolean
-      niimath: { tag: string } | null
-    }
-    if (body.niimath) {
-      health.textContent = `server ok · niimath ${body.niimath.tag}`
-      health.classList.remove('error')
-      health.classList.add('ok')
-    } else {
-      health.textContent =
-        'server up · niimath NOT installed (run `bun run setup`)'
-      health.classList.add('error')
-    }
-  } catch {
-    health.textContent = 'server unreachable'
-    health.classList.add('error')
-  }
-}
-
-// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -606,7 +566,5 @@ function setStatus(text: string, busy = false): void {
 }
 
 renderPipeline()
-void checkHealth()
-void refreshHistory()
 sampleSelect.value = SAMPLE_VOLUMES[0].name
 void loadSample(SAMPLE_VOLUMES[0].name)

--- a/apps/demo-ext-niimath/src/main.ts
+++ b/apps/demo-ext-niimath/src/main.ts
@@ -429,15 +429,22 @@ async function runPipeline(): Promise<void> {
   // numeric args back to strings — NiimathStep allows numbers.
   const args = steps.flatMap((s) => [`-${s.method}`, ...s.args.map(String)])
 
+  // Capture timing before any awaits so history reflects when the user
+  // clicked Run, not when the result happened to land. Use performance.now
+  // for the duration delta to avoid the precision loss of round-tripping
+  // through a toFixed string.
+  const startedAt = Date.now()
+  const t0 = performance.now()
+
   try {
     await niimathReady
     if (!niimathOk) {
       throw new Error('niimath WASM failed to initialize — reload the page')
     }
     const file = await sourceAsFile(source)
-    const t0 = performance.now()
     const blob = await runNiimathPipeline(niimath, file, steps)
-    const elapsed = ((performance.now() - t0) / 1000).toFixed(2)
+    const durationMs = performance.now() - t0
+    const elapsed = (durationMs / 1000).toFixed(2)
     if (myRun !== latestRunId) return
 
     const filename = inferOutputName(file.name)
@@ -451,8 +458,8 @@ async function runPipeline(): Promise<void> {
       args,
       inputName: file.name,
       outputName: filename,
-      startedAt: Date.now(),
-      durationMs: Number(elapsed) * 1000,
+      startedAt,
+      durationMs,
       status: 'completed',
       blob,
     })
@@ -465,8 +472,8 @@ async function runPipeline(): Promise<void> {
       args,
       inputName: source.name,
       outputName: inferOutputName(source.name),
-      startedAt: Date.now(),
-      durationMs: 0,
+      startedAt,
+      durationMs: performance.now() - t0,
       status: 'failed',
       error: msg,
     })

--- a/apps/demo-ext-niimath/src/operators.ts
+++ b/apps/demo-ext-niimath/src/operators.ts
@@ -1,0 +1,96 @@
+/**
+ * Curated set of niimath operators exposed in the demo's "Add Operation"
+ * picker. Mirrors the list from the source fullstack-niivue-demo
+ * (frontend/src/components/niimath-config.tsx).
+ */
+export interface NiimathOperator {
+  name: string
+  description: string
+  args: { name: string; description: string; default?: string }[]
+}
+
+export const NIIMATH_OPERATORS: NiimathOperator[] = [
+  { name: '-ceil', description: 'Round up to nearest integer', args: [] },
+  { name: '-floor', description: 'Round down to nearest integer', args: [] },
+  { name: '-round', description: 'Round to nearest integer', args: [] },
+  { name: '-abs', description: 'Absolute value', args: [] },
+  {
+    name: '-bandpass',
+    description: 'Temporal bandpass filter',
+    args: [
+      { name: 'hp', description: 'High-pass cutoff (Hz)', default: '0.01' },
+      { name: 'lp', description: 'Low-pass cutoff (Hz)', default: '0.1' },
+      { name: 'tr', description: 'TR (seconds)', default: '2.0' },
+    ],
+  },
+  {
+    name: '-s',
+    description: 'Gaussian smoothing (sigma mm)',
+    args: [{ name: 'sigma', description: 'Sigma in mm', default: '3.0' }],
+  },
+  {
+    name: '-add',
+    description: 'Add constant value',
+    args: [{ name: 'value', description: 'Value to add', default: '100' }],
+  },
+  {
+    name: '-sub',
+    description: 'Subtract constant value',
+    args: [{ name: 'value', description: 'Value to subtract', default: '50' }],
+  },
+  {
+    name: '-mul',
+    description: 'Multiply by constant value',
+    args: [{ name: 'value', description: 'Multiplier', default: '2.0' }],
+  },
+  {
+    name: '-div',
+    description: 'Divide by constant value',
+    args: [{ name: 'value', description: 'Divisor', default: '1000' }],
+  },
+  {
+    name: '-thr',
+    description: 'Threshold (zero values below)',
+    args: [{ name: 'threshold', description: 'Threshold', default: '0.5' }],
+  },
+  {
+    name: '-uthr',
+    description: 'Upper threshold (zero values above)',
+    args: [
+      { name: 'threshold', description: 'Upper threshold', default: '1000' },
+    ],
+  },
+  {
+    name: '-bin',
+    description: 'Binarize (set non-zero values to 1)',
+    args: [],
+  },
+]
+
+/**
+ * Append `_processed` before the NIfTI extension. Mirrors the server logic so
+ * the displayed command matches what actually runs.
+ *
+ * niimath / fslmaths default to writing `.nii.gz` regardless of the requested
+ * extension unless `FSLOUTPUTTYPE` is set. The server pins
+ * `FSLOUTPUTTYPE=NIFTI_GZ` and asks for a `.nii.gz` output explicitly.
+ */
+export function inferOutputName(inputName: string): string {
+  const lower = inputName.toLowerCase()
+  let stem = inputName
+  if (lower.endsWith('.nii.gz')) stem = inputName.slice(0, -7)
+  else if (lower.endsWith('.nii')) stem = inputName.slice(0, -4)
+  // Idempotent: chained runs against an already-processed name don't keep
+  // appending `_processed`.
+  const suffix = stem.endsWith('_processed') ? '' : '_processed'
+  return `${stem}${suffix}.nii.gz`
+}
+
+/** Sample volumes shipped via @niivue/dev-images. Served at /volumes/<name>.nii.gz. */
+export const SAMPLE_VOLUMES = [
+  { name: 'mni152.nii.gz', label: 'MNI152 (T1 brain)' },
+  { name: 'FA.nii.gz', label: 'FA (fractional anisotropy)' },
+  { name: 'spmMotor.nii.gz', label: 'spmMotor (statistical map)' },
+  { name: 'visiblehuman.nii.gz', label: 'Visible Human (CT)' },
+  { name: 'torso.nii.gz', label: 'Torso (CT)' },
+] as const

--- a/apps/demo-ext-niimath/src/style.css
+++ b/apps/demo-ext-niimath/src/style.css
@@ -1,0 +1,454 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  grid-template-columns: 1fr 320px;
+  grid-template-areas:
+    "header header"
+    "main   sidebar"
+    "footer footer";
+  font-family:
+    system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #e8e8ea;
+  background: #1c1c1f;
+  user-select: none;
+}
+
+header {
+  grid-area: header;
+  background: #232327;
+  border-bottom: 1px solid #2f2f33;
+  padding: 0.75rem 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+header h1 {
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+header .health {
+  font-size: 0.75rem;
+  color: #9aa0a6;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+}
+
+header .health.ok {
+  color: #82d181;
+}
+
+header .health.error {
+  color: #ef6b6b;
+}
+
+main {
+  grid-area: main;
+  background: #000;
+  position: relative;
+  min-height: 0;
+  min-width: 0;
+}
+
+main canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+  cursor: crosshair;
+}
+
+main canvas:focus {
+  outline: 0;
+}
+
+aside {
+  grid-area: sidebar;
+  background: #1f1f23;
+  border-left: 1px solid #2f2f33;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.tabs {
+  display: flex;
+  border-bottom: 1px solid #2f2f33;
+}
+
+.tab-btn {
+  flex: 1;
+  background: transparent;
+  border: 0;
+  color: #9aa0a6;
+  padding: 0.65rem 0.5rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+}
+
+.tab-btn:hover {
+  color: #e8e8ea;
+}
+
+.tab-btn.active {
+  color: #e8e8ea;
+  border-bottom-color: #6c8cff;
+}
+
+.tab-panel {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.85rem;
+  display: none;
+}
+
+.tab-panel.active {
+  display: block;
+}
+
+.section {
+  margin-bottom: 1rem;
+}
+
+.section h2 {
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #9aa0a6;
+  margin-bottom: 0.4rem;
+}
+
+.section p {
+  font-size: 0.8rem;
+  color: #9aa0a6;
+  margin-bottom: 0.5rem;
+  line-height: 1.4;
+}
+
+.card {
+  background: #26262b;
+  border: 1px solid #2f2f33;
+  border-radius: 6px;
+  padding: 0.75rem;
+  margin-bottom: 0.65rem;
+}
+
+.card h3 {
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.card .desc {
+  font-size: 0.75rem;
+  color: #9aa0a6;
+  margin-bottom: 0.5rem;
+}
+
+button,
+select,
+input[type="text"],
+input[type="number"] {
+  font-family: inherit;
+  font-size: 0.85rem;
+  background: #2c2c31;
+  color: #e8e8ea;
+  border: 1px solid #3a3a3f;
+  border-radius: 4px;
+  padding: 0.4rem 0.6rem;
+}
+
+button {
+  cursor: pointer;
+}
+
+button:hover:not(:disabled) {
+  background: #34343a;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+button.primary {
+  background: #4a6dff;
+  border-color: #5b7bff;
+  color: #fff;
+  font-weight: 500;
+}
+
+button.primary:hover:not(:disabled) {
+  background: #5b7bff;
+}
+
+.row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.row > * {
+  min-width: 0;
+}
+
+.row > .grow {
+  flex: 1;
+}
+
+label.field {
+  display: block;
+  font-size: 0.75rem;
+  color: #9aa0a6;
+  margin-bottom: 0.2rem;
+}
+
+.pipeline-item {
+  background: #1c1c1f;
+  border: 1px solid #2f2f33;
+  border-radius: 4px;
+  padding: 0.5rem;
+  margin-bottom: 0.4rem;
+  cursor: grab;
+}
+
+.pipeline-item.dragging {
+  opacity: 0.4;
+  cursor: grabbing;
+}
+
+.pipeline-item.drag-over {
+  border-color: #6c8cff;
+  border-style: dashed;
+}
+
+.pipeline-item .head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.pipeline-item .badge {
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 0.75rem;
+  background: #2c2c31;
+  border: 1px solid #3a3a3f;
+  border-radius: 3px;
+  padding: 0.1rem 0.4rem;
+}
+
+.pipeline-item .desc {
+  font-size: 0.7rem;
+  color: #9aa0a6;
+  margin: 0.25rem 0 0.4rem;
+}
+
+.pipeline-item .arg-row {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: 0.4rem;
+  align-items: center;
+  margin-top: 0.25rem;
+}
+
+.pipeline-item .arg-row label {
+  font-size: 0.72rem;
+  color: #9aa0a6;
+}
+
+.pipeline-item .arg-row input {
+  width: 100%;
+  font-size: 0.8rem;
+  padding: 0.25rem 0.4rem;
+}
+
+.pipeline-item .remove {
+  background: transparent;
+  border: 0;
+  color: #9aa0a6;
+  font-size: 0.95rem;
+  padding: 0.1rem 0.4rem;
+  cursor: pointer;
+}
+
+.pipeline-item .remove:hover {
+  color: #ef6b6b;
+}
+
+code,
+pre {
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 0.75rem;
+}
+
+pre.command {
+  background: #1c1c1f;
+  border: 1px solid #2f2f33;
+  border-radius: 4px;
+  padding: 0.55rem 0.65rem;
+  word-break: break-all;
+  white-space: pre-wrap;
+  color: #c8d3e1;
+  cursor: copy;
+  position: relative;
+  transition:
+    border-color 0.15s,
+    background 0.15s;
+}
+
+pre.command:hover {
+  border-color: #4a6dff;
+}
+
+pre.command:hover::after {
+  content: "click to copy";
+  position: absolute;
+  top: 4px;
+  right: 6px;
+  font-size: 0.6rem;
+  color: #6c8cff;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+pre.command.copied {
+  border-color: #82d181;
+  background: #1c2a20;
+}
+
+pre.command.copied::after {
+  content: "copied";
+  position: absolute;
+  top: 4px;
+  right: 6px;
+  font-size: 0.6rem;
+  color: #82d181;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.history-item {
+  background: #1c1c1f;
+  border: 1px solid #2f2f33;
+  border-radius: 5px;
+  padding: 0.55rem 0.65rem;
+  margin-bottom: 0.45rem;
+  font-size: 0.78rem;
+}
+
+.history-item .top {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0.2rem;
+}
+
+.history-item .meta {
+  color: #9aa0a6;
+  font-size: 0.7rem;
+}
+
+.history-item .status-completed {
+  color: #82d181;
+}
+
+.history-item .status-failed {
+  color: #ef6b6b;
+}
+
+.history-item .status-running {
+  color: #f0c674;
+}
+
+footer {
+  grid-area: footer;
+  background: #232327;
+  border-top: 1px solid #2f2f33;
+  padding: 0.45rem 1rem;
+  font-size: 0.78rem;
+  color: #9aa0a6;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  min-height: 1.7rem;
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+footer #status {
+  flex: 1;
+  border-radius: 3px;
+  padding: 0.05rem 0.3rem;
+  margin: -0.05rem -0.3rem;
+  transition:
+    background 0.15s,
+    color 0.15s;
+}
+
+footer #status.copyable {
+  cursor: copy;
+}
+
+footer #status.copyable:hover {
+  background: #2c2c31;
+  color: #e8e8ea;
+}
+
+footer #status.copied {
+  background: #1c2a20;
+  color: #82d181;
+}
+
+footer .spinner {
+  width: 12px;
+  height: 12px;
+  border: 2px solid rgba(255, 255, 255, 0.15);
+  border-top-color: #6c8cff;
+  border-radius: 50%;
+  animation: spin 0.85s linear infinite;
+  display: inline-block;
+}
+
+footer .spinner.hidden {
+  display: none;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+[hidden],
+.hidden {
+  display: none;
+}
+
+input[type="file"] {
+  display: none;
+}
+
+.file-label {
+  display: inline-block;
+  background: #2c2c31;
+  border: 1px solid #3a3a3f;
+  border-radius: 4px;
+  padding: 0.4rem 0.6rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.file-label:hover {
+  background: #34343a;
+}

--- a/apps/demo-ext-niimath/tsconfig.json
+++ b/apps/demo-ext-niimath/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/apps/demo-ext-niimath/vite.config.js
+++ b/apps/demo-ext-niimath/vite.config.js
@@ -1,0 +1,52 @@
+import { devImagesPlugin } from '@niivue/dev-images/vite-plugin'
+import { defineConfig } from 'vite'
+
+// VITE_BASE: the app's own base path (e.g. /mono/demo-ext-niimath/)
+// VITE_IMAGES_BASE: where shared dev-images live (e.g. /mono/)
+// When VITE_IMAGES_BASE is set, images aren't emitted into this app's
+// build output — they're served from the shared root instead.
+const ghBase = process.env.VITE_BASE ?? ''
+const imagesBase = process.env.VITE_IMAGES_BASE ?? ghBase
+
+function ghPagesRewritePlugin() {
+  if (!imagesBase) return null
+  return {
+    name: 'ghpages-rewrite-asset-urls',
+    enforce: 'post',
+    renderChunk(code) {
+      let out = code
+      for (const dir of ['volumes', 'meshes']) {
+        out = out
+          .replaceAll(`"/${dir}/`, `"${imagesBase}${dir}/`)
+          .replaceAll(`'/${dir}/`, `'${imagesBase}${dir}/`)
+          .replaceAll(`\`/${dir}/`, `\`${imagesBase}${dir}/`)
+      }
+      return out
+    },
+  }
+}
+
+export default defineConfig({
+  base: ghBase || '/',
+  plugins: [
+    devImagesPlugin({ emit: !process.env.VITE_IMAGES_BASE }),
+    ghPagesRewritePlugin(),
+  ],
+  // The underlying @niivue/niimath WASM worker uses a dynamic import that
+  // chokes when prebundled; let Vite leave it alone (matches the pattern
+  // demo-ext-dcm2niix uses for @niivue/dcm2niix). nv-ext-niimath is the
+  // workspace wrapper that re-exports it.
+  optimizeDeps: {
+    exclude: ['@niivue/niimath', '@niivue/nv-ext-niimath'],
+  },
+  server: {
+    port: 8089,
+  },
+  build: {
+    outDir: 'dist',
+    target: 'esnext',
+    rollupOptions: {
+      input: 'index.html',
+    },
+  },
+})

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "nx-mono-repo-test",
@@ -30,6 +29,17 @@
         "@niivue/nv-ext-drawing": "workspace:*",
       },
       "devDependencies": {
+        "vite": "^6.3.2",
+      },
+    },
+    "apps/demo-ext-fullstack": {
+      "name": "demo-ext-fullstack",
+      "dependencies": {
+        "@niivue/dev-images": "workspace:*",
+        "@niivue/niivue": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.1.0",
         "vite": "^6.3.2",
       },
     },
@@ -877,6 +887,8 @@
 
     "demo-ext-drawing": ["demo-ext-drawing@workspace:apps/demo-ext-drawing"],
 
+    "demo-ext-fullstack": ["demo-ext-fullstack@workspace:apps/demo-ext-fullstack"],
+
     "demo-ext-image-processing": ["demo-ext-image-processing@workspace:apps/demo-ext-image-processing"],
 
     "demo-ext-save-html": ["demo-ext-save-html@workspace:apps/demo-ext-save-html"],
@@ -1401,6 +1413,8 @@
 
     "cosmiconfig/yaml": ["yaml@1.10.3", "", {}, "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA=="],
 
+    "demo-ext-fullstack/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
     "demo-nv-web-component/vite": ["vite@8.0.9", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.10", "rolldown": "1.0.0-rc.16", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw=="],
 
     "filelist/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
@@ -1466,6 +1480,8 @@
     "@vitejs/plugin-react/vite/tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
     "@vue/language-core/minimatch/brace-expansion": ["brace-expansion@2.0.3", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA=="],
+
+    "demo-ext-fullstack/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "demo-nv-web-component/vite/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -54,6 +54,17 @@
         "vite": "^6.3.2",
       },
     },
+    "apps/demo-ext-niimath": {
+      "name": "demo-ext-niimath",
+      "dependencies": {
+        "@niivue/dev-images": "workspace:*",
+        "@niivue/niivue": "workspace:*",
+        "@niivue/nv-ext-niimath": "workspace:*",
+      },
+      "devDependencies": {
+        "vite": "^6.3.2",
+      },
+    },
     "apps/demo-ext-save-html": {
       "name": "demo-ext-save-html",
       "dependencies": {
@@ -174,6 +185,22 @@
       "dependencies": {
         "gl-matrix": "^3.4.4",
         "nifti-reader-js": "^0.8.0",
+      },
+      "devDependencies": {
+        "@niivue/niivue": "workspace:*",
+        "typescript": "~5.8.3",
+        "vite": "^6.3.2",
+        "vite-plugin-dts": "^4.5.4",
+      },
+      "peerDependencies": {
+        "@niivue/niivue": "workspace:*",
+      },
+    },
+    "packages/nv-ext-niimath": {
+      "name": "@niivue/nv-ext-niimath",
+      "version": "1.0.0-rc.0",
+      "dependencies": {
+        "@niivue/niimath": "^1.2.0",
       },
       "devDependencies": {
         "@niivue/niivue": "workspace:*",
@@ -563,6 +590,8 @@
 
     "@niivue/dev-images": ["@niivue/dev-images@workspace:packages/dev-images"],
 
+    "@niivue/niimath": ["@niivue/niimath@1.2.0", "", {}, "sha512-Llats13a09Pj9CRn0izLhG0TQ6sJ4ny5ZzQSbO8e4EjSpdLYM+amZA42ZuMAt+5k/N/Mh3mzt8423GcUkl0pig=="],
+
     "@niivue/niivue": ["@niivue/niivue@workspace:packages/niivue"],
 
     "@niivue/nv-ext-dcm2niix": ["@niivue/nv-ext-dcm2niix@workspace:packages/nv-ext-dcm2niix"],
@@ -570,6 +599,8 @@
     "@niivue/nv-ext-drawing": ["@niivue/nv-ext-drawing@workspace:packages/nv-ext-drawing"],
 
     "@niivue/nv-ext-image-processing": ["@niivue/nv-ext-image-processing@workspace:packages/nv-ext-image-processing"],
+
+    "@niivue/nv-ext-niimath": ["@niivue/nv-ext-niimath@workspace:packages/nv-ext-niimath"],
 
     "@niivue/nv-ext-save-html": ["@niivue/nv-ext-save-html@workspace:packages/nv-ext-save-html"],
 
@@ -890,6 +921,8 @@
     "demo-ext-fullstack": ["demo-ext-fullstack@workspace:apps/demo-ext-fullstack"],
 
     "demo-ext-image-processing": ["demo-ext-image-processing@workspace:apps/demo-ext-image-processing"],
+
+    "demo-ext-niimath": ["demo-ext-niimath@workspace:apps/demo-ext-niimath"],
 
     "demo-ext-save-html": ["demo-ext-save-html@workspace:apps/demo-ext-save-html"],
 
@@ -1368,6 +1401,8 @@
     "@niivue/nv-ext-drawing/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 
     "@niivue/nv-ext-image-processing/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+
+    "@niivue/nv-ext-niimath/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 
     "@niivue/nv-ext-save-html/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "nx-mono-repo-test",

--- a/packages/niivue/examples/vox.4d.html
+++ b/packages/niivue/examples/vox.4d.html
@@ -50,7 +50,7 @@
       <label for="webgpuCheck">WebGPU</label>
       <input type="checkbox" id="webgpuCheck" checked/>
       &nbsp;
-      <button type="button" id="aboutBtn">Load all volumes</button>
+      <button type="button" id="loadAllBtn">Load all volumes</button>
     </header>
     <main id="canvas-container">
       <canvas id="gl1"></canvas>

--- a/packages/niivue/examples/vox.4d.js
+++ b/packages/niivue/examples/vox.4d.js
@@ -48,12 +48,12 @@ nextFrame.onclick = () => {
   currentVol++
   nv1.setFrame4D(nv1.volumes[0].id, currentVol)
 }
-aboutBtn.onclick = async () => {
+loadAllBtn.onclick = async () => {
   const vol = nv1.volumes[0]
   if (vol.nTotalFrame4D > vol.nFrame4D) {
-    aboutBtn.textContent = 'Loading...'
+    loadAllBtn.textContent = 'Loading...'
     await nv1.loadDeferred4DVolumes(vol.id)
-    aboutBtn.textContent = `Loaded all ${vol.nFrame4D} frames`
+    loadAllBtn.textContent = `Loaded all ${vol.nFrame4D} frames`
   } else {
     window.alert(`All ${vol.nFrame4D} frames are loaded.`)
   }

--- a/packages/niivue/src/NVControlBase.ts
+++ b/packages/niivue/src/NVControlBase.ts
@@ -73,9 +73,11 @@ import type {
 } from '@/volume/transforms'
 import * as NVVolumeTransforms from '@/volume/transforms'
 import {
+  calMinMax,
   calMinMaxFrame,
   computeVolumeLabelCentroids,
   reorientDrawingToNative,
+  toTypedViewOrU8,
 } from '@/volume/utils'
 
 type ViewBackend = {
@@ -1943,8 +1945,19 @@ export default class NiiVueGPU extends EventTarget {
       return
     }
     const nii = await NVVolume.loadVolume(vol.url)
-    vol.img = nii.img instanceof ArrayBuffer ? null : nii.img
+    vol.img = toTypedViewOrU8(nii.img, vol.hdr.datatypeCode)
     vol.nFrame4D = vol.nTotalFrame4D
+    // Recompute intensity range over the now-full timeseries. Later
+    // frames in dynamic scans often widen the range; leaving the
+    // truncated values would give a brightness shift versus a fresh
+    // full load. Same fields `recalculateCalMinMax` writes.
+    const [pct2, pct98, mnScale, mxScale] = calMinMax(vol.hdr, vol.img)
+    vol.calMin = pct2
+    vol.calMax = pct98
+    vol.robustMin = pct2
+    vol.robustMax = pct98
+    vol.globalMin = mnScale
+    vol.globalMax = mxScale
     await this.updateGLVolume()
   }
 

--- a/packages/niivue/src/NVControlBase.ts
+++ b/packages/niivue/src/NVControlBase.ts
@@ -1945,13 +1945,17 @@ export default class NiiVueGPU extends EventTarget {
       return
     }
     const nii = await NVVolume.loadVolume(vol.url)
+    // Compute intensity stats on `nii.img` BEFORE typed-view coercion —
+    // calMinMax's RGB/RGBA sentinel only triggers when its internal
+    // `toTypedView` sees a raw ArrayBuffer; once we've coerced to
+    // Uint8Array via toTypedViewOrU8, calMinMax would scan RGB bytes
+    // as scalar intensities. Matches nii2volume's call order.
+    // (Like nii2volume, this scans the first 3D frame only — so
+    // intensity range may differ from a hypothetical scan over the
+    // full timeseries; that's the existing initial-load behavior.)
+    const [pct2, pct98, mnScale, mxScale] = calMinMax(vol.hdr, nii.img)
     vol.img = toTypedViewOrU8(nii.img, vol.hdr.datatypeCode)
     vol.nFrame4D = vol.nTotalFrame4D
-    // Recompute intensity range over the now-full timeseries. Later
-    // frames in dynamic scans often widen the range; leaving the
-    // truncated values would give a brightness shift versus a fresh
-    // full load. Same fields `recalculateCalMinMax` writes.
-    const [pct2, pct98, mnScale, mxScale] = calMinMax(vol.hdr, vol.img)
     vol.calMin = pct2
     vol.calMax = pct98
     vol.robustMin = pct2

--- a/packages/niivue/src/NVControlBase.ts
+++ b/packages/niivue/src/NVControlBase.ts
@@ -75,8 +75,8 @@ import type {
 } from '@/volume/transforms'
 import * as NVVolumeTransforms from '@/volume/transforms'
 import {
-  calMinMax,
   calculateWorldExtents,
+  calMinMax,
   calMinMaxFrame,
   computeVolumeLabelCentroids,
   reorientDrawingToNative,

--- a/packages/niivue/src/volume/NVVolume.ts
+++ b/packages/niivue/src/volume/NVVolume.ts
@@ -7,7 +7,7 @@ import {
   calculateWorldExtents,
   calMinMax,
   ensureValidNonZero,
-  toTypedView,
+  toTypedViewOrU8,
 } from './utils'
 
 // Re-export utilities for external use
@@ -212,12 +212,7 @@ export function nii2volume(
     )
   }
   const [pct2, pct98, mnScale, mxScale] = calMinMax(hdr, truncatedImg)
-  // Ensure img is always a typed array, never a raw ArrayBuffer
-  const typedImg: TypedVoxelArray =
-    truncatedImg instanceof ArrayBuffer
-      ? (toTypedView(truncatedImg, hdr.datatypeCode) ??
-        new Uint8Array(truncatedImg))
-      : truncatedImg
+  const typedImg = toTypedViewOrU8(truncatedImg, hdr.datatypeCode)
   const volume: NVImage = {
     img: typedImg,
     hdr: hdr,

--- a/packages/niivue/src/volume/utils.test.ts
+++ b/packages/niivue/src/volume/utils.test.ts
@@ -12,6 +12,8 @@ import {
   getVoxelValue,
   hdrToArrayBuffer,
   reorientDrawingToNative,
+  toTypedView,
+  toTypedViewOrU8,
 } from './utils'
 
 // ---------------------------------------------------------------------------
@@ -357,5 +359,45 @@ describe('reorientDrawingToNative', () => {
     const vol = makeMinimalVolume({ permRAS: undefined })
     const result = reorientDrawingToNative(vol, drawing)
     expect(result).toBe(drawing)
+  })
+})
+
+describe('toTypedView', () => {
+  test('arrayBuffer_int16_returnsInt16Array', () => {
+    const buf = new Int16Array([10, -3, 32000]).buffer
+    const view = toTypedView(buf, NiiDataType.DT_INT16)
+    expect(view).toBeInstanceOf(Int16Array)
+    expect(Array.from(view as Int16Array)).toEqual([10, -3, 32000])
+  })
+
+  test('arrayBuffer_rgb24_returnsNull', () => {
+    const buf = new Uint8Array([255, 0, 0, 0, 255, 0]).buffer
+    expect(toTypedView(buf, NiiDataType.DT_RGB24)).toBeNull()
+  })
+
+  test('alreadyTypedArray_returnsAsIs', () => {
+    const arr = new Float32Array([1.5, 2.5])
+    expect(toTypedView(arr, NiiDataType.DT_FLOAT32)).toBe(arr)
+  })
+})
+
+describe('toTypedViewOrU8', () => {
+  test('arrayBuffer_int16_returnsInt16Array', () => {
+    const buf = new Int16Array([1, 2, 3]).buffer
+    const view = toTypedViewOrU8(buf, NiiDataType.DT_INT16)
+    expect(view).toBeInstanceOf(Int16Array)
+    expect(Array.from(view)).toEqual([1, 2, 3])
+  })
+
+  test('arrayBuffer_rgb24_fallsBackToUint8Array', () => {
+    const bytes = new Uint8Array([255, 0, 128, 64, 32, 16])
+    const view = toTypedViewOrU8(bytes.buffer, NiiDataType.DT_RGB24)
+    expect(view).toBeInstanceOf(Uint8Array)
+    expect(Array.from(view)).toEqual([255, 0, 128, 64, 32, 16])
+  })
+
+  test('alreadyTypedArray_returnsAsIs', () => {
+    const arr = new Uint8Array([7, 8, 9])
+    expect(toTypedViewOrU8(arr, NiiDataType.DT_UINT8)).toBe(arr)
   })
 })

--- a/packages/niivue/src/volume/utils.ts
+++ b/packages/niivue/src/volume/utils.ts
@@ -113,6 +113,21 @@ export function toTypedView(
 }
 
 /**
+ * Coerce raw NIfTI bytes to a typed view, falling back to a Uint8Array for
+ * RGB/RGBA datatypes that have no per-voxel intensity. The fallback matches
+ * how loaders treat those bytes elsewhere — `nii2volume` and the deferred-
+ * load path in `NVControlBase.loadDeferred4DVolumes` must agree on this
+ * shape, so it lives here once.
+ */
+export function toTypedViewOrU8(
+  img: ArrayBuffer | TypedVoxelArray,
+  dt: number,
+): TypedVoxelArray {
+  if (!(img instanceof ArrayBuffer)) return img
+  return toTypedView(img, dt) ?? new Uint8Array(img)
+}
+
+/**
  * Compute robust (2%–98% histogram percentile) intensity range over a typed array slice.
  * Returns [robust_min, robust_max, global_min, global_max] in raw (unscaled) values.
  */

--- a/packages/nv-ext-niimath/README.md
+++ b/packages/nv-ext-niimath/README.md
@@ -1,0 +1,89 @@
+# @niivue/nv-ext-niimath
+
+Browser-side niimath pipelines for [NiiVue](https://github.com/niivue), wrapping the [`@niivue/niimath`](https://www.npmjs.com/package/@niivue/niimath) WebAssembly build of Chris Rorden's [`niimath`](https://github.com/rordenlab/niimath). All processing runs in a Web Worker; no data leaves the browser.
+
+## Installation
+
+```bash
+bun add @niivue/nv-ext-niimath
+```
+
+Requires `@niivue/niivue` as a peer dependency.
+
+## Usage
+
+```ts
+import NiiVueGPU from '@niivue/niivue'
+import { Niimath, runNiimathPipeline } from '@niivue/nv-ext-niimath'
+
+const nv = new NiiVueGPU()
+await nv.attachTo('gl1')
+
+// One Niimath instance per page — its worker is expensive to spin up.
+const niimath = new Niimath()
+await niimath.init()
+
+const input = document.querySelector<HTMLInputElement>('#nifti')!
+input.addEventListener('change', async () => {
+  const file = input.files?.[0]
+  if (!file) return
+  const result = await runNiimathPipeline(niimath, file, [
+    { method: 's', args: [3] },     // -s 3   (Gaussian smoothing, sigma 3 mm)
+    { method: 'thr', args: [0.5] }, // -thr 0.5
+    { method: 'bin', args: [] },    // -bin
+  ])
+  await nv.loadVolumes([
+    { url: new File([result], 'processed.nii.gz'), name: 'processed.nii.gz' },
+  ])
+})
+```
+
+## API
+
+### `runNiimathPipeline(niimath, file, steps, outName?): Promise<Blob>`
+
+Walks `steps` and dispatches each to the matching method on the niimath
+chain. Returns the final NIfTI result as a `Blob`. The caller owns the
+`Niimath` lifetime; this function never terminates the worker so it can
+be reused across many pipelines.
+
+**Serial only.** The underlying worker has a single `onmessage` handler
+that gets reassigned on every `run()`, so two overlapping calls against
+the same `Niimath` instance will steal each other's responses. Either
+await the previous call (typical UI pattern: disable Run while a job is
+in flight) or instantiate a separate `Niimath` per concurrent stream.
+
+`outName` defaults to `'output.nii.gz'`. The WASM build of niimath
+gzip-compresses its output, so a `.nii` filename produces a file the
+worker then can't read back (surfaces as a generic
+`Uncaught [object Object]` error). Override only if you have a reason.
+
+### `NiimathStep`
+
+```ts
+interface NiimathStep {
+  method: string                     // niimath flag without '-' (e.g. 's', 'thr')
+  args: (string | number)[]          // positional parameters; strings auto-parsed
+}
+```
+
+### Re-exports
+
+- `Niimath` — the underlying `@niivue/niimath` class for full control.
+- `ImageProcessorMethods`, `Operators`, `OperatorDefinition` — types from
+  `@niivue/niimath` for callers building UIs against the operator catalog.
+
+## Why a wrapper?
+
+`@niivue/niimath` already exposes a clean method-chain API (`.s(3).thr(0.5).bin().run()`). This wrapper exists so that UIs whose pipelines come from user input (drag-reorderable steps, dropdown selections, etc.) can build a `NiimathStep[]` array and hand it off, rather than having to build the chain via dynamic-method dispatch themselves.
+
+## Try it locally
+
+A full example app lives at [`apps/demo-ext-niimath`](https://github.com/niivue/mono/tree/main/apps/demo-ext-niimath) (UI: sample-volume picker, drag-reorderable pipeline, generated-command preview, history). To run it from a clone of the monorepo:
+
+```bash
+bun install                       # From monorepo root
+bunx nx dev demo-ext-niimath      # Start dev server (port 8089)
+```
+
+## Part of the [NiiVue](https://github.com/niivue) ecosystem

--- a/packages/nv-ext-niimath/package.json
+++ b/packages/nv-ext-niimath/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@niivue/nv-ext-niimath",
+  "version": "1.0.0-rc.0",
+  "type": "module",
+  "description": "Browser-side niimath pipeline runner for NiiVue, wrapping the @niivue/niimath WebAssembly build",
+  "main": "./dist/nv-ext-niimath.js",
+  "module": "./dist/nv-ext-niimath.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/nv-ext-niimath.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "peerDependencies": {
+    "@niivue/niivue": "workspace:*"
+  },
+  "dependencies": {
+    "@niivue/niimath": "^1.2.0"
+  },
+  "devDependencies": {
+    "@niivue/niivue": "workspace:*",
+    "typescript": "~5.8.3",
+    "vite": "^6.3.2",
+    "vite-plugin-dts": "^4.5.4"
+  },
+  "scripts": {
+    "build": "bunx --bun vite build",
+    "typecheck": "bunx tsc --noEmit"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/nv-ext-niimath/project.json
+++ b/packages/nv-ext-niimath/project.json
@@ -1,0 +1,32 @@
+{
+  "name": "nv-ext-niimath",
+  "projectType": "library",
+  "tags": ["type:lib", "lang:typescript"],
+  "targets": {
+    "build": {
+      "command": "bunx --bun vite build",
+      "options": { "cwd": "{projectRoot}" },
+      "dependsOn": ["^build"],
+      "inputs": [
+        "typescript",
+        "{projectRoot}/vite.config.ts",
+        "{projectRoot}/src/**/*"
+      ],
+      "outputs": ["{projectRoot}/dist"]
+    },
+    "typecheck": {
+      "command": "bunx tsc --noEmit",
+      "options": { "cwd": "{projectRoot}" },
+      "dependsOn": ["^build"],
+      "inputs": ["typescript"]
+    },
+    "lint": {
+      "command": "bunx biome check {projectRoot}",
+      "inputs": ["typescript"]
+    },
+    "format": {
+      "command": "bunx biome format {projectRoot} --write",
+      "inputs": ["typescript"]
+    }
+  }
+}

--- a/packages/nv-ext-niimath/src/index.ts
+++ b/packages/nv-ext-niimath/src/index.ts
@@ -1,0 +1,121 @@
+/**
+ * @niivue/nv-ext-niimath
+ *
+ * Browser-side niimath pipelines for NiiVue, wrapping the
+ * `@niivue/niimath` WebAssembly build of Chris Rorden's niimath.
+ *
+ * Most callers want one function:
+ *
+ *   - {@link runNiimathPipeline} — apply a sequence of niimath operations
+ *     to a `File` and resolve to the resulting `Blob`.
+ *
+ * The underlying `Niimath` class is re-exported for callers who want full
+ * control over worker lifecycle (e.g. reusing a single instance across
+ * many runs).
+ *
+ * Usage:
+ * ```ts
+ * import NiiVueGPU from '@niivue/niivue'
+ * import { Niimath, runNiimathPipeline } from '@niivue/nv-ext-niimath'
+ *
+ * const nv = new NiiVueGPU()
+ * await nv.attachTo('gl1')
+ *
+ * const niimath = new Niimath()
+ * await niimath.init()
+ *
+ * const result = await runNiimathPipeline(niimath, inputFile, [
+ *   { method: 's', args: [3] },     // -s 3   (Gaussian smoothing)
+ *   { method: 'thr', args: [0.5] }, // -thr 0.5
+ *   { method: 'bin', args: [] },    // -bin
+ * ])
+ *
+ * await nv.loadVolumes([{ url: result, name: 'processed.nii.gz' }])
+ * ```
+ */
+
+import { type ImageProcessorMethods, Niimath } from '@niivue/niimath'
+
+export type {
+  ImageProcessorMethods,
+  OperatorDefinition,
+  Operators,
+} from '@niivue/niimath'
+// Re-export so callers can drop down to the raw API when they need
+// operators we don't expose helpers for, or want to manage the worker
+// lifecycle directly.
+export { Niimath }
+
+/**
+ * One step in a niimath pipeline.
+ *
+ * `method` is the niimath operator name **without** the leading dash —
+ * e.g. `'s'` for `-s`, `'thr'` for `-thr`, `'bin'` for `-bin`. See the
+ * [niimath operator catalog](https://github.com/rordenlab/niimath#options).
+ *
+ * `args` are positional parameters. Strings that parse as numbers are
+ * converted automatically; pass numbers directly if you already have them.
+ */
+export interface NiimathStep {
+  method: string
+  args: (string | number)[]
+}
+
+type Chain = ImageProcessorMethods & { run(outName?: string): Promise<Blob> }
+
+/**
+ * Run a sequence of niimath operations against an input file.
+ *
+ * The caller owns the `Niimath` instance — pass an already-`init()`ed one.
+ * That lets you reuse a single worker across many pipelines (the WASM
+ * cold-start is non-trivial; reuse matters for interactive UIs).
+ *
+ * **Serial only.** The underlying `@niivue/niimath` worker has a single
+ * `onmessage` handler that gets reassigned on every `run()` call, so two
+ * overlapping `runNiimathPipeline` calls against the same `Niimath`
+ * instance will steal each other's responses. Either await the previous
+ * call before kicking off the next one (the typical UI pattern: disable
+ * the Run button while a job is in flight), or instantiate a separate
+ * `Niimath` per concurrent stream.
+ *
+ * @param niimath  An initialised `Niimath` instance (after `await niimath.init()`).
+ * @param file     Input NIfTI as a browser `File`.
+ * @param steps    Pipeline steps; applied in order.
+ * @param outName  Output filename in the WASM filesystem; must end in
+ *                 `.nii.gz` since the WASM build always gzips its output.
+ * @returns        The processed NIfTI as a `Blob` (gzipped).
+ *
+ * @throws If a step references a method the WASM build doesn't expose.
+ */
+export async function runNiimathPipeline(
+  niimath: Niimath,
+  file: File,
+  steps: NiimathStep[],
+  outName = 'output.nii.gz',
+): Promise<Blob> {
+  let chain = niimath.image(file) as unknown as Chain
+  for (const step of steps) {
+    const args = step.args.map((a) => {
+      if (typeof a === 'number') return a
+      const trimmed = a.trim()
+      const n = Number(trimmed)
+      return Number.isFinite(n) && trimmed.length > 0 ? n : trimmed
+    })
+    // niimath generates each operator method as an *own* property on the
+    // ImageProcessor instance, so `Object.hasOwn` reliably rejects
+    // inherited names like `constructor`/`toString` that would otherwise
+    // dispatch to harmless-but-cryptic prototype methods.
+    const obj = chain as unknown as Record<
+      string,
+      ((...a: (string | number)[]) => Chain) | undefined
+    >
+    if (
+      !Object.hasOwn(obj, step.method) ||
+      typeof obj[step.method] !== 'function'
+    ) {
+      throw new Error(`Unknown niimath method: -${step.method}`)
+    }
+    chain = obj[step.method]?.apply(chain, args) as Chain
+  }
+  return await chain.run(outName)
+}

--- a/packages/nv-ext-niimath/src/index.ts
+++ b/packages/nv-ext-niimath/src/index.ts
@@ -93,6 +93,11 @@ export async function runNiimathPipeline(
   steps: NiimathStep[],
   outName = 'output.nii.gz',
 ): Promise<Blob> {
+  if (!outName.toLowerCase().endsWith('.nii.gz')) {
+    throw new Error(
+      `outName must end with .nii.gz; got "${outName}". The WASM build of niimath always gzips its output.`,
+    )
+  }
   let chain = niimath.image(file) as unknown as Chain
   for (const step of steps) {
     const args = step.args.map((a) => {

--- a/packages/nv-ext-niimath/tsconfig.json
+++ b/packages/nv-ext-niimath/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "target": "ESNext",
+    "useDefineForClassFields": false,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/nv-ext-niimath/vite.config.ts
+++ b/packages/nv-ext-niimath/vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vite'
+import dts from 'vite-plugin-dts'
+
+export default defineConfig({
+  plugins: [dts({ tsconfigPath: './tsconfig.json' })],
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    lib: {
+      entry: 'src/index.ts',
+      formats: ['es'],
+      fileName: 'nv-ext-niimath',
+    },
+    rollupOptions: {
+      external: ['@niivue/niivue', '@niivue/niimath'],
+    },
+  },
+})


### PR DESCRIPTION
Adds two complementary niimath demos plus a small reusable library, so the monorepo now shows both edge-based (webassembly) and cloud-based (native executable) image processing.

- **`apps/demo-ext-fullstack`** — local fullstack demo wiring NiiVue
  (browser) to a Bun server that spawns the native `niimath` binary as a
  subprocess. Loopback-only, no Docker, no DB, no auth. Complements the more complex [fullstack-niivue-demo](https://github.com/niivue/fullstack-niivue-demo) which includes these features. Runs on macOS, Linux, and Windows from a single `bunx nx dev` command.

- **`packages/nv-ext-niimath`** — thin browser-side wrapper around
  `@niivue/niimath` that exposes `runNiimathPipeline(niimath, file, steps,
  outName?)`. 

- **`apps/demo-ext-niimath`** — same UI shell as the fullstack demo, but
  niimath runs entirely in a Web Worker via the WASM build. Static-only,
  ships through the existing GitHub Pages workflow alongside the other
  `demo-ext-*` apps.
