### PR TITLE
fix(niivue): 4D wheel scroll, frame-aware contrast, DPR-change resize

### DIFF
--- a/packages/niivue/src/NVControlBase.ts
+++ b/packages/niivue/src/NVControlBase.ts
@@ -183,6 +183,10 @@ export default class NiiVueGPU extends EventTarget {
   model: NVModel
   view: ViewBackend | null = null
   resizeObserver: ResizeObserver | null
+  _dprMediaQuery: {
+    mql: MediaQueryList
+    handler: (event: MediaQueryListEvent) => void
+  } | null = null
   _eventListeners: Record<string, EventHandler | null>
   private _updating = false
   private _pendingUpdate = false
@@ -2880,6 +2884,13 @@ export default class NiiVueGPU extends EventTarget {
     if (this.resizeObserver) {
       this.resizeObserver.disconnect()
       this.resizeObserver = null
+    }
+    if (this._dprMediaQuery) {
+      this._dprMediaQuery.mql.removeEventListener(
+        'change',
+        this._dprMediaQuery.handler,
+      )
+      this._dprMediaQuery = null
     }
     if (this.view) this.view.destroy()
     this._viewLifecycle.unregister?.(this)

--- a/packages/niivue/src/control/dragModes.ts
+++ b/packages/niivue/src/control/dragModes.ts
@@ -72,6 +72,9 @@ export function calculateNewRange(
   const step = vol.img2RASstep
   const slope = vol.hdr.scl_slope
   const inter = vol.hdr.scl_inter
+  // For 4D volumes, scope the search to the currently-displayed frame so
+  // contrast reflects the visible volume, not always frame 0.
+  const frameOffset = (vol.frame4D ?? 0) * vol.nVox3D
 
   let lo = Number.MAX_VALUE
   let hi = -Number.MAX_VALUE
@@ -80,7 +83,7 @@ export function calculateNewRange(
     for (let y = yMin; y <= yMax; y++) {
       const yzi = zi + start[1] + y * step[1]
       for (let x = xMin; x <= xMax; x++) {
-        const idx = yzi + start[0] + x * step[0]
+        const idx = frameOffset + yzi + start[0] + x * step[0]
         if (idx >= 0 && idx < imgData.length) {
           const raw = imgData[idx]
           if (raw < lo) lo = raw

--- a/packages/niivue/src/control/interactions.ts
+++ b/packages/niivue/src/control/interactions.ts
@@ -1112,6 +1112,16 @@ export function initInteraction(ctrl: NiiVueGPU): void {
     setNextActionTag('wheel')
     evt.preventDefault()
     const [px, py] = wheelHit
+    // Wheel over the 4D timeline graph: step to previous/next frame
+    const graphLayout = ctrl.view?.graphLayout as GraphLayout | null
+    if (graphLayout && graphHitTest(px, py, graphLayout)) {
+      const vol = ctrl.volumes[0]
+      if (vol?.id && (vol.nFrame4D ?? 1) > 1) {
+        const delta = evt.deltaY > 0 ? 1 : -1
+        ctrl.setFrame4D(vol.id, (vol.frame4D ?? 0) + delta)
+      }
+      return
+    }
     const hit = ctrl.view?.hitTest(px, py)
     if (!hit) return
     // 2D slice: zoom when pan/slicer3D mode, otherwise step crosshair
@@ -1311,7 +1321,7 @@ export function setupResizeHandler(ctrl: NiiVueGPU): void {
   if (ctrl.resizeObserver) {
     ctrl.resizeObserver.disconnect()
   }
-  ctrl.resizeObserver = new ResizeObserver(() => {
+  const onResize = () => {
     setNextActionTag('resize')
     ctrl.view?.resize()
     if (ctrl.canvas) {
@@ -1320,13 +1330,43 @@ export function setupResizeHandler(ctrl: NiiVueGPU): void {
         height: ctrl.canvas.clientHeight,
       })
     }
-  })
+  }
+  ctrl.resizeObserver = new ResizeObserver(onResize)
   try {
     ctrl.resizeObserver.observe(ctrl.canvas as HTMLCanvasElement, {
       box: 'device-pixel-content-box',
     })
   } catch {
     ctrl.resizeObserver.observe(ctrl.canvas as HTMLCanvasElement)
+  }
+  // Track devicePixelRatio changes (e.g., window moved between displays
+  // with different DPR). matchMedia('(resolution: ...)') fires once when
+  // the DPR crosses the queried value; re-arm with the new DPR each time.
+  if (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function'
+  ) {
+    const armDprListener = () => {
+      const mql = window.matchMedia(
+        `(resolution: ${window.devicePixelRatio}dppx)`,
+      )
+      const handler = () => {
+        mql.removeEventListener('change', handler)
+        ctrl._dprMediaQuery = null
+        onResize()
+        armDprListener()
+      }
+      mql.addEventListener('change', handler)
+      ctrl._dprMediaQuery = { mql, handler }
+    }
+    if (ctrl._dprMediaQuery) {
+      ctrl._dprMediaQuery.mql.removeEventListener(
+        'change',
+        ctrl._dprMediaQuery.handler,
+      )
+      ctrl._dprMediaQuery = null
+    }
+    armDprListener()
   }
 }
 


### PR DESCRIPTION
Resolves #43.

## Summary

Three independent fixes to the core viewer, surfaced by `examples/vox.4d.html` but applying everywhere:

- **Wheel over the timeline graph steps 4D frames.** The graph previously consumed click events for frame selection but ignored wheel events. The wheel handler now runs a graph hit-test before the existing slice/render dispatch and calls `setFrame4D` when over the graph (including the backing area). 2D-slice depth scroll and 3D-render zoom/clip behavior are unchanged.
- **Contrast drag uses the currently displayed 4D frame.** `calculateNewRange` was scanning intensities from index 0, so the right-button contrast box always optimized for frame 0 regardless of which volume was on screen. It now adds `frame4D * nVox3D` to the linear index so the scan is scoped to the visible frame.
- **DPR change on display move triggers a real resize.** The existing `ResizeObserver` with `device-pixel-content-box` fires on DPR change in Chromium but not in Safari (no support) or older Firefox (silent fallback to CSS content-box), so dragging a window between displays with different DPR was leaving the canvas backing store mis-sized and breaking pointer-to-canvas hit-testing. Added a `matchMedia('(resolution: Xdppx)')` listener that re-arms on each DPR change and triggers `view.resize()`. The handle lives on `_dprMediaQuery` and is torn down in `destroy()`.

## Test plan

- [x] `bunx nx lint niivue`
- [x] `bunx nx typecheck niivue`
- [x] `bunx nx test niivue` (238 pass)
- [x] `bunx nx build niivue`
- [x] Manual: in `examples/vox.4d.html`, scroll wheel over the timeline graph and confirm frames advance
- [x] Manual: in `examples/vox.4d.html`, advance to a later frame, right-drag a contrast box, confirm the auto-cal range reflects that frame's intensities (not frame 0)
- [x] Manual: open any example in a window, drag between two displays with different DPRs, confirm the canvas re-sizes and crosshair placement remains accurate after the move