### PR TITLE
fix: render physio graph traces continuously

### DIFF
--- a/packages/niivue/src/view/NVGraph.test.ts
+++ b/packages/niivue/src/view/NVGraph.test.ts
@@ -206,7 +206,7 @@ describe('signal-mode rendering', () => {
   })
 })
 
-describe('missing-data rug (NaN gaps)', () => {
+describe('missing-data rug (NaN markers)', () => {
   // Rug ticks are short VERTICAL lane segments whose bottom sits AT the plot
   // bottom (lane 0) or above it (stacked lanes) — never below. That cleanly
   // separates them from full-height grid verticals (too tall) and from x-axis
@@ -221,8 +221,14 @@ describe('missing-data rug (NaN gaps)', () => {
     )
   }
 
+  function traceLines(lines: LineCall[], pT: number, pH: number): LineCall[] {
+    const ticks = new Set(rugTicks(lines, pT, pH))
+    const maxThick = Math.max(...lines.map((l) => l.thick))
+    return lines.filter((l) => l.thick === maxThick && !ticks.has(l))
+  }
+
   test('drawsATickPerMissingSample', () => {
-    // gaps at x=1 and x=3 -> two rug ticks
+    // missing samples at x=1 and x=3 -> two rug ticks
     const data = signalData([
       { label: 'a', x: [0, 1, 2, 3, 4], y: [1, NaN, 3, NaN, 5] },
     ])
@@ -232,6 +238,44 @@ describe('missing-data rug (NaN gaps)', () => {
     const { lines, buildText, buildLine } = makeStubs()
     buildGraphElements(data, layout, buildText, buildLine, [0, 0, 0])
     expect(rugTicks(lines, pT, pH).length).toBe(2)
+  })
+
+  test('sampledTraceInterpolatesAcrossMissingSample', () => {
+    const data = signalData([{ label: 'a', x: [0, 1, 2], y: [1, NaN, 3] }])
+    const layout = computeGraphLayout(data, W, H, 0, 1)
+    if (!layout) throw new Error('no layout')
+    const [, pT, , pH] = layout.plotLTWH
+    const { lines, buildText, buildLine } = makeStubs()
+    buildGraphElements(data, layout, buildText, buildLine, [0, 0, 0])
+    const ticks = rugTicks(lines, pT, pH)
+    expect(ticks.length).toBe(1)
+    const traces = traceLines(lines, pT, pH)
+    expect(traces.length).toBe(1)
+    expect(Math.min(traces[0].x0, traces[0].x1)).toBeLessThan(ticks[0].x0)
+    expect(Math.max(traces[0].x0, traces[0].x1)).toBeGreaterThan(ticks[0].x0)
+  })
+
+  test('decimatedTraceInterpolatesAcrossMissingRun', () => {
+    const n = 5000
+    const missLo = 2200
+    const missHi = 2600
+    const y = new Float32Array(n).fill(1)
+    for (let i = missLo; i <= missHi; i++) y[i] = Number.NaN
+    const data = signalData([{ label: 'a', x: null, y }])
+    const layout = computeGraphLayout(data, W, H, 0, 1)
+    if (!layout) throw new Error('no layout')
+    const [pL, pT, pW, pH] = layout.plotLTWH
+    const { lines, buildText, buildLine } = makeStubs()
+    buildGraphElements(data, layout, buildText, buildLine, [0, 0, 0])
+    expect(rugTicks(lines, pT, pH).length).toBeGreaterThan(0)
+    const missingMidX = pL + ((missLo + missHi) / 2 / (n - 1)) * pW
+    expect(
+      traceLines(lines, pT, pH).some(
+        (l) =>
+          Math.min(l.x0, l.x1) < missingMidX &&
+          Math.max(l.x0, l.x1) > missingMidX,
+      ),
+    ).toBe(true)
   })
 
   test('coincidentGapsStackIntoSeparateLanes', () => {
@@ -548,6 +592,10 @@ describe('signal-mode performance bounds', () => {
     return lines.filter((l) => l.thick === maxThick)
   }
 
+  function nonDegenerate(lines: LineCall[]): LineCall[] {
+    return lines.filter((l) => Math.hypot(l.x1 - l.x0, l.y1 - l.y0) > 1e-6)
+  }
+
   test('denseSeriesDecimatedToPlotWidth', () => {
     const n = 5000
     const y = new Float32Array(n)
@@ -563,6 +611,19 @@ describe('signal-mode performance bounds', () => {
     // never ~5000 segments
     expect(segs.length).toBeLessThanOrEqual(2 * (Math.ceil(pW) + 1))
     expect(segs.length).toBeLessThan(n)
+  })
+
+  test('decimatedFlatSeriesSkipsDegenerateTraceSegments', () => {
+    const n = 5000
+    const y = new Float32Array(n).fill(1)
+    const data = signalData([{ label: 'flat', x: null, y }])
+    const layout = computeGraphLayout(data, W, H, 0, 1)
+    if (!layout) throw new Error('no layout')
+    const { lines, buildText, buildLine } = makeStubs()
+    buildGraphElements(data, layout, buildText, buildLine, [0, 0, 0])
+    const segs = dataLines(lines)
+    expect(segs.length).toBeGreaterThan(0)
+    expect(nonDegenerate(segs).length).toBe(segs.length)
   })
 
   test('legendCappedWithMoreRow', () => {

--- a/packages/niivue/src/view/NVGraph.ts
+++ b/packages/niivue/src/view/NVGraph.ts
@@ -389,25 +389,20 @@ function drawDecimatedSeries(
     if (sy < minY[col]) minY[col] = sy
     if (sy > maxY[col]) maxY[col] = sy
   }
-  // Connect columns into a continuous line: from the previous column up to this
-  // column's min, then a vertical bar across its [min,max] range. This keeps
-  // smooth signals (low per-column range) continuous instead of collapsing to
-  // disconnected dots, while still showing the full envelope of dense regions.
+  // Connect populated columns into a continuous envelope. Empty columns are
+  // skipped, so missing samples are interpolated and marked only by the rug.
   let havePrev = false
   let prevX = 0
   let prevY = 0
   for (let col = 0; col < cols; col++) {
-    // Empty column = a NaN run (or window edge). Break the line so the gap is
-    // not bridged by a connector, matching the non-decimated path's behaviour.
-    if (maxY[col] < minY[col]) {
-      havePrev = false
-      continue
-    }
+    if (maxY[col] < minY[col]) continue
     const x = pL + col
     if (havePrev) {
       out.push(buildLine(prevX, prevY, x, minY[col], lineThick, color))
     }
-    out.push(buildLine(x, minY[col], x, maxY[col], lineThick, color))
+    if (maxY[col] > minY[col]) {
+      out.push(buildLine(x, minY[col], x, maxY[col], lineThick, color))
+    }
     havePrev = true
     prevX = x
     prevY = maxY[col]
@@ -416,10 +411,10 @@ function drawDecimatedSeries(
 
 /**
  * Mark samples that have no plottable value (BIDS `n/a` -> NaN) as short ticks
- * along the bottom axis (a "rug"). The trace itself is left gapped (missing data
- * is not interpolated); this surfaces WHERE it is missing — which is otherwise
- * invisible for a dense, decimated series. Decimation-safe: at most one tick per
- * pixel column, so a long run of gaps collapses to a bounded number of ticks.
+ * along the bottom axis (a "rug"). The trace interpolates across interior
+ * missing samples; the ticks mark all missing sample locations. Decimation-safe:
+ * at most one tick per pixel column, so a long run of gaps collapses to a
+ * bounded number of ticks.
  *
  * Each series gets its own horizontal lane (by `laneIndex`), stacked upward from
  * the bottom axis, so when two series miss the same sample their ticks sit
@@ -895,10 +890,8 @@ function buildSignalGraphElements(
     labels.push(tb)
   }
 
-  // 5) Data lines, clipped to the x-window and plot area. Dense series (more
-  // samples than ~2 per horizontal pixel) are decimated to a per-pixel-column
-  // min/max envelope so the line buffer stays bounded by the plot width
-  // regardless of sample count.
+  // 5) Data lines, clipped to the x-window and plot area. Dense visible windows
+  // are decimated to keep the line buffer bounded by the plot width.
   const decimateThreshold = Math.max(2, Math.ceil(pW * 2))
   for (let j = 0; j < series.length; j++) {
     const s = series[j]
@@ -909,7 +902,26 @@ function buildSignalGraphElements(
       lineAlpha < 1
         ? [base[0], base[1], base[2], (base[3] ?? 1) * lineAlpha]
         : base
-    if (s.y.length > decimateThreshold) {
+    let visibleSamples = 0
+    if (s.x) {
+      for (
+        let i = 0;
+        i < s.y.length && visibleSamples <= decimateThreshold;
+        i++
+      ) {
+        const xv = s.x[i]
+        if (xv >= xMin && xv <= xMax && Number.isFinite(s.y[i])) {
+          visibleSamples++
+        }
+      }
+    } else {
+      const i0 = Math.max(0, Math.ceil(xMin))
+      const i1 = Math.min(s.y.length - 1, Math.floor(xMax))
+      for (let i = i0; i <= i1 && visibleSamples <= decimateThreshold; i++) {
+        if (Number.isFinite(s.y[i])) visibleSamples++
+      }
+    }
+    if (visibleSamples > decimateThreshold) {
       drawDecimatedSeries(
         s,
         xMin,
@@ -928,21 +940,19 @@ function buildSignalGraphElements(
       )
       continue
     }
-    // Connect consecutive finite samples, CLIPPING each segment to the x-window
-    // in data space. This draws the segment from an out-of-window neighbour up to
-    // the plot edge (e.g. a sparse volume time-course whose first/last in-window
-    // sample would otherwise float disconnected from the left/right edge). NaN
-    // (missing) samples break the line so gaps are preserved.
+    // Connect finite samples, CLIPPING each segment to the x-window in data
+    // space. This draws the segment from an out-of-window neighbour up to the
+    // plot edge (e.g. a sparse volume time-course whose first/last in-window
+    // sample would otherwise float disconnected from the left/right edge). NaNs
+    // are skipped, so interior missing samples are interpolated; the bottom rug
+    // marks all missing samples.
     let prevX = 0
     let prevY = 0
     let havePrev = false
     for (let i = 0; i < s.y.length; i++) {
       const xv = seriesX(s, i)
       const yv = s.y[i]
-      if (!Number.isFinite(yv)) {
-        havePrev = false
-        continue
-      }
+      if (!Number.isFinite(yv)) continue
       if (havePrev) {
         const seg = clipSegmentX(prevX, prevY, xv, yv, xMin, xMax)
         if (seg) {
@@ -965,9 +975,10 @@ function buildSignalGraphElements(
   }
 
   // 5a) Missing-data rug: short ticks at the bottom axis marking samples with no
-  // value (BIDS `n/a`). Gaps are left in the trace (not interpolated); this is
-  // the only on-graph cue for missing data in a dense, decimated series. Each
-  // series gets its own stacked lane so coincident gaps don't overwrite.
+  // value (BIDS `n/a`). The trace interpolates across interior missing samples,
+  // and the rug is the explicit on-graph cue for all missing locations. Each
+  // series gets its own stacked lane so coincident missing samples don't
+  // overwrite.
   const rugLaneH = Math.max(2, Math.round(fontSize * 0.35))
   // Keep the stacked lanes inside a reserved band at the bottom (~20% of plot
   // height); with many series carrying gaps, excess lanes share the top lane


### PR DESCRIPTION
## Summary
- render signal traces continuously across missing samples while retaining missing-sample rug ticks
- choose dense-series decimation from finite samples in the visible window so zoomed physio traces use connected segments
- add graph tests for sampled and decimated interpolation plus degenerate decimated segments

Closes #66.

## Testing
- bunx nx run niivue:format
- bunx nx run niivue:lint
- bunx nx run niivue:typecheck
- bunx nx test niivue
- bunx nx run niivue:build
- bun run check-boundaries
- git diff --check

Note: local codespell still reports pre-existing `LOD` terms outside this change.