### PR TITLE
Fix GitHub release script output handling

### DIFF
--- a/.github/scripts/create-github-releases.ts
+++ b/.github/scripts/create-github-releases.ts
@@ -12,14 +12,16 @@ const run = (command: string[], options?: { quiet?: boolean }): string => {
     stdout: options?.quiet ? 'pipe' : 'inherit',
     stderr: options?.quiet ? 'pipe' : 'inherit',
   })
+  const stdout = result.stdout?.toString() ?? ''
+  const stderr = result.stderr?.toString() ?? ''
   if (result.exitCode !== 0) {
-    const output = `${result.stdout.toString()}${result.stderr.toString()}`
+    const output = `${stdout}${stderr}`
     if (output) {
       Bun.stderr.write(output)
     }
     throw new Error(`Command failed: ${command.join(' ')}`)
   }
-  return result.stdout.toString().trim()
+  return stdout.trim()
 }
 
 const commandSucceeds = (command: string[]): boolean => {


### PR DESCRIPTION
Link to any related issues present on GitHub or Linear.

None found.

## Context & Motivation

- The release workflow failed after creating a GitHub Release because `Bun.spawnSync` has no `stdout` buffer when stdio is inherited.

## Changes

- Safely handle optional `stdout` and `stderr` in `.github/scripts/create-github-releases.ts`.
- Keep returning captured output for quiet commands while allowing inherited-stdio commands to return an empty string.

### Interface Delta

None.

## Alternatives Explored

None.

## Validation

- `bunx biome check .github/scripts/create-github-releases.ts` passed.
