### PR TITLE
ci: add publish-from-tags recovery workflow

### DIFF
--- a/.github/scripts/publish-tags-to-npm.ts
+++ b/.github/scripts/publish-tags-to-npm.ts
@@ -59,6 +59,18 @@ const tags =
     ? explicit
     : output(['git', 'tag', '--points-at', 'HEAD']).split('\n').filter(Boolean)
 
+// Safety guard: workflow_dispatch can check out an arbitrary ref. Refuse to run
+// with npm credentials unless HEAD is contained in origin/main.
+run(['git', 'fetch', '--quiet', 'origin', 'main'])
+const onMain = Bun.spawnSync(
+  ['git', 'merge-base', '--is-ancestor', 'HEAD', 'origin/main'],
+  { stdout: 'ignore', stderr: 'inherit' },
+)
+if (onMain.exitCode !== 0) {
+  throw new Error(
+    'Ref at HEAD is not contained in origin/main; refusing to publish with npm credentials.',
+  )
+}
 if (explicit.length > 0) {
   const head = output(['git', 'rev-parse', 'HEAD'])
   for (const tag of explicit) {

--- a/.github/scripts/publish-tags-to-npm.ts
+++ b/.github/scripts/publish-tags-to-npm.ts
@@ -1,0 +1,133 @@
+#!/usr/bin/env bun
+// Publish npm packages for a set of existing git tags.
+//
+// Use this when `nx release` already ran (tags + GitHub Releases exist) but
+// the npm publish step did not complete — e.g. an expired NPM_TOKEN. It is
+// idempotent: tags whose `<project>@<version>` is already on the registry are
+// skipped, so reruns are safe.
+//
+// Usage:
+//   bun .github/scripts/publish-tags-to-npm.ts            # tags at HEAD
+//   bun .github/scripts/publish-tags-to-npm.ts <tag>...   # explicit tags
+
+import { readFileSync } from 'node:fs'
+
+const run = (command: string[]) => {
+  const result = Bun.spawnSync(command, {
+    stdout: 'inherit',
+    stderr: 'inherit',
+  })
+  if (result.exitCode !== 0) {
+    throw new Error(`Command failed: ${command.join(' ')}`)
+  }
+}
+
+const output = (command: string[]): string => {
+  const result = Bun.spawnSync(command, { stdout: 'pipe', stderr: 'inherit' })
+  if (result.exitCode !== 0) {
+    throw new Error(`Command failed: ${command.join(' ')}`)
+  }
+  return result.stdout.toString().trim()
+}
+
+const tryOutput = (command: string[]): string | null => {
+  const result = Bun.spawnSync(command, { stdout: 'pipe', stderr: 'pipe' })
+  if (result.exitCode !== 0) {
+    return null
+  }
+  return result.stdout.toString().trim()
+}
+
+const isNpmReleaseProject = (project: string): boolean =>
+  project === 'niivue' || project.startsWith('nv-')
+
+// Parse explicit tags from argv. Accept whitespace-, comma-, or
+// newline-separated input so the workflow_dispatch text box can be lenient.
+const explicit = Bun.argv
+  .slice(2)
+  .flatMap((arg) => arg.split(/[\s,]+/))
+  .map((tag) => tag.trim())
+  .filter(Boolean)
+
+const tags =
+  explicit.length > 0
+    ? explicit
+    : output(['git', 'tag', '--points-at', 'HEAD']).split('\n').filter(Boolean)
+
+if (tags.length === 0) {
+  console.log('No tags to publish.')
+  process.exit(0)
+}
+
+console.log(`Considering ${tags.length} tag(s):`)
+for (const tag of tags) {
+  console.log(`  - ${tag}`)
+}
+
+const summary: string[] = []
+
+for (const tag of tags) {
+  const atIndex = tag.lastIndexOf('@')
+  if (atIndex < 1) {
+    console.log(`Skipping ${tag} (not a project@version tag)`)
+    continue
+  }
+
+  const project = tag.slice(0, atIndex)
+  const version = tag.slice(atIndex + 1)
+
+  if (!isNpmReleaseProject(project)) {
+    console.log(`Skipping ${tag} (not an npm release project)`)
+    continue
+  }
+
+  // Resolve the npm package name from the project's package.json so the
+  // existence check works regardless of project-name vs. scoped-name mapping.
+  const projectInfo = JSON.parse(
+    output(['bunx', 'nx', 'show', 'project', project, '--json']),
+  ) as { root?: unknown }
+  if (typeof projectInfo.root !== 'string') {
+    throw new Error(`Could not resolve Nx project root for ${project}`)
+  }
+  const pkg = JSON.parse(
+    readFileSync(`${projectInfo.root}/package.json`, 'utf8'),
+  ) as { name?: unknown }
+  if (typeof pkg.name !== 'string') {
+    throw new Error(`Missing package.json "name" for ${project}`)
+  }
+  const pkgName = pkg.name
+
+  const existing = tryOutput(['npm', 'view', `${pkgName}@${version}`, 'version'])
+  if (existing && existing.trim() === version) {
+    console.log(`Skipping ${pkgName}@${version} (already on npm)`)
+    summary.push(`skipped ${pkgName}@${version} (already published)`)
+    continue
+  }
+
+  const npmTag = version.includes('-') ? 'next' : 'latest'
+
+  console.log(`Building ${project}`)
+  run(['bunx', 'nx', 'run', `${project}:build`])
+
+  console.log(`Verifying built package files for ${project}`)
+  run(['bun', '.github/scripts/verify-built-package.ts', project])
+
+  console.log(`Publishing ${pkgName}@${version} with dist-tag '${npmTag}'`)
+  run([
+    'bunx',
+    'nx',
+    'release',
+    'publish',
+    '--projects',
+    project,
+    '--tag',
+    npmTag,
+    '--verbose',
+  ])
+  summary.push(`published ${pkgName}@${version} (tag: ${npmTag})`)
+}
+
+console.log('\nSummary:')
+for (const line of summary) {
+  console.log(`  - ${line}`)
+}

--- a/.github/scripts/publish-tags-to-npm.ts
+++ b/.github/scripts/publish-tags-to-npm.ts
@@ -54,6 +54,17 @@ const tags =
     ? explicit
     : output(['git', 'tag', '--points-at', 'HEAD']).split('\n').filter(Boolean)
 
+if (explicit.length > 0) {
+  const head = output(['git', 'rev-parse', 'HEAD'])
+  for (const tag of explicit) {
+    const tagCommit = output(['git', 'rev-list', '-n', '1', tag])
+    if (tagCommit !== head) {
+      throw new Error(
+        `Tag ${tag} does not point at HEAD (${tagCommit} != ${head}). Check out the release commit for that tag before publishing.`,
+      )
+    }
+  }
+}
 if (tags.length === 0) {
   console.log('No tags to publish.')
   process.exit(0)

--- a/.github/scripts/publish-tags-to-npm.ts
+++ b/.github/scripts/publish-tags-to-npm.ts
@@ -102,12 +102,19 @@ for (const tag of tags) {
   }
   const pkg = JSON.parse(
     readFileSync(`${projectInfo.root}/package.json`, 'utf8'),
-  ) as { name?: unknown }
+  ) as { name?: unknown; version?: unknown }
   if (typeof pkg.name !== 'string') {
     throw new Error(`Missing package.json "name" for ${project}`)
   }
+  if (typeof pkg.version !== 'string') {
+    throw new Error(`Missing package.json "version" for ${project}`)
+  }
   const pkgName = pkg.name
-
+  if (pkg.version !== version) {
+    throw new Error(
+      `Tag ${tag} version (${version}) does not match ${pkgName} package.json version (${pkg.version}) at the checked-out ref.`,
+    )
+  }
   const existing = tryOutput(['npm', 'view', `${pkgName}@${version}`, 'version'])
   if (existing && existing.trim() === version) {
     console.log(`Skipping ${pkgName}@${version} (already on npm)`)

--- a/.github/scripts/publish-tags-to-npm.ts
+++ b/.github/scripts/publish-tags-to-npm.ts
@@ -33,7 +33,12 @@ const output = (command: string[]): string => {
 const tryOutput = (command: string[]): string | null => {
   const result = Bun.spawnSync(command, { stdout: 'pipe', stderr: 'pipe' })
   if (result.exitCode !== 0) {
-    return null
+    const err = result.stderr.toString()
+    // For `npm view <pkg>@<version> version`, E404 means the version is not published.
+    if (/\bE404\b/.test(err) || /is not in (this|the) registry/i.test(err)) {
+      return null
+    }
+    throw new Error(`Command failed: ${command.join(' ')}\n${err}`)
   }
   return result.stdout.toString().trim()
 }

--- a/.github/workflows/publish-from-tags.yml
+++ b/.github/workflows/publish-from-tags.yml
@@ -1,0 +1,57 @@
+name: Publish from tags
+
+# Recovery workflow for partially-failed releases. Use this when
+# `nx release` already created git tags and GitHub Releases but the npm
+# publish step did not complete (for example, an expired NPM_TOKEN).
+#
+# Idempotent: any tag whose <project>@<version> is already on the npm
+# registry is skipped, so it is safe to rerun.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to check out (branch, tag, or commit). Defaults to main, where the release commit lives."
+        type: string
+        default: main
+      tags:
+        description: "Tags to publish (comma-, space-, or newline-separated). Leave blank to publish all tags pointing at the checked-out commit."
+        type: string
+        default: ""
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish tags to npm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+          fetch-tags: true
+          lfs: true
+
+      - uses: oven-sh/setup-bun@v2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: "https://registry.npmjs.org"
+
+      - run: bun install
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
+          INPUT_TAGS: ${{ inputs.tags }}
+        run: bun .github/scripts/publish-tags-to-npm.ts $INPUT_TAGS

--- a/.github/workflows/publish-from-tags.yml
+++ b/.github/workflows/publish-from-tags.yml
@@ -31,6 +31,10 @@ jobs:
   publish:
     name: Publish tags to npm
     runs-on: ubuntu-latest
+    # workflow_dispatch can be triggered from any branch. Only allow running the
+    # publishing workflow definition from main to avoid exposing NPM_TOKEN to
+    # unreviewed code.
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/publish-from-tags.yml
+++ b/.github/workflows/publish-from-tags.yml
@@ -58,4 +58,4 @@ jobs:
           NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
           INPUT_TAGS: ${{ inputs.tags }}
-        run: bun .github/scripts/publish-tags-to-npm.ts $INPUT_TAGS
+        run: bun .github/scripts/publish-tags-to-npm.ts "$INPUT_TAGS"


### PR DESCRIPTION
Add a workflow_dispatch workflow and supporting script that publishes npm packages from existing git tags. Use when nx release has already created tags and GitHub Releases but the npm publish step did not complete (e.g. expired NPM_TOKEN).

The script is idempotent: tags whose <project>@<version> is already on the registry are skipped, so reruns are safe. Defaults publish all tags pointing at the checked-out commit (main HEAD after a release), and an optional input narrows to specific tags.