### PR TITLE
Harden release publishing

### DIFF
--- a/.github/scripts/configure-release-git.ts
+++ b/.github/scripts/configure-release-git.ts
@@ -1,0 +1,24 @@
+#!/usr/bin/env bun
+// Configure git identity for release commits.
+//
+// Usage: bun .github/scripts/configure-release-git.ts
+
+const commands = [
+  ['git', 'config', 'user.name', 'github-actions[bot]'],
+  [
+    'git',
+    'config',
+    'user.email',
+    '41898282+github-actions[bot]@users.noreply.github.com',
+  ],
+]
+
+for (const command of commands) {
+  const result = Bun.spawnSync(command, {
+    stdout: 'inherit',
+    stderr: 'inherit',
+  })
+  if (result.exitCode !== 0) {
+    throw new Error(`Command failed: ${command.join(' ')}`)
+  }
+}

--- a/.github/scripts/create-github-releases.ts
+++ b/.github/scripts/create-github-releases.ts
@@ -92,14 +92,17 @@ const tags = run(['git', 'tag', '--points-at', 'HEAD'], { quiet: true })
 const tempDir = mkdtempSync(join(tmpdir(), 'github-releases-'))
 
 for (const tag of tags) {
-  const project = tag.replace(/@[^@]+$/, '')
+  const atIndex = tag.lastIndexOf('@')
+  const project = tag.slice(0, atIndex)
+  const version = tag.slice(atIndex + 1)
   const pkgDir = resolvePackageDir(project)
   const notes = pkgDir ? changelogTopSection(pkgDir) : null
-  const notesFile = notes
-    ? join(tempDir, `${tag.replace(/[^a-zA-Z0-9._-]/g, '_')}.md`)
-    : null
-  if (notesFile && notes) {
-    await Bun.write(notesFile, notes)
+  const notesFile =
+    notes !== null
+      ? join(tempDir, `${tag.replace(/[^a-zA-Z0-9._-]/g, '_')}.md`)
+      : null
+  if (notesFile) {
+    await Bun.write(notesFile, notes ?? '')
   }
 
   const releaseExists = commandSucceeds(['gh', 'release', 'view', tag])
@@ -123,7 +126,7 @@ for (const tag of tags) {
     )
     args.push('--generate-notes')
   }
-  if (tag.includes('-')) {
+  if (version.includes('-')) {
     args.push('--prerelease')
   }
   run(args)

--- a/.github/scripts/create-github-releases.ts
+++ b/.github/scripts/create-github-releases.ts
@@ -1,0 +1,130 @@
+#!/usr/bin/env bun
+// Create or update GitHub Releases for all Nx release tags at HEAD.
+//
+// Usage: bun .github/scripts/create-github-releases.ts
+
+import { existsSync, mkdtempSync, readdirSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const run = (command: string[], options?: { quiet?: boolean }): string => {
+  const result = Bun.spawnSync(command, {
+    stdout: options?.quiet ? 'pipe' : 'inherit',
+    stderr: options?.quiet ? 'pipe' : 'inherit',
+  })
+  if (result.exitCode !== 0) {
+    const output = `${result.stdout.toString()}${result.stderr.toString()}`
+    if (output) {
+      Bun.stderr.write(output)
+    }
+    throw new Error(`Command failed: ${command.join(' ')}`)
+  }
+  return result.stdout.toString().trim()
+}
+
+const commandSucceeds = (command: string[]): boolean => {
+  const result = Bun.spawnSync(command, { stdout: 'ignore', stderr: 'ignore' })
+  return result.exitCode === 0
+}
+
+type ProjectJson = {
+  name?: unknown
+}
+
+type PackageJson = {
+  name?: unknown
+}
+
+const readJson = <T>(path: string): T =>
+  JSON.parse(readFileSync(path, 'utf8')) as T
+
+const resolvePackageDir = (project: string): string | null => {
+  for (const name of readdirSync('packages')) {
+    const dir = join('packages', name)
+    const projectPath = join(dir, 'project.json')
+    if (existsSync(projectPath)) {
+      const projectJson = readJson<ProjectJson>(projectPath)
+      if (projectJson.name === project) {
+        return dir
+      }
+    }
+
+    const packagePath = join(dir, 'package.json')
+    if (existsSync(packagePath)) {
+      const packageJson = readJson<PackageJson>(packagePath)
+      if (packageJson.name === project) {
+        return dir
+      }
+    }
+  }
+  return null
+}
+
+const changelogTopSection = (pkgDir: string): string | null => {
+  const changelogPath = join(pkgDir, 'CHANGELOG.md')
+  if (!existsSync(changelogPath)) {
+    return null
+  }
+
+  const lines = readFileSync(changelogPath, 'utf8').split('\n')
+  const body: string[] = []
+  let seenHeading = false
+  for (const line of lines) {
+    if (line.startsWith('## ')) {
+      if (seenHeading) {
+        break
+      }
+      seenHeading = true
+      continue
+    }
+    if (seenHeading) {
+      body.push(line)
+    }
+  }
+
+  return body.join('\n').trim()
+}
+
+const sha = run(['git', 'rev-parse', 'HEAD'], { quiet: true })
+const tags = run(['git', 'tag', '--points-at', 'HEAD'], { quiet: true })
+  .split('\n')
+  .filter(Boolean)
+const tempDir = mkdtempSync(join(tmpdir(), 'github-releases-'))
+
+for (const tag of tags) {
+  const project = tag.replace(/@[^@]+$/, '')
+  const pkgDir = resolvePackageDir(project)
+  const notes = pkgDir ? changelogTopSection(pkgDir) : null
+  const notesFile = notes
+    ? join(tempDir, `${tag.replace(/[^a-zA-Z0-9._-]/g, '_')}.md`)
+    : null
+  if (notesFile && notes) {
+    await Bun.write(notesFile, notes)
+  }
+
+  const releaseExists = commandSucceeds(['gh', 'release', 'view', tag])
+  if (releaseExists) {
+    console.log(`Updating existing GitHub Release for ${tag}`)
+    const args = ['gh', 'release', 'edit', tag, '--title', tag]
+    if (notesFile) {
+      args.push('--notes-file', notesFile)
+    }
+    run(args)
+    continue
+  }
+
+  console.log(`Creating GitHub Release for ${tag}`)
+  const args = ['gh', 'release', 'create', tag, '--title', tag, '--target', sha]
+  if (notesFile) {
+    args.push('--notes-file', notesFile)
+  } else {
+    console.log(
+      `No CHANGELOG.md found for ${project}; using auto-generated notes.`,
+    )
+    args.push('--generate-notes')
+  }
+  if (tag.includes('-')) {
+    args.push('--prerelease')
+  }
+  run(args)
+}

--- a/.github/scripts/publish-npm-packages.ts
+++ b/.github/scripts/publish-npm-packages.ts
@@ -1,0 +1,71 @@
+#!/usr/bin/env bun
+// Build, verify, and publish npm packages for all TypeScript release tags at HEAD.
+//
+// Usage: bun .github/scripts/publish-npm-packages.ts
+
+const run = (command: string[]) => {
+  const result = Bun.spawnSync(command, {
+    stdout: 'inherit',
+    stderr: 'inherit',
+  })
+  if (result.exitCode !== 0) {
+    throw new Error(`Command failed: ${command.join(' ')}`)
+  }
+}
+
+const output = (command: string[]): string => {
+  const result = Bun.spawnSync(command, { stdout: 'pipe', stderr: 'inherit' })
+  if (result.exitCode !== 0) {
+    throw new Error(`Command failed: ${command.join(' ')}`)
+  }
+  return result.stdout.toString().trim()
+}
+
+const isNpmReleaseProject = (project: string): boolean =>
+  project === 'niivue' || project.startsWith('nv-')
+
+const tags = output(['git', 'tag', '--points-at', 'HEAD'])
+  .split('\n')
+  .filter(Boolean)
+
+for (const tag of tags) {
+  const atIndex = tag.lastIndexOf('@')
+  if (atIndex < 1) {
+    continue
+  }
+
+  const project = tag.slice(0, atIndex)
+  const version = tag.slice(atIndex + 1)
+
+  if (!isNpmReleaseProject(project)) {
+    continue
+  }
+
+  const npmTag = version.includes('-') ? 'next' : 'latest'
+
+  // `nx release publish --projects ...` intentionally excludes task
+  // dependencies for filtered publishes, so targetDefaults on
+  // nx-release-publish will not run `build` here. Run the project's Nx build
+  // target explicitly so cached outputs are restored (or the package is built)
+  // before npm packs the `files` allowlist.
+  console.log(`Building ${project} before npm publish`)
+  run(['bunx', 'nx', 'run', `${project}:build`])
+
+  console.log(`Verifying built package files for ${project}`)
+  run(['bun', '.github/scripts/verify-built-package.ts', project])
+
+  console.log(
+    `Publishing ${project}@${version} to npm with dist-tag '${npmTag}'`,
+  )
+  run([
+    'bunx',
+    'nx',
+    'release',
+    'publish',
+    '--projects',
+    project,
+    '--tag',
+    npmTag,
+    '--verbose',
+  ])
+}

--- a/.github/scripts/push-release-commit.ts
+++ b/.github/scripts/push-release-commit.ts
@@ -1,0 +1,16 @@
+#!/usr/bin/env bun
+// Push the release commit and tags back to main.
+//
+// Usage: bun .github/scripts/push-release-commit.ts
+
+const result = Bun.spawnSync(
+  ['git', 'push', '--follow-tags', 'origin', 'HEAD:main'],
+  {
+    stdout: 'inherit',
+    stderr: 'inherit',
+  },
+)
+
+if (result.exitCode !== 0) {
+  throw new Error('Failed to push release commit and tags')
+}

--- a/.github/scripts/run-typescript-release.ts
+++ b/.github/scripts/run-typescript-release.ts
@@ -33,6 +33,14 @@ if (!isDryRun) {
   releaseArgs.push('--verbose')
 }
 
+if (!isDryRun) {
+  const result = Bun.spawnSync(['bunx', ...releaseArgs], {
+    stdout: 'inherit',
+    stderr: 'inherit',
+  })
+  process.exit(result.exitCode)
+}
+
 const result = Bun.spawnSync(['bunx', ...releaseArgs], {
   stdout: 'pipe',
   stderr: 'pipe',
@@ -40,10 +48,6 @@ const result = Bun.spawnSync(['bunx', ...releaseArgs], {
 
 const output = `${result.stdout.toString()}${result.stderr.toString()}`
 Bun.write(Bun.stdout, output)
-
-if (!isDryRun) {
-  process.exit(result.exitCode)
-}
 
 const cleanOutput = stripAnsi(output)
 const summaryPath = process.env.GITHUB_STEP_SUMMARY

--- a/.github/scripts/run-typescript-release.ts
+++ b/.github/scripts/run-typescript-release.ts
@@ -1,0 +1,89 @@
+#!/usr/bin/env bun
+// Run the TypeScript Nx release flow. In dry-run mode, append a compact
+// release summary to GITHUB_STEP_SUMMARY.
+//
+// Usage: bun .github/scripts/run-typescript-release.ts [--rc] [--dry-run]
+
+import {
+  appendFileSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const args = new Set(Bun.argv.slice(2))
+const isRc = args.has('--rc')
+const isDryRun = args.has('--dry-run')
+
+const ESC = String.fromCharCode(27)
+const ansiPattern = new RegExp(`${ESC}\\[[0-9;?]*[ -/]*[@-~]`, 'g')
+const stripAnsi = (value: string): string => value.replace(ansiPattern, '')
+
+const releaseArgs = ['nx', 'release', '--groups', 'typescript']
+if (isRc) {
+  releaseArgs.push('--preid', 'rc')
+}
+if (isDryRun) {
+  releaseArgs.push('--dry-run')
+}
+releaseArgs.push('--skip-publish')
+if (!isDryRun) {
+  releaseArgs.push('--verbose')
+}
+
+const result = Bun.spawnSync(['bunx', ...releaseArgs], {
+  stdout: 'pipe',
+  stderr: 'pipe',
+})
+
+const output = `${result.stdout.toString()}${result.stderr.toString()}`
+Bun.write(Bun.stdout, output)
+
+if (!isDryRun) {
+  process.exit(result.exitCode)
+}
+
+const cleanOutput = stripAnsi(output)
+const summaryPath = process.env.GITHUB_STEP_SUMMARY
+if (summaryPath) {
+  const lines = ['## Nx Release Dry Run', '']
+
+  if (result.exitCode !== 0) {
+    const tempDir = mkdtempSync(join(tmpdir(), 'nx-release-'))
+    const cleanLog = join(tempDir, 'dry-run.log')
+    writeFileSync(cleanLog, cleanOutput)
+    const tail = readFileSync(cleanLog, 'utf8')
+      .split('\n')
+      .slice(-80)
+      .join('\n')
+    lines.push(`Nx release dry run failed with exit code ${result.exitCode}.`)
+    lines.push('', '```', tail, '```')
+  } else {
+    lines.push('| Project | Version | npm dist-tag | GitHub release |')
+    lines.push('| --- | --- | --- | --- |')
+
+    const releases = [
+      ...cleanOutput.matchAll(/- project: ([^ ]+) ([0-9][^ ]*)/g),
+    ]
+    if (releases.length === 0) {
+      lines.push('| None | None | None | None |')
+    } else {
+      for (const release of releases) {
+        const project = release[1]
+        const version = release[2]
+        const isPrerelease = version.includes('-')
+        lines.push(
+          `| \`${project}\` | \`${version}\` | \`${
+            isPrerelease ? 'next' : 'latest'
+          }\` | \`${isPrerelease ? 'prerelease' : 'release'}\` |`,
+        )
+      }
+    }
+  }
+
+  appendFileSync(summaryPath, `${lines.join('\n')}\n`)
+}
+
+process.exit(result.exitCode)

--- a/.github/scripts/verify-built-package.ts
+++ b/.github/scripts/verify-built-package.ts
@@ -1,0 +1,126 @@
+#!/usr/bin/env bun
+// Verify that an npm package has its built files before publishing.
+//
+// Usage: bun .github/scripts/verify-built-package.ts <nx-project-name>
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+const project = Bun.argv[2]
+if (!project) {
+  Bun.stderr.write('usage: verify-built-package.ts <nx-project-name>\n')
+  process.exit(2)
+}
+
+type ProjectInfo = {
+  root: string
+}
+
+type PackageJson = {
+  name?: string
+  files?: unknown
+  main?: unknown
+  module?: unknown
+  types?: unknown
+  exports?: unknown
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null
+
+const parseProjectInfo = (value: unknown): ProjectInfo => {
+  if (!isRecord(value) || typeof value.root !== 'string') {
+    throw new Error(`Could not resolve Nx project root for ${project}`)
+  }
+  return { root: value.root }
+}
+
+const parsePackageJson = (value: unknown): PackageJson => {
+  if (!isRecord(value)) {
+    throw new Error('package.json did not contain an object')
+  }
+  return value
+}
+
+const projectJson = execFileSync(
+  'bunx',
+  ['nx', 'show', 'project', project, '--json'],
+  { encoding: 'utf8' },
+)
+const { root: pkgDir } = parseProjectInfo(JSON.parse(projectJson))
+const pkgPath = join(pkgDir, 'package.json')
+const pkg = parsePackageJson(JSON.parse(readFileSync(pkgPath, 'utf8')))
+const packageName = typeof pkg.name === 'string' ? pkg.name : project
+const missing: string[] = []
+
+const existsWithContent = (relativePath: string): boolean => {
+  const absolutePath = join(pkgDir, relativePath.replace(/^\.\//, ''))
+  if (!existsSync(absolutePath)) {
+    return false
+  }
+
+  const stat = statSync(absolutePath)
+  if (stat.isFile()) {
+    return stat.size > 0
+  }
+  if (!stat.isDirectory()) {
+    return true
+  }
+
+  const entries = readdirSync(absolutePath, {
+    recursive: true,
+    withFileTypes: true,
+  })
+  return entries.some((entry) => entry.isFile())
+}
+
+const verifyPath = (label: string, value: unknown) => {
+  if (
+    typeof value === 'string' &&
+    value.startsWith('./') &&
+    !existsWithContent(value)
+  ) {
+    missing.push(`${label}: ${value}`)
+  }
+}
+
+if (Array.isArray(pkg.files)) {
+  for (const entry of pkg.files) {
+    if (
+      typeof entry === 'string' &&
+      !entry.startsWith('!') &&
+      !existsWithContent(entry)
+    ) {
+      missing.push(`files entry: ${entry}`)
+    }
+  }
+}
+
+verifyPath('main', pkg.main)
+verifyPath('module', pkg.module)
+verifyPath('types', pkg.types)
+
+const verifyExports = (value: unknown, label: string) => {
+  if (typeof value === 'string') {
+    verifyPath(label, value)
+    return
+  }
+  if (!isRecord(value)) {
+    return
+  }
+  for (const [key, child] of Object.entries(value)) {
+    verifyExports(child, `${label}.${key}`)
+  }
+}
+verifyExports(pkg.exports, 'exports')
+
+if (missing.length > 0) {
+  Bun.stderr.write(`Package ${packageName} is missing built files:\n`)
+  for (const item of missing) {
+    Bun.stderr.write(`- ${item}\n`)
+  }
+  process.exit(1)
+}
+
+Bun.write(Bun.stdout, `Package ${packageName} built files verified\n`)

--- a/.github/scripts/verify-built-package.ts
+++ b/.github/scripts/verify-built-package.ts
@@ -101,6 +101,16 @@ verifyPath('main', pkg.main)
 verifyPath('module', pkg.module)
 verifyPath('types', pkg.types)
 
+const exportLabel = (label: string, key: string): string => {
+  if (key === '.') {
+    return label
+  }
+  if (key.startsWith('./')) {
+    return `${label}["${key}"]`
+  }
+  return `${label}.${key}`
+}
+
 const verifyExports = (value: unknown, label: string) => {
   if (typeof value === 'string') {
     verifyPath(label, value)
@@ -110,7 +120,7 @@ const verifyExports = (value: unknown, label: string) => {
     return
   }
   for (const [key, child] of Object.entries(value)) {
-    verifyExports(child, `${label}.${key}`)
+    verifyExports(child, exportLabel(label, key))
   }
 }
 verifyExports(pkg.exports, 'exports')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,77 +49,25 @@ jobs:
       - name: Configure git identity
         # Uses the official github-actions[bot] noreply address (user id 41898282).
         # This attributes release commits to the bot in the GitHub UI with its avatar.
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        run: bun .github/scripts/configure-release-git.ts
 
       - name: Release (dry run)
         if: ${{ inputs.dry_run }}
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
-        run: |
-          set +e
-          log_file=$(mktemp)
-          clean_log=$(mktemp)
-
-          if [ "${{ inputs.rc }}" = "true" ]; then
-            bunx nx release --groups typescript --preid rc --dry-run --skip-publish > "$log_file" 2>&1
-          else
-            bunx nx release --groups typescript --dry-run --skip-publish > "$log_file" 2>&1
-          fi
-          status=$?
-          cat "$log_file"
-
-          # Strip ANSI escape sequences before parsing Nx output.
-          perl -pe 's/\e\[[0-9;?]*[ -\/]*[@-~]//g' "$log_file" > "$clean_log"
-
-          {
-            echo '## Nx Release Dry Run'
-            echo ''
-            if [ "$status" -ne 0 ]; then
-              echo "Nx release dry run failed with exit code $status."
-              echo ''
-              echo '```'
-              tail -n 80 "$clean_log"
-              echo '```'
-            else
-              echo '| Project | Version | npm dist-tag | GitHub release |'
-              echo '| --- | --- | --- | --- |'
-              releases=$(sed -nE 's/.*- project: ([^ ]+) ([0-9][^ ]*).*/\1 \2/p' "$clean_log")
-              if [ -z "$releases" ]; then
-                echo '| None | None | None | None |'
-              else
-                while read -r project version; do
-                  npm_tag='latest'
-                  github_release='release'
-                  if [[ "$version" == *-* ]]; then
-                    npm_tag='next'
-                    github_release='prerelease'
-                  fi
-                  echo "| \`$project\` | \`$version\` | \`$npm_tag\` | \`$github_release\` |"
-                done <<< "$releases"
-              fi
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
-
-          exit "$status"
+        run: bun .github/scripts/run-typescript-release.ts --dry-run ${{ inputs.rc && '--rc' || '' }}
 
       - name: Release
         if: ${{ !inputs.dry_run }}
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
-        run: |
-          if [ "${{ inputs.rc }}" = "true" ]; then
-            bunx nx release --groups typescript --preid rc --skip-publish --verbose
-          else
-            bunx nx release --groups typescript --skip-publish --verbose
-          fi
+        run: bun .github/scripts/run-typescript-release.ts ${{ inputs.rc && '--rc' || '' }}
 
       - name: Push release commit and tags
         if: ${{ !inputs.dry_run }}
-        run: git push --follow-tags origin HEAD:main
+        run: bun .github/scripts/push-release-commit.ts
 
       - name: Create GitHub Releases
         if: ${{ !inputs.dry_run }}
@@ -128,71 +76,7 @@ jobs:
         # For each tag Nx created at HEAD, create (or update, if rerunning) a
         # matching GitHub Release whose body is the project's freshly-written
         # CHANGELOG.md top section.
-        run: |
-          set -euo pipefail
-          sha=$(git rev-parse HEAD)
-          for tag in $(git tag --points-at HEAD); do
-            # Nx tag format is "{projectName}@{version}"; projectName is the
-            # Nx project name (e.g. "niivue"), which may differ from the
-            # published package.json "name" (e.g. "@niivue/niivue").
-            project="${tag%@*}"
-
-            # Resolve the project directory. Match project.json "name" first
-            # (authoritative for Nx tags), then fall back to package.json
-            # "name" for packages without a project.json entry.
-            pkg_dir=""
-            for d in packages/*; do
-              if [ -f "$d/project.json" ]; then
-                nx_name=$(node -p "require('./$d/project.json').name || ''")
-                if [ "$nx_name" = "$project" ]; then
-                  pkg_dir="$d"
-                  break
-                fi
-              fi
-              if [ -f "$d/package.json" ]; then
-                pkg_name=$(node -p "require('./$d/package.json').name || ''")
-                if [ "$pkg_name" = "$project" ]; then
-                  pkg_dir="$d"
-                  break
-                fi
-              fi
-            done
-
-            # Prefer the package's CHANGELOG top section as the release body.
-            notes_file=""
-            if [ -n "$pkg_dir" ] && [ -f "$pkg_dir/CHANGELOG.md" ]; then
-              notes_file=$(mktemp)
-              awk '/^## /{if(seen)exit; seen=1; next} seen' \
-                "$pkg_dir/CHANGELOG.md" > "$notes_file"
-            fi
-
-            if gh release view "$tag" >/dev/null 2>&1; then
-              echo "Updating existing GitHub Release for $tag"
-              if [ -n "$notes_file" ]; then
-                # `gh release edit` has no --generate-notes, so only update
-                # notes when we have a CHANGELOG-derived body.
-                gh release edit "$tag" --title "$tag" --notes-file "$notes_file"
-              else
-                gh release edit "$tag" --title "$tag"
-              fi
-            else
-              echo "Creating GitHub Release for $tag"
-              if [ -n "$notes_file" ]; then
-                gh_args=(--title "$tag" --target "$sha" --notes-file "$notes_file")
-                if [[ "$tag" == *-* ]]; then
-                  gh_args+=(--prerelease)
-                fi
-                gh release create "$tag" "${gh_args[@]}"
-              else
-                echo "No CHANGELOG.md found for $project; using auto-generated notes."
-                gh_args=(--title "$tag" --target "$sha" --generate-notes)
-                if [[ "$tag" == *-* ]]; then
-                  gh_args+=(--prerelease)
-                fi
-                gh release create "$tag" "${gh_args[@]}"
-              fi
-            fi
-          done
+        run: bun .github/scripts/create-github-releases.ts
 
       - name: Publish to npm
         if: ${{ !inputs.dry_run }}
@@ -200,26 +84,4 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
-        run: |
-          set -euo pipefail
-          for tag in $(git tag --points-at HEAD); do
-            project="${tag%@*}"
-            version="${tag##*@}"
-
-            # Only publish npm packages from the TypeScript release group.
-            case "$project" in
-              niivue|nv-*) ;;
-              *) continue ;;
-            esac
-
-            npm_tag="latest"
-            if [[ "$version" == *-* ]]; then
-              npm_tag="next"
-            fi
-
-            echo "Publishing $project@$version to npm with dist-tag '$npm_tag'"
-            bunx nx release publish \
-              --projects "$project" \
-              --tag "$npm_tag" \
-              --verbose
-          done
+        run: bun .github/scripts/publish-npm-packages.ts

--- a/nx.json
+++ b/nx.json
@@ -32,7 +32,12 @@
       "cache": true
     },
     "nx-release-publish": {
-      "dependsOn": ["build"]
+      "dependsOn": ["build"],
+      "cache": false
+    },
+    "@nx/js:release-publish": {
+      "dependsOn": ["build"],
+      "cache": false
     }
   },
   "release": {

--- a/packages/niivue/README.md
+++ b/packages/niivue/README.md
@@ -34,7 +34,7 @@ Add a `<canvas>` to your page and attach NiiVueGPU to it:
 ```html
 <canvas id="gl1"></canvas>
 <script type="module">
-  import NiiVue from 'niivuegpu'
+  import NiiVue from '@niivue/niivue'
 
   const nv = new NiiVue()
   await nv.attachToCanvas(document.getElementById('gl1'))
@@ -47,14 +47,14 @@ Add a `<canvas>` to your page and attach NiiVueGPU to it:
 By default, `niivuegpu` includes both backends (WebGPU + WebGL2 fallback):
 
 ```js
-import NiiVue from 'niivuegpu'
+import NiiVue from '@niivue/niivue'
 ```
 
 You can also import backend-only builds to reduce package size:
 
 ```js
-import NiiVueWebGPU from 'niivuegpu/webgpu' // WebGPU-only
-import NiiVueWebGL2 from 'niivuegpu/webgl2' // WebGL2-only
+import NiiVueWebGPU from '@niivue/niivue/webgpu' // WebGPU-only
+import NiiVueWebGL2 from '@niivue/niivue/webgl2' // WebGL2-only
 ```
 
 In backend-only builds, selecting the missing backend throws an explicit error.


### PR DESCRIPTION
Link to any related issues present on GitHub or Linear.

None found.

## Context & Motivation

- npm releases could be published without built package files when `dist` was missing.
- The release workflow had large inline bash/JavaScript blocks that were hard to validate and reuse.

## Changes

- Build each npm package with Nx before publishing it.
- Verify declared package output paths exist before publish.
- Move release workflow logic into Bun scripts under `.github/scripts/`.
- Mark Nx release publish targets as non-cacheable and retain build dependencies in target defaults.

### Interface Delta

- CI workflow behavior changes only; no public package API changes.

## Alternatives Explored

- Relying only on `nx-release-publish` target dependencies, but filtered `nx release publish --projects` excludes task dependencies.

## Validation

- `bunx biome check .github/scripts/run-typescript-release.ts .github/scripts/create-github-releases.ts .github/scripts/publish-npm-packages.ts .github/scripts/configure-release-git.ts .github/scripts/verify-built-package.ts .github/scripts/push-release-commit.ts` passed.
- `bun .github/scripts/verify-built-package.ts niivue` passed.
- `bun .github/scripts/run-typescript-release.ts --dry-run --rc` passed.
