### PR TITLE
Export nii2volume, writeVolume, makeLabelLut for extensions

### DIFF
--- a/packages/niivue/src/index.ts
+++ b/packages/niivue/src/index.ts
@@ -124,5 +124,10 @@ export type {
 } from './volume/transforms'
 // Volume utilities for extensions
 export { extractVoxelFid, getImageDataRAS } from './volume/utils'
+// Volume construction/serialization for extensions building derived volumes
+// (e.g. wrapping segmentation labels into an overlay NVImage)
+export { nii2volume, writeVolume } from './volume/NVVolume'
+// Label colormap LUT builder for extensions producing label/atlas volumes
+export { makeLabelLut } from './cmap/NVCmaps'
 // Worker bridge for external transform packages
 export { NVWorker } from './workers/NVWorker'

--- a/packages/niivue/src/index.ts
+++ b/packages/niivue/src/index.ts
@@ -4,8 +4,10 @@
  * @packageDocumentation
  */
 
+// Label colormap LUT builder for extensions producing label/atlas volumes
+// biome-ignore lint/performance/noBarrelFile: package public API entry point
+export { makeLabelLut } from './cmap/NVCmaps'
 // Extension API
-// biome-ignore lint/performance/noBarrelFile: package entry point
 export { NVExtensionContext } from './extension/context'
 export type {
   BackgroundVolumeAccess,
@@ -114,6 +116,9 @@ export {
 } from './signal/processing'
 // MRSI (spatial spectroscopic imaging) volume helpers
 export { buildDerivedScalarVolume, isMrsiVolume } from './volume/mrsi'
+// Volume construction/serialization for extensions building derived volumes
+// (e.g. wrapping segmentation labels into an overlay NVImage)
+export { nii2volume, writeVolume } from './volume/NVVolume'
 // Transform types
 export type {
   OptionField,
@@ -124,10 +129,5 @@ export type {
 } from './volume/transforms'
 // Volume utilities for extensions
 export { extractVoxelFid, getImageDataRAS } from './volume/utils'
-// Volume construction/serialization for extensions building derived volumes
-// (e.g. wrapping segmentation labels into an overlay NVImage)
-export { nii2volume, writeVolume } from './volume/NVVolume'
-// Label colormap LUT builder for extensions producing label/atlas volumes
-export { makeLabelLut } from './cmap/NVCmaps'
 // Worker bridge for external transform packages
 export { NVWorker } from './workers/NVWorker'


### PR DESCRIPTION
## What

Re-export three volume/colormap primitives from the niivue package index:

- `nii2volume(hdr, img, name)` — build an `NVImage` from a NIfTI header + voxel array
- `writeVolume(...)` — serialize an `NVImage` back to NIfTI bytes
- `makeLabelLut(colormap)` — compile a label colormap LUT

## Why

These functions already exist in core (`volume/NVVolume.ts`, `cmap/NVCmaps.ts`) but are not surfaced through the package's public `index.ts`. Downstream extensions that build *derived* volumes — e.g. **brain2print**, which wraps WebGPU segmentation-model output labels into a colored overlay `NVImage` — currently have to fork niivue just to reach them.

They sit naturally alongside the extension utilities already exported here (`getImageDataRAS`, `NVWorker`). No implementation change; export-only.

Requested for inclusion in the next RC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)