### PR TITLE
feat(niivue): SLICE_TYPE.NONE — hide slices so the signal graph fills the canvas

### DIFF
--- a/packages/niivue/AGENTS.md
+++ b/packages/niivue/AGENTS.md
@@ -498,9 +498,18 @@ axis when the rate is unknown.
 **Rendering** (`view/NVGraph.ts`): the GPU graph was extended with a "signal mode"
 (multi-color Okabe-Ito series, legend, real/reversible/windowed x-axis) gated on a
 non-empty `series` field; the legacy 4D-volume graph path is unchanged. When the
-scene is signal-only (a signal but no volume/mesh) the plot fills the instance area
-and BOTH renderers skip the entire spatial pass — no slices, crosshair, or
-orientation labels (`NVViewGPU.ts` / `NVViewGL.ts` compute `signalOnly`).
+spatial view is hidden the plot fills the instance area and BOTH renderers skip the
+entire spatial pass — no slices, crosshair, or orientation labels (`NVViewGPU.ts` /
+`NVViewGL.ts` compute `spatialHidden = md.isSpatialViewHidden()`). The spatial view
+is hidden when the scene is signal-only (a signal but no volume/mesh) OR the user
+selects `SLICE_TYPE.NONE` — the latter hands the whole canvas to the graph while a
+volume stays loaded (e.g. a 4D BOLD time-course wanting full screen real-estate).
+`NVModel.isSpatialViewHidden()` is the single source of truth used by both
+renderers AND the graph-data builders' `fullCanvas` flag, so the slice-skip and the
+graph width never disagree. The association graph's `_assocCache` key includes
+`isSpatialViewHidden()` so toggling `SLICE_TYPE.NONE` rebuilds the layout (side
+strip <-> full canvas) rather than reusing the stale cached graph. Demo:
+`physio.bold.html` exposes a "None (graph only)" slice-type option.
 
 **Graph wheel:** scrolling over the graph steps the 4D frame when a spatial
 volume is present; for a signal-only graph it falls back to scrubbing the cursor
@@ -991,7 +1000,7 @@ Configurable drag interactions on 2D slices. `interaction.primaryDragMode` (defa
 
 `DRAG_MODE` enum: `none`(0), `contrast`(1), `measurement`(2), `pan`(3), `slicer3D`(4), `callbackOnly`(5), `roiSelection`(6), `angle`(7), `crosshair`(8), `windowing`(9).
 
-Public enum exports from the package root (alongside `DRAG_MODE`): `SLICE_TYPE` (axial/coronal/sagittal/multiplanar/render), `MULTIPLANAR_TYPE` (auto/column/grid/row), `SHOW_RENDER`, and `NiiDataType`.
+Public enum exports from the package root (alongside `DRAG_MODE`): `SLICE_TYPE` (axial/coronal/sagittal/multiplanar/render/none — `none` skips the spatial pass so a signal graph fills the canvas, see "signal mode" above), `MULTIPLANAR_TYPE` (auto/column/grid/row), `SHOW_RENDER`, and `NiiDataType`.
 
 **Overlay rendering:** Selection boxes use GlyphBatch panels (`_dragOverlay.rect`). Measurement/angle lines use line renderer (`_dragOverlay.lines`). Overlay state lives on `model._dragOverlay` (transient, not serialized).
 

--- a/packages/niivue/examples/physio.bold.html
+++ b/packages/niivue/examples/physio.bold.html
@@ -15,6 +15,8 @@
         <option value="1">Coronal</option>
         <option value="2">Sagittal</option>
         <option value="3">A+C+S+R</option>
+        <!-- 5 = SLICE_TYPE.NONE: hide the slices, graph fills the canvas -->
+        <option value="5">None (graph only)</option>
       </select>
       &nbsp;
       <button type="button" id="prevFrame">Back</button>

--- a/packages/niivue/src/NVConstants.test.ts
+++ b/packages/niivue/src/NVConstants.test.ts
@@ -48,4 +48,16 @@ describe('sliceTypeDim', () => {
   test('sagittal_returns0', () => {
     expect(sliceTypeDim(SLICE_TYPE.SAGITTAL)).toBe(0)
   })
+
+  test('noneFallsBackToDefault', () => {
+    // SLICE_TYPE.NONE hides the spatial view (no slice dim applies); the helper
+    // must return its safe default (2) rather than throw or yield NaN.
+    expect(sliceTypeDim(SLICE_TYPE.NONE)).toBe(2)
+  })
+
+  test('sliceTypeNoneIsDistinct', () => {
+    const values = Object.values(SLICE_TYPE)
+    expect(SLICE_TYPE.NONE).toBe(5)
+    expect(new Set(values).size).toBe(values.length) // all enum values unique
+  })
 })

--- a/packages/niivue/src/NVConstants.ts
+++ b/packages/niivue/src/NVConstants.ts
@@ -86,6 +86,11 @@ export const SLICE_TYPE = Object.freeze({
   SAGITTAL: 2,
   MULTIPLANAR: 3,
   RENDER: 4,
+  // No spatial view: skip the slice/render pass entirely and hand the whole
+  // canvas to the signal graph (or leave it blank if no graph is shown). Lets a
+  // signal+volume scene (e.g. a 4D BOLD time-course) use all screen real-estate
+  // for the plot without unloading the volume. See NVModel.isSpatialViewHidden().
+  NONE: 5,
 } as const)
 
 /** Maps AXIAL→2, CORONAL→1, SAGITTAL→0 (the RAS dimension perpendicular to the slice). */

--- a/packages/niivue/src/NVModel.ts
+++ b/packages/niivue/src/NVModel.ts
@@ -424,6 +424,21 @@ export default class NVModel {
     )
   }
 
+  /**
+   * True when no spatial view should render: either the scene has only signals
+   * (nothing spatial to show) or the user chose `SLICE_TYPE.NONE` to hand the
+   * whole canvas to the signal graph while keeping a volume loaded (e.g. a 4D
+   * BOLD time-course). Both renderers skip the spatial pass and the signal graph
+   * fills the instance area (`fullCanvas`). Single source of truth for that
+   * decision so the renderers and graph-data builders stay in agreement.
+   */
+  isSpatialViewHidden(): boolean {
+    return (
+      this.isSignalOnlyScene() ||
+      this.layout.sliceType === NVConstants.SLICE_TYPE.NONE
+    )
+  }
+
   getClipPlaneDepthAziElev(clipPlaneIndex = 0): [number, number, number] {
     if (clipPlaneIndex < 0 || clipPlaneIndex >= NVConstants.NUM_CLIP_PLANE) {
       clipPlaneIndex = 0
@@ -844,8 +859,9 @@ export default class NVModel {
       series,
       xAxis: axis,
       showLegend: lead.sig.display.showLegend,
-      // With no spatial data, let the plot fill the whole instance area.
-      fullCanvas: this.isSignalOnlyScene(),
+      // No spatial view (signal-only scene, or SLICE_TYPE.NONE) -> the plot fills
+      // the whole instance area; otherwise it's a side strip beside the slices.
+      fullCanvas: this.isSpatialViewHidden(),
       cursorX: this.signalCursorX,
       annotations: annotations.length > 0 ? annotations : undefined,
     }
@@ -942,7 +958,10 @@ export default class NVModel {
     // So the cache key omits frame4D, and the crosshair when BOLD is hidden — a
     // frame step then reuses the cached series and just re-marks the cursor.
     const cursorX = (vol.frame4D ?? 0) * tr
-    const key = `${vol.id}|${showVol}|${showVol ? `${cp[0]},${cp[1]},${cp[2]}` : ''}|${nFrames}|${tr}|${attached
+    // `fullCanvas` depends on the spatial-hidden state, so it is part of the key:
+    // toggling SLICE_TYPE.NONE must rebuild the graph (side strip <-> full canvas)
+    // rather than return the stale cached layout.
+    const key = `${vol.id}|${showVol}|${this.isSpatialViewHidden()}|${showVol ? `${cp[0]},${cp[1]},${cp[2]}` : ''}|${nFrames}|${tr}|${attached
       .map((s) => `${s.id}:${JSON.stringify(s.display)}`)
       .join(';')}`
     if (this._assocCache && this._assocCache.key === key) {
@@ -1007,7 +1026,10 @@ export default class NVModel {
       series,
       xAxis: { label: 'Time (s)', reversed: false, min: 0, max: tMax },
       showLegend: true,
-      fullCanvas: false,
+      // Side strip beside the slices by default; full canvas when the user hides
+      // the spatial view with SLICE_TYPE.NONE (the volume stays loaded for the
+      // time-course).
+      fullCanvas: this.isSpatialViewHidden(),
       // Marker at the current frame's time ties 4D scrubbing to the time axis.
       cursorX,
     }

--- a/packages/niivue/src/gl/NVViewGL.ts
+++ b/packages/niivue/src/gl/NVViewGL.ts
@@ -440,12 +440,12 @@ export default class NVGlview {
     const baseGraphWidth = graphData
       ? NVGraph.graphTotalWidth(graphData, canvasWidth, canvasHeight)
       : 0
-    // Signal-only scene (a signal loaded, no volume/mesh): skip all spatial
-    // tiles so no slices, crosshairs, or orientation labels render; the signal
-    // graph fills the instance area on its own. Otherwise lay out the slices and
-    // let the graph reclaim any horizontal slack (fitSlicesAndGraph).
-    const signalOnly = md.isSignalOnlyScene()
-    const fit = signalOnly
+    // No spatial view (a signal-only scene, OR the user chose SLICE_TYPE.NONE):
+    // skip all spatial tiles so no slices, crosshairs, or orientation labels
+    // render; the signal graph fills the instance area on its own. Otherwise lay
+    // out the slices and let the graph reclaim any horizontal slack.
+    const spatialHidden = md.isSpatialViewHidden()
+    const fit = spatialHidden
       ? {
           screenSlices: [] as NVSliceLayout.SliceTile[],
           graphWidth: baseGraphWidth,

--- a/packages/niivue/src/wgpu/NVViewGPU.ts
+++ b/packages/niivue/src/wgpu/NVViewGPU.ts
@@ -732,12 +732,12 @@ export default class NVView {
     const baseGraphWidth = graphData
       ? NVGraph.graphTotalWidth(graphData, canvasWidth, canvasHeight)
       : 0
-    // Signal-only scene (a signal loaded, no volume/mesh): skip all spatial
-    // tiles so no slices, crosshairs, or orientation labels render; the signal
-    // graph fills the instance area on its own. Otherwise lay out the slices and
-    // let the graph reclaim any horizontal slack (fitSlicesAndGraph).
-    const signalOnly = md.isSignalOnlyScene()
-    const fit = signalOnly
+    // No spatial view (a signal-only scene, OR the user chose SLICE_TYPE.NONE):
+    // skip all spatial tiles so no slices, crosshairs, or orientation labels
+    // render; the signal graph fills the instance area on its own. Otherwise lay
+    // out the slices and let the graph reclaim any horizontal slack.
+    const spatialHidden = md.isSpatialViewHidden()
+    const fit = spatialHidden
       ? {
           screenSlices: [] as NVSliceLayout.SliceTile[],
           graphWidth: baseGraphWidth,


### PR DESCRIPTION
## Summary

Adds a `None` slice type so a **signal + volume** scene (e.g. a 4D BOLD time-course with attached physio in `physio.bold.html`) can use the whole canvas for the signal graph, instead of always showing it as a side strip beside the slices. The volume stays loaded (so the BOLD time-course still works) — only its spatial rendering is skipped.

Replicable anywhere with `nv.sliceType = SLICE_TYPE.NONE`.

## Design

The renderers already had a "skip the spatial pass + graph fills the canvas" path, triggered by a signal-only scene (`isSignalOnlyScene()` — a signal with no volume/mesh). This generalizes that one trigger:

- **`SLICE_TYPE.NONE = 5`** (NVConstants).
- **`NVModel.isSpatialViewHidden()`** = `isSignalOnlyScene() || sliceType === NONE` — the single source of truth. Both renderers compute `spatialHidden` from it (replacing the `signalOnly` check), and both graph-data builders set `fullCanvas` from it (the association graph was hard-coded `false`). So the slice-skip and the graph width can never disagree.
- The association graph's `_assocCache` key now includes `isSpatialViewHidden()`, so toggling `NONE` rebuilds the layout (side strip ⇄ full canvas) rather than returning the stale cached graph.
- `sliceTypeDim` already falls back to its default for an unknown value, so `NONE` is safe there.

## Demo

`physio.bold.html` gains a **"None (graph only)"** option in the slice-type dropdown.

## Verification

- In-browser (both render paths): selecting **None** hides the slices and the graph fills 100% of the canvas width with all features intact (trigger rug, missing-data rug, legend, pan/zoom controls); switching back to Axial restores the side-strip layout. No console errors.
- 377 niivue tests pass (+2: `sliceTypeDim(NONE)` default, enum uniqueness), lint, typecheck, build, codespell green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)