### PR TITLE
feat(niivue): add per-axis crosshair colors

### DIFF
--- a/packages/niivue/FEATURES.md
+++ b/packages/niivue/FEATURES.md
@@ -129,6 +129,7 @@ TRX, TT, TSF (scalars), VTK lines.
 | `isMeasureUnitsVisible` | Prop | |
 | `isThumbnailVisible`, `thumbnailUrl`, `placeholderText` | Prop | Load-time preview |
 | `crosshairColor`, `crosshairGap`, `crosshairWidth` | Prop | |
+| `crosshairColorPerAxis` | Prop | `[xColor, yColor, zColor]` RGBA; `[]` (default) uses `crosshairColor` for every axis |
 | `fontColor`, `fontScale`, `fontMinSize` | Prop | |
 | `selectionBoxColor`, `measureLineColor`, `measureTextColor` | Prop | |
 | `rulerWidth` | Prop | |

--- a/packages/niivue/e2e/crosshair-per-axis.spec.ts
+++ b/packages/niivue/e2e/crosshair-per-axis.spec.ts
@@ -1,0 +1,203 @@
+import { expect, test } from '@playwright/test'
+
+// `crosshairColorPerAxis` tints each crosshair segment by the world axis it
+// extends along, and the mapping is only observable in the rendered pixels: the
+// colour is chosen per cylinder inside gl/crosshair.ts and wgpu/crosshair.ts,
+// downstream of anything the Bun runner can import. getAxisColor()'s unit tests
+// pin the resolver; they cannot tell you that cylinder index 2 is the Y axis, or
+// that the WebGPU path reads the same array as WebGL2.
+//
+// So this asserts the mapping through the public API, on both backends, by
+// counting saturated pixels per channel on a single-slice view:
+//
+//   AXIAL     shows X and Y  -> red + green, never blue
+//   CORONAL   shows X and Z  -> red + blue,  never green
+//   SAGITTAL  shows Y and Z  -> green + blue, never red
+//
+// A swapped pair fails on the channel that is asserted absent, which a
+// "some colour changed" assertion would miss. The default (`[]`) is checked
+// first, and must show red only -- that is the backward-compatibility claim.
+
+// WebGPU is off by default in headless Chromium. These flags bring up Dawn on
+// SwiftShader; scoped to this file so the rest of the suite keeps the config's
+// plain WebGL2-on-SwiftShader setup. `launchOptions` REPLACES the config's
+// object rather than merging into it, so the config's PLAYWRIGHT_CHROMIUM_PATH
+// escape hatch has to be repeated here or this file alone fails to launch on a
+// machine without Playwright's pinned revision.
+test.use({
+  launchOptions: {
+    args: [
+      '--enable-unsafe-swiftshader',
+      '--enable-unsafe-webgpu',
+      '--use-angle=swiftshader',
+      '--enable-features=Vulkan',
+      '--use-vulkan=swiftshader',
+    ],
+    ...(process.env.PLAYWRIGHT_CHROMIUM_PATH
+      ? { executablePath: process.env.PLAYWRIGHT_CHROMIUM_PATH }
+      : {}),
+  },
+})
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/examples/index.html', { waitUntil: 'load' })
+})
+
+// The real mni152 from packages/dev-images, so this spec loads the same single
+// LFS object niivue-e2e.yml already pulls for texcache-kind-change. An unpulled
+// pointer parses as "not NIFTI" and fails loudly rather than testing nothing.
+const VOLUME = '/volumes/mni152.nii.gz'
+
+// Pure primaries, so each segment is classified by which channel dominates.
+// The crosshair is lit 3D geometry, not a flat 2D line: a pure-green cylinder
+// lands around rgb(0,139,0) and the red one ranges from rgb(92,0,0) to
+// rgb(240,45,45) depending on the angle it is seen at. Only the ordering of
+// the channels is stable, so the classifier must not test brightness.
+const PER_AXIS = '[[1,0,0,1],[0,1,0,1],[0,0,1,1]]'
+
+// A crosshair is a few pixels wide across one canvas edge; anything above a
+// handful of pixels is a drawn line rather than an anti-aliased stray.
+const MIN_LINE_PIXELS = 20
+
+type Counts = { red: number; green: number; blue: number }
+type Phase = { name: string; counts: Counts }
+type Result = { skip?: string; backend?: string; phases?: Phase[] }
+
+for (const backend of ['webgl2', 'webgpu'] as const) {
+  test(`crosshair segments take their axis colour (${backend})`, async ({
+    page,
+  }) => {
+    test.setTimeout(180_000)
+
+    const result: Result = await page.evaluate(`(async () => {
+     try {
+      if ('${backend}' === 'webgpu') {
+        if (!navigator.gpu) return { skip: 'no navigator.gpu' }
+        let adapter = null
+        try {
+          adapter = await navigator.gpu.requestAdapter()
+        } catch (e) {
+          // Dawn on a headless runner throws "A valid external Instance
+          // reference no longer exists" rather than resolving null. That is a
+          // missing adapter, not a failed assertion.
+          return { skip: 'requestAdapter threw: ' + e }
+        }
+        if (!adapter) return { skip: 'no WebGPU adapter' }
+      }
+      const { default: NiiVue, SLICE_TYPE } = await import('/src/index.ts')
+      const nextFrame = () => new Promise((r) =>
+        requestAnimationFrame(() => requestAnimationFrame(r)))
+
+      const canvas = document.createElement('canvas')
+      canvas.width = 512
+      canvas.height = 512
+      document.body.appendChild(canvas)
+
+      const nv = new NiiVue({
+        backend: '${backend}',
+        backgroundColor: [0, 0, 0, 1],
+        sliceType: SLICE_TYPE.AXIAL,
+        crosshairWidth: 2,
+        // The orientation cube is drawn in red/green/blue, and the labels in
+        // the font colour. Both would be counted as crosshair pixels.
+        isOrientCubeVisible: false,
+        isOrientationTextVisible: false,
+        isColorbarVisible: false,
+      })
+      await nv.attachToCanvas(canvas)
+      // The both-backends build silently falls back to WebGL2 when WebGPU init
+      // throws, which would run this case twice on the same backend and report
+      // it as WebGPU coverage. Skip instead of passing on a lie.
+      if ('${backend}' === 'webgpu' && nv.backend !== 'webgpu') {
+        return { skip: 'WebGPU init fell back to ' + nv.backend }
+      }
+
+      await nv.loadVolumes([{ url: '${VOLUME}' }])
+      await nextFrame()
+
+      // Same capture path as saveBitmap(): render, then copy in the same task,
+      // so the drawing buffer is still valid without preserveDrawingBuffer.
+      const readback = document.createElement('canvas')
+      readback.width = canvas.width
+      readback.height = canvas.height
+      const ctx = readback.getContext('2d', { willReadFrequently: true })
+      if (!ctx) return { skip: 'no 2D readback context' }
+
+      const count = () => {
+        if (nv.view) nv.view.render()
+        ctx.clearRect(0, 0, readback.width, readback.height)
+        ctx.drawImage(canvas, 0, 0)
+        const px = ctx.getImageData(0, 0, readback.width, readback.height).data
+        let red = 0
+        let green = 0
+        let blue = 0
+        // The slice itself is grayscale (r == g == b) and the background is
+        // black, so a channel leading the other two by this margin is a
+        // crosshair pixel whatever the lighting did to its brightness.
+        const LEAD = 40
+        const FLOOR = 50
+        for (let i = 0; i < px.length; i += 4) {
+          const r = px[i]
+          const g = px[i + 1]
+          const b = px[i + 2]
+          if (r > FLOOR && r - g > LEAD && r - b > LEAD) red++
+          else if (g > FLOOR && g - r > LEAD && g - b > LEAD) green++
+          else if (b > FLOOR && b - r > LEAD && b - g > LEAD) blue++
+        }
+        return { red, green, blue }
+      }
+
+      const phases = []
+      const measure = async (name, sliceType) => {
+        nv.sliceType = sliceType
+        await nextFrame()
+        await nextFrame()
+        phases.push({ name, counts: count() })
+      }
+
+      // Default: crosshairColorPerAxis is [], so every segment is crosshairColor.
+      await measure('default-axial', SLICE_TYPE.AXIAL)
+
+      nv.crosshairColorPerAxis = ${PER_AXIS}
+      await measure('perAxis-axial', SLICE_TYPE.AXIAL)
+      await measure('perAxis-coronal', SLICE_TYPE.CORONAL)
+      await measure('perAxis-sagittal', SLICE_TYPE.SAGITTAL)
+
+      return { backend: nv.backend, phases }
+     } catch (e) {
+      return { skip: 'threw: ' + (e && e.message ? e.message : e) }
+     }
+    })()`)
+
+    test.skip(!!result.skip, result.skip ?? '')
+    expect(result.backend).toBe(backend)
+
+    const phases = result.phases ?? []
+    const at = (name: string): Counts => {
+      const phase = phases.find((p) => p.name === name)
+      if (!phase) throw new Error(`missing phase ${name}`)
+      return phase.counts
+    }
+
+    // Unchanged for existing users: the whole crosshair is crosshairColor (red).
+    const fallback = at('default-axial')
+    expect(fallback.red).toBeGreaterThan(MIN_LINE_PIXELS)
+    expect(fallback.green).toBe(0)
+    expect(fallback.blue).toBe(0)
+
+    const axial = at('perAxis-axial')
+    expect(axial.red).toBeGreaterThan(MIN_LINE_PIXELS)
+    expect(axial.green).toBeGreaterThan(MIN_LINE_PIXELS)
+    expect(axial.blue).toBe(0)
+
+    const coronal = at('perAxis-coronal')
+    expect(coronal.red).toBeGreaterThan(MIN_LINE_PIXELS)
+    expect(coronal.blue).toBeGreaterThan(MIN_LINE_PIXELS)
+    expect(coronal.green).toBe(0)
+
+    const sagittal = at('perAxis-sagittal')
+    expect(sagittal.green).toBeGreaterThan(MIN_LINE_PIXELS)
+    expect(sagittal.blue).toBeGreaterThan(MIN_LINE_PIXELS)
+    expect(sagittal.red).toBe(0)
+  })
+}

--- a/packages/niivue/src/NVConstants.ts
+++ b/packages/niivue/src/NVConstants.ts
@@ -340,6 +340,7 @@ export const UI_DEFAULTS: UIConfig = {
   thumbnailUrl: '',
   placeholderText: 'No image loaded',
   crosshairColor: [1.0, 0, 0, 1.0],
+  crosshairColorPerAxis: [],
   crosshairGap: 10,
   crosshairWidth: 2,
   fontColor: [0.5, 0.5, 0.5, 1],

--- a/packages/niivue/src/NVControlBase.ts
+++ b/packages/niivue/src/NVControlBase.ts
@@ -1159,6 +1159,21 @@ export default class NiiVue extends EventTarget {
     this.drawScene()
   }
 
+  /**
+   * Per-axis crosshair colors as `[xColor, yColor, zColor]` (each RGBA, 0..1).
+   * Set to 3 colors to tint each crosshair segment by the world axis it extends
+   * along (X = left-right, Y = anterior-posterior, Z = superior-inferior).
+   * Set to `[]` to fall back to the single {@link crosshairColor} for all axes.
+   */
+  get crosshairColorPerAxis(): number[][] {
+    return this.model.ui.crosshairColorPerAxis
+  }
+  set crosshairColorPerAxis(v: number[][]) {
+    this.model.ui.crosshairColorPerAxis = v
+    this.emit('change', { property: 'crosshairColorPerAxis', value: v })
+    this.drawScene()
+  }
+
   get crosshairGap(): number {
     return this.model.ui.crosshairGap
   }

--- a/packages/niivue/src/NVModel.ts
+++ b/packages/niivue/src/NVModel.ts
@@ -233,6 +233,9 @@ export default class NVModel {
       ...(options.crosshairColor !== undefined && {
         crosshairColor: options.crosshairColor,
       }),
+      ...(options.crosshairColorPerAxis !== undefined && {
+        crosshairColorPerAxis: options.crosshairColorPerAxis,
+      }),
       ...(options.crosshairGap !== undefined && {
         crosshairGap: options.crosshairGap,
       }),

--- a/packages/niivue/src/NVTypes.ts
+++ b/packages/niivue/src/NVTypes.ts
@@ -668,6 +668,14 @@ export type UIConfig = {
   thumbnailUrl: string
   placeholderText: string
   crosshairColor: number[]
+  /**
+   * Optional per-axis crosshair colors as `[xColor, yColor, zColor]`, each an
+   * RGBA array. When this holds 3 valid colors, each crosshair segment is tinted
+   * by the world axis it extends along (0 = X / left-right, 1 = Y /
+   * anterior-posterior, 2 = Z / superior-inferior). When empty (the default),
+   * every segment falls back to `crosshairColor`.
+   */
+  crosshairColorPerAxis: number[][]
   crosshairGap: number
   /**
    * Crosshair thickness in canvas pixels, on 2D slice tiles, on the 3D render
@@ -1138,6 +1146,7 @@ export type NiiVueOptions = {
   thumbnailUrl?: string
   placeholderText?: string
   crosshairColor?: number[]
+  crosshairColorPerAxis?: number[][]
   crosshairGap?: number
   /**
    * Crosshair thickness in canvas pixels, on 2D slice tiles, on the 3D render

--- a/packages/niivue/src/gl/NVViewGL.ts
+++ b/packages/niivue/src/gl/NVViewGL.ts
@@ -743,6 +743,7 @@ export default class NVGlview {
               Math.max(1, md.ui.crosshairWidth),
               md.ui.crosshairColor,
               buildLine,
+              md.ui.crosshairColorPerAxis,
             ),
           )
         }

--- a/packages/niivue/src/gl/crosshair.ts
+++ b/packages/niivue/src/gl/crosshair.ts
@@ -1,5 +1,6 @@
 import type NVModel from '@/NVModel'
 import type { NVMesh, WebGLMeshGPU } from '@/NVTypes'
+import { getAxisColor } from '@/view/crosshairColor'
 import {
   applyCrosshairOffset,
   crosshairExplodeOffsetForModel,
@@ -23,13 +24,14 @@ export type CrosshairResources = WebGLMeshGPU & {
 export class CrosshairRenderer extends NVRenderer {
   private gl: WebGL2RenderingContext | null = null
   private cylinders: CrosshairResources[] = []
-  // radius, packed colour, 6 segments x 2 endpoints x 3 axes, explode offset
-  private _geometryKey = new Float64Array(2 + 36 + 3).fill(Number.NaN)
+  // radius, one packed colour per axis, 6 segments x 2 endpoints x 3 axes,
+  // explode offset
+  private _geometryKey = new Float64Array(1 + 3 + 36 + 3).fill(Number.NaN)
 
   /** True when the buffers do not already hold this geometry. */
   private _geometryChanged(
     radius: number,
-    colorPacked: number,
+    axisColors: ArrayLike<number>,
     segments: ReturnType<typeof calculateCrosshairSegments>,
     off: ArrayLike<number>,
   ): boolean {
@@ -41,7 +43,9 @@ export class CrosshairRenderer extends NVRenderer {
       key[k++] = v
     }
     put(radius)
-    put(colorPacked)
+    put(axisColors[0])
+    put(axisColors[1])
+    put(axisColors[2])
     for (const seg of segments) {
       for (const pt of seg) {
         put(pt[0])
@@ -134,7 +138,6 @@ export class CrosshairRenderer extends NVRenderer {
 
     const { extentsMin, extentsMax, scene, ui } = model
     const radius = radiusMM
-    const colorPacked = packColor(ui.crosshairColor)
     const segments = calculateCrosshairSegments(
       extentsMin,
       extentsMax,
@@ -147,12 +150,20 @@ export class CrosshairRenderer extends NVRenderer {
     // block lookup is in volume texture fraction, so convert via mm.
     const off = crosshairExplodeOffsetForModel(model)
 
+    // Cylinders are ordered X-, X+, Y-, Y+, Z-, Z+, so axis = floor(i / 2).
+    const axisColors = [0, 1, 2].map((axis) =>
+      packColor(
+        getAxisColor(axis, ui.crosshairColor, ui.crosshairColorPerAxis),
+      ),
+    )
+
     // Tiles that share a radius -- the usual case -- share the geometry, so only
     // the first of them pays for the rebuild.
-    if (!this._geometryChanged(radius, colorPacked, segments, off)) return
+    if (!this._geometryChanged(radius, axisColors, segments, off)) return
 
     // Update each cylinder's vertex buffer
     for (let i = 0; i < 6; i++) {
+      const colorPacked = axisColors[Math.floor(i / 2)]
       const seg = segments[i]
       const start = applyCrosshairOffset(seg[0], off)
       const end = applyCrosshairOffset(seg[1], off)

--- a/packages/niivue/src/view/NVSliceLayout.ts
+++ b/packages/niivue/src/view/NVSliceLayout.ts
@@ -8,6 +8,7 @@ import type {
   NVGlobalCamera,
   ViewHitTest,
 } from '@/NVTypes'
+import { getAxisColor } from '@/view/crosshairColor'
 import type { BuildLineFn, LineData } from './NVLine'
 
 // ---------- Types ----------
@@ -1173,6 +1174,7 @@ export function buildCrossLines(
   thickness: number,
   color: number[],
   lineFn: BuildLineFn,
+  perAxisColors?: number[][],
 ): LineData[] {
   if (
     !tile.crossLines ||
@@ -1221,23 +1223,25 @@ export function buildCrossLines(
     if (dim === depthDim || mmValues.length === 0) continue
     for (const mm of mmValues) {
       if (dim === vDim) {
-        // Horizontal line: span full U extent at this V position
+        // Horizontal line: span full U extent at this V position (extends along uDim)
         const [x1, y1] = project(
           ...makePoint(extentsMin[uDim], mm, depthCenter),
         )
         const [x2, y2] = project(
           ...makePoint(extentsMax[uDim], mm, depthCenter),
         )
-        lines.push(lineFn(x1, y1, x2, y2, thickness, color))
+        const lineColor = getAxisColor(uDim, color, perAxisColors)
+        lines.push(lineFn(x1, y1, x2, y2, thickness, lineColor))
       } else if (dim === uDim) {
-        // Vertical line: span full V extent at this U position
+        // Vertical line: span full V extent at this U position (extends along vDim)
         const [x1, y1] = project(
           ...makePoint(mm, extentsMin[vDim], depthCenter),
         )
         const [x2, y2] = project(
           ...makePoint(mm, extentsMax[vDim], depthCenter),
         )
-        lines.push(lineFn(x1, y1, x2, y2, thickness, color))
+        const lineColor = getAxisColor(vDim, color, perAxisColors)
+        lines.push(lineFn(x1, y1, x2, y2, thickness, lineColor))
       }
     }
   }

--- a/packages/niivue/src/view/crosshairColor.test.ts
+++ b/packages/niivue/src/view/crosshairColor.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'bun:test'
+import { getAxisColor } from './crosshairColor'
+
+const RED = [1, 0, 0, 1]
+const GREEN = [0, 1, 0, 1]
+const BLUE = [0, 0, 1, 1]
+const FALLBACK = [0.5, 0.5, 0.5, 1]
+
+describe('getAxisColor', () => {
+  test('noPerAxis_returnsFallback', () => {
+    expect(getAxisColor(0, FALLBACK)).toEqual(FALLBACK)
+  })
+
+  test('emptyPerAxis_returnsFallback', () => {
+    expect(getAxisColor(1, FALLBACK, [])).toEqual(FALLBACK)
+  })
+
+  test('threeColors_returnsPerAxis', () => {
+    const perAxis = [RED, GREEN, BLUE]
+    expect(getAxisColor(0, FALLBACK, perAxis)).toEqual(RED)
+    expect(getAxisColor(1, FALLBACK, perAxis)).toEqual(GREEN)
+    expect(getAxisColor(2, FALLBACK, perAxis)).toEqual(BLUE)
+  })
+
+  test('rgbWithoutAlpha_isAccepted', () => {
+    const perAxis = [
+      [1, 0, 0],
+      [0, 1, 0],
+      [0, 0, 1],
+    ]
+    expect(getAxisColor(2, FALLBACK, perAxis)).toEqual([0, 0, 1])
+  })
+
+  test('wrongLengthTriple_fallsBack', () => {
+    // Only two entries: not a valid per-axis triple, so fall back.
+    expect(getAxisColor(0, FALLBACK, [RED, GREEN])).toEqual(FALLBACK)
+  })
+
+  test('outOfRangeAxis_fallsBack', () => {
+    const perAxis = [RED, GREEN, BLUE]
+    expect(getAxisColor(3, FALLBACK, perAxis)).toEqual(FALLBACK)
+    expect(getAxisColor(-1, FALLBACK, perAxis)).toEqual(FALLBACK)
+  })
+
+  test('malformedAxisEntry_fallsBack', () => {
+    // Z entry too short to be a usable RGB(A) color.
+    const perAxis = [RED, GREEN, [0, 0] as number[]]
+    expect(getAxisColor(2, FALLBACK, perAxis)).toEqual(FALLBACK)
+  })
+
+  test('doesNotMutateInputs', () => {
+    const perAxis = [RED, GREEN, BLUE]
+    const result = getAxisColor(0, FALLBACK, perAxis)
+    expect(result).toBe(RED)
+  })
+})

--- a/packages/niivue/src/view/crosshairColor.ts
+++ b/packages/niivue/src/view/crosshairColor.ts
@@ -1,0 +1,38 @@
+/**
+ * Per-axis crosshair color resolution.
+ *
+ * Kept in its own dependency-free module so it can be shared by the WebGL2 and
+ * WebGPU crosshair renderers, the mosaic cross-line builder, and unit tests
+ * without pulling in mesh/GPU code.
+ */
+
+/**
+ * Resolve the crosshair color for a given world axis.
+ *
+ * @param axisIndex - 0 = X (left-right), 1 = Y (anterior-posterior),
+ *   2 = Z (superior-inferior). For the 3D crosshair, cylinder index `i` maps to
+ *   its axis via `Math.floor(i / 2)`.
+ * @param crosshairColor - fallback RGBA used when no per-axis color applies.
+ * @param perAxisColors - optional `[xColor, yColor, zColor]`. Used only when it
+ *   contains exactly 3 entries and the requested axis holds a valid color with
+ *   at least 3 channels. Otherwise `crosshairColor` is returned.
+ * @returns the RGBA array to use for that axis.
+ */
+export function getAxisColor(
+  axisIndex: number,
+  crosshairColor: number[],
+  perAxisColors?: number[][],
+): number[] {
+  if (
+    perAxisColors &&
+    perAxisColors.length === 3 &&
+    axisIndex >= 0 &&
+    axisIndex < 3
+  ) {
+    const c = perAxisColors[axisIndex]
+    if (Array.isArray(c) && c.length >= 3) {
+      return c
+    }
+  }
+  return crosshairColor
+}

--- a/packages/niivue/src/wgpu/NVViewGPU.ts
+++ b/packages/niivue/src/wgpu/NVViewGPU.ts
@@ -1052,6 +1052,7 @@ export default class NVView {
               Math.max(1, md.ui.crosshairWidth),
               md.ui.crosshairColor,
               buildLine,
+              md.ui.crosshairColorPerAxis,
             ),
           )
         }

--- a/packages/niivue/src/wgpu/crosshair.ts
+++ b/packages/niivue/src/wgpu/crosshair.ts
@@ -1,4 +1,5 @@
 import type NVModel from '@/NVModel'
+import { getAxisColor } from '@/view/crosshairColor'
 import {
   applyCrosshairOffset,
   crosshairExplodeOffsetForModel,
@@ -115,7 +116,6 @@ export class CrosshairRenderer extends NVRenderer {
     const { extentsMin, extentsMax, scene, ui } = model
     const radius = radiusMM
     const offset = crosshairSlotOffset(slot)
-    const colorPacked = packColor(ui.crosshairColor)
     const segments = calculateCrosshairSegments(
       extentsMin,
       extentsMax,
@@ -128,8 +128,16 @@ export class CrosshairRenderer extends NVRenderer {
     // block lookup is in volume texture fraction, so convert via mm.
     const off = crosshairExplodeOffsetForModel(model)
 
-    // Update each cylinder's vertex buffer
+    // Update each cylinder's vertex buffer. Cylinders are ordered
+    // X-, X+, Y-, Y+, Z-, Z+, so axis = floor(i / 2).
     for (let i = 0; i < 6; i++) {
+      const colorPacked = packColor(
+        getAxisColor(
+          Math.floor(i / 2),
+          ui.crosshairColor,
+          ui.crosshairColorPerAxis,
+        ),
+      )
       const seg = segments[i]
       const start = applyCrosshairOffset(seg[0], off)
       const end = applyCrosshairOffset(seg[1], off)


### PR DESCRIPTION
# feat(niivue): add per-axis crosshair colors

## Summary

The MPR and render-view crosshairs are currently drawn in a single color
(`crosshairColor`, default red) for all three axes — there is no way to color
each axis differently. This PR adds an optional `crosshairColorPerAxis` option
so each crosshair segment can be tinted by the world axis it extends along.

When the option is left at its default (an empty array), every segment uses the
existing single `crosshairColor`, so **behavior is unchanged for existing
users** — this is purely additive and backward compatible.

## What it does

- New UI option `crosshairColorPerAxis: number[][]` = `[xColor, yColor, zColor]`,
  each an RGBA array in `0..1`.
- Coloring is applied by the **world axis the segment extends along**:
  `0 = X` (left-right), `1 = Y` (anterior-posterior), `2 = Z` (superior-inferior).
- Works in both 2D MPR slice tiles and the 3D render view, on **both the WebGL2
  and WebGPU backends** (the 6 crosshair cylinders map to an axis via
  `Math.floor(i / 2)`).
- Mosaic cross-reference lines (`buildCrossLines`) are also colored by their
  extension axis for consistency.
- Public getter/setter `crosshairColorPerAxis` on the control class, emitting a
  `change` event and redrawing, matching the existing `crosshairColor` accessor.

### Why color by extension axis rather than by represented plane?

Each crosshair cylinder is a single 3D object shared across all views, with one
color. A given cylinder represents *different* planes in different views (e.g.
the X-extending line marks the coronal plane in the axial view, but the axial
plane in the coronal view), so a per-plane coloring scheme cannot be satisfied
by a single per-cylinder color. Coloring by the world axis the cylinder extends
along is the view-independent choice that the cylinder architecture supports
consistently. The `calculateCrosshairSegments` ordering (`X-, X+, Y-, Y+, Z-,
Z+`) makes `axis = floor(i / 2)`.

## Usage

```ts
// Per-axis colors: X red, Y green, Z blue
nv.crosshairColorPerAxis = [
  [1, 0, 0, 1],
  [0, 1, 0, 1],
  [0, 0, 1, 1],
]

// Back to a single color for all axes
nv.crosshairColorPerAxis = []
```

Or via constructor options:

```ts
new Niivue({
  crosshairColorPerAxis: [
    [1, 0, 0, 1],
    [0, 1, 0, 1],
    [0, 0, 1, 1],
  ],
})
```

## Implementation notes

- `getAxisColor()` lives in a new dependency-free module
  `src/view/crosshairColor.ts` so it can be shared by the WebGL2/WebGPU
  renderers, the mosaic cross-line builder, and unit tests without pulling in
  mesh/GPU code. It falls back to `crosshairColor` whenever `perAxisColors` is
  absent, not a length-3 triple, or the requested axis entry is malformed.
- New unit tests in `src/view/crosshairColor.test.ts` cover the fallback,
  per-axis selection, RGB-without-alpha, and malformed-input cases (100%
  coverage of the new module).

## Testing

- `bunx tsc --noEmit` — passes
- `bunx biome check src` — passes (on the changed files)
- `bun test` — new tests pass; the only failures in this environment are
  pre-existing and unrelated (Git LFS dev-image fixtures for MRS/NIfTI/BIDS
  readers were not pulled in a shallow clone).