### PR TITLE
feat(pages): publish the nv-ext-mrs (MRSI) demo to GitHub Pages

### DIFF
--- a/.github/build-pages.sh
+++ b/.github/build-pages.sh
@@ -24,6 +24,7 @@ APPS=(
   demo-ext-save-html
   demo-ext-dcm2niix
   demo-ext-niimath
+  demo-ext-mrs
   demo-nv-web-component
 )
 

--- a/.github/pages/index.html
+++ b/.github/pages/index.html
@@ -168,6 +168,14 @@
             >niimath (WASM)</a
           >
         </li>
+        <li>
+          <a
+            href="./demo-ext-mrs/mrsi.html"
+            target="_blank"
+            rel="noopener noreferrer"
+            >MR Spectroscopy (MRSI)</a
+          >
+        </li>
       </ul>
     </main>
   </body>

--- a/apps/demo-ext-mrs/src/main.ts
+++ b/apps/demo-ext-mrs/src/main.ts
@@ -16,8 +16,9 @@ import NiiVue, { SLICE_TYPE } from '@niivue/niivue'
 import { MrsScene } from '@niivue/nv-ext-mrs'
 
 // Data lives alongside the other signal fixtures in @niivue/dev-images
-// (images/signals/), served at /signals/.
-const DATA_BASE = '/signals'
+// (images/signals/), served at /signals/. Use full literal `/signals/...` URLs
+// (not a `${base}/file` concatenation) so the GitHub Pages build's URL-rewrite
+// plugin can prefix them with the shared images base (e.g. /mono/signals/...).
 const footer = document.getElementById('location') as HTMLElement
 
 function fail(msg: string, err?: unknown): void {
@@ -37,9 +38,9 @@ const scene = new MrsScene(nv)
 
 try {
   await scene.load({
-    anatomyUrl: `${DATA_BASE}/mrsi_T1.nii.gz`,
-    mrsiUrl: `${DATA_BASE}/mrsi.nii.gz`,
-    maskUrl: `${DATA_BASE}/mrsi_mask.nii.gz`,
+    anatomyUrl: '/signals/mrsi_T1.nii.gz',
+    mrsiUrl: '/signals/mrsi.nii.gz',
+    maskUrl: '/signals/mrsi_mask.nii.gz',
     mrsiColormap: 'warm',
     mrsiOpacity: 0.7,
   })


### PR DESCRIPTION
## Summary

The `nv-ext-mrs` (MR spectroscopic imaging) demo was built but never wired into the GitHub Pages deploy, so it was missing from the landing page at niivue.github.io/mono/. This adds it alongside the other extension demos.

## Changes

- **`.github/build-pages.sh`** — add `demo-ext-mrs` to the `APPS` build/copy list so it is built and assembled into `_site/demo-ext-mrs/`.
- **`.github/pages/index.html`** — add the "MR Spectroscopy (MRSI)" link under Extension Demos.
- **`apps/demo-ext-mrs/src/main.ts`** — load data via literal `"/signals/<file>"` URLs instead of a `` `${DATA_BASE}/<file>` `` concatenation. The Pages URL-rewrite plugin only matches a literal `"/signals/"` prefix, so the concatenated form left a bare `"/signals"` in the bundle that was **not** rewritten to the shared images base — the deployed demo would have 404'd its data (mrsi / T1 / mask).

## Verification

Production build confirmed (`BASE_PATH=/mono/`):
- the `demo-ext-mrs` bundle now requests `/mono/signals/mrsi.nii.gz`, `/mono/signals/mrsi_T1.nii.gz`, `/mono/signals/mrsi_mask.nii.gz`;
- the examples build emits those three files to the site root (`dist/signals/`), so the rewritten URLs resolve;
- `lint` + `typecheck` green for `demo-ext-mrs`.

Once merged, the `niivue-ghpages` workflow runs `build-pages.sh` and the MRSI demo appears on the live site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)