### PR TITLE
Fix example to show 3D render panel in the `A+C+S+R` layout

### DIFF
--- a/packages/niivue/examples/vox.basic.html
+++ b/packages/niivue/examples/vox.basic.html
@@ -41,7 +41,7 @@
     </main>
     <footer id="location">NiiVue</footer>
     <script type="module">
-      import NiiVue from '../src/index.ts'
+      import NiiVue, { SHOW_RENDER } from '../src/index.ts'
 
       orientCheck.onclick = async function () {
         nv1.isOrientCubeVisible = this.checked
@@ -66,7 +66,7 @@
       darkCheck.onclick = function () {
         nv1.volumeIsAlphaClipDark = this.checked
       }
-      const nv1 = new NiiVue({backgroundColor: [0.2,0.2,0.2, 1], isColorbarVisible: true })
+      const nv1 = new NiiVue({backgroundColor: [0.2,0.2,0.2, 1], isColorbarVisible: true, showRender: SHOW_RENDER.ALWAYS })
       nv1.addEventListener('locationChange', (e) => handleLocationChange(e.detail))
       await nv1.attachToCanvas(gl1)
       for (const cmap of nv1.colormaps) {


### PR DESCRIPTION
In this example (https://niivue.github.io/mono/examples/vox.basic.html), I don't see the 3D render view when the `A+C+S+R` layout is selected.

<img width="1916" height="877" alt="image" src="https://github.com/user-attachments/assets/24f39603-48f3-4cdb-ad98-5a29c93ec255" />

cc @satra @ayendiki