### PR TITLE
[ENH] More events needed for FreeBrowse

### DIFF
--- a/packages/niivue/AGENTS.md
+++ b/packages/niivue/AGENTS.md
@@ -262,6 +262,19 @@ nv1.addEventListener('clipPlaneChange', (e) => { ... }) // clip plane adjusted
 
 See `docs/events.md` for the full event catalog and detail types.
 
+**Emission order — the event's referenced item is present in the collection at emit time.**
+Add / update / reorder events fire *after* the model mutation, so the item is
+present (or updated) when the event fires: `addVolume`→`volumeLoaded`,
+`setVolume`→`volumeUpdated`, `moveVolume*`→`volumeOrderChanged`, and the mesh
+equivalents. Removal events fire *before* the mutation, so the item being removed
+is still present: `removeVolume` / `removeMesh` / `removeAllVolumes` /
+`removeAllMeshes` → `volumeRemoved` / `meshRemoved`. New methods should follow
+this so a listener can always reach the referenced item — via the collection or
+the event `detail` — at emit time. Corollary: do **not** switch removal to
+emit-after; a consumer that rebuilds a list by re-reading the collection must
+read *after* the mutation instead (e.g. on the next render, or a microtask), the
+same way it must for the bulk-removal methods.
+
 ### Per-item options (unified load + update)
 
 ```js

--- a/packages/niivue/docs/events.md
+++ b/packages/niivue/docs/events.md
@@ -49,6 +49,25 @@ nv.addEventListener('documentLoaded', (evt) => {
 })
 ```
 
+## Emission timing
+
+Events are emitted so that **the item an event references is present in the
+collection (`nv.volumes` / `nv.meshes`) at the moment the event fires**:
+
+- **Add / update / reorder** fire *after* the model changes — the item is now
+  present or updated (`volumeLoaded`, `meshLoaded`, `volumeUpdated`,
+  `meshUpdated`, `volumeOrderChanged`).
+- **Removal** fires *before* the model changes — the item being removed is still
+  present (`volumeRemoved`, `meshRemoved`, and their bulk forms). This lets a
+  listener inspect the departing item via the collection, not just the `detail`.
+
+**Consumer corollary:** a listener that rebuilds a list by *re-reading the
+collection* will read a stale list if it does so synchronously inside a removal
+event (the item is still there). Read after the mutation instead — on the next
+render, or a microtask. (Listeners that consume the event `detail` directly are
+unaffected.) New emitting methods should preserve this ordering rather than, for
+example, moving removal to emit-after.
+
 ## Event Reference
 
 ### User Interaction
@@ -151,7 +170,7 @@ Fired after a mesh is successfully added (via `addMesh()` or `loadMeshes()`). Fi
 | `mesh` | `NVMesh` | The newly loaded mesh |
 
 #### `volumeRemoved`
-Fired before a volume is removed. When removing all volumes, fires once per volume in reverse order.
+Fired before a volume is removed — by `removeVolume(index)`, or once per volume in reverse order by `removeAllVolumes()`.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -159,7 +178,7 @@ Fired before a volume is removed. When removing all volumes, fires once per volu
 | `index` | `number` | Index in the volumes array |
 
 #### `meshRemoved`
-Fired before a mesh is removed.
+Fired before a mesh is removed — by `removeMesh(index)`, or once per mesh by `removeAllMeshes()`.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -215,7 +234,8 @@ nv.addEventListener('canvasResize', (e) => {
 ### View Control
 
 #### `azimuthElevationChange`
-Fired when `azimuth` or `elevation` is set programmatically.
+Fired when `azimuth` or `elevation` is set programmatically, or when the user
+rotates the 3D render view (mouse drag or the H/J/K/L keys).
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -241,7 +261,8 @@ Fired when `sliceType` is set.
 ### Data Updates
 
 #### `volumeUpdated`
-Fired after `setVolume()` applies property changes to a volume.
+Fired after `setVolume()` applies property changes to a volume, or after
+`setColormapLabel()` sets/clears a label colormap (for which `changes` is empty).
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -257,13 +278,15 @@ nv.addEventListener('volumeUpdated', (e) => {
 ```
 
 #### `meshUpdated`
-Fired after `setMesh()` applies property changes to a mesh.
+Fired after `setMesh()` applies property changes to a mesh, or after a
+scalar-overlay layer change (`addMeshLayer`, `removeMeshLayer`,
+`setMeshLayerProperty`).
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `meshIndex` | `number` | Index of the updated mesh |
 | `mesh` | `NVMesh` | The mesh (after update) |
-| `changes` | `MeshUpdate` | The options that were applied |
+| `changes` | `MeshUpdate` | The options that were applied — **empty (`{}`) for layer changes**, since layer state isn't a `MeshUpdate` diff; re-read `mesh.layers` |
 
 #### `colormapAdded`
 Fired after `addColormap()` or `addColormapFromUrl()` registers a new user-defined colormap. The new LUT is then visible to volumes, mesh layers, colorbars, connectomes, and tracts.
@@ -288,12 +311,14 @@ Fired on drawing lifecycle events and user strokes.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `action` | `'stroke' \| 'create' \| 'close' \| 'undo'` | What happened |
+| `action` | `'stroke' \| 'create' \| 'close' \| 'undo' \| 'load' \| 'update'` | What happened |
 
 - `'create'` — `createEmptyDrawing()` was called
 - `'stroke'` — user completed a pen stroke (pointerup)
 - `'undo'` — `drawUndo()` restored a previous state
 - `'close'` — `closeDrawing()` destroyed the drawing
+- `'load'` — `loadDrawing()` loaded a drawing from a volume
+- `'update'` — the drawing bitmap was updated programmatically (extension `ctx.drawing.update()`)
 
 #### `drawingEnabled`
 Fired when `drawIsEnabled` is set.

--- a/packages/niivue/src/NVControlBase.ts
+++ b/packages/niivue/src/NVControlBase.ts
@@ -476,6 +476,9 @@ export default class NiiVueGPU extends EventTarget {
   set crosshairPos(v: vec3) {
     this.model.scene.crosshairPos = v
     this.emit('change', { property: 'crosshairPos', value: v })
+    // Mirror the interaction/setCrosshairPos paths so a programmatic crosshair
+    // move also yields a locationChange (with voxel/intensity readout).
+    this.createOnLocationChange()
     this.drawScene()
   }
 
@@ -2330,6 +2333,23 @@ export default class NiiVueGPU extends EventTarget {
     await this.updateGLVolume()
   }
 
+  /**
+   * Remove a single volume by index, emitting `volumeRemoved`.
+   * @param volumeIndex - Index of the volume to remove
+   * @example
+   * await nv1.removeVolume(1) // remove the first overlay
+   */
+  async removeVolume(volumeIndex: number): Promise<void> {
+    const volumes = this.model.getVolumes()
+    if (!this._checkBounds(volumes, volumeIndex, 'Volume')) return
+    const volume = volumes[volumeIndex]
+    // Emit before removal, matching removeAllVolumes/removeAllMeshes: at emit
+    // time the collection still contains the referenced item.
+    this.emit('volumeRemoved', { volume, index: volumeIndex })
+    this.model.removeVolume(volumeIndex)
+    await this.updateGLVolume()
+  }
+
   async removeAllMeshes(): Promise<void> {
     const meshes = this.model.getMeshes()
     for (let i = meshes.length - 1; i >= 0; i--) {
@@ -2422,6 +2442,13 @@ export default class NiiVueGPU extends EventTarget {
         computeVolumeLabelCentroids(volumes[volumeIndex])
     }
     volumes[volumeIndex].isDirty = true
+    // Structural change (the label LUT is not a VolumeUpdate option); the volume
+    // reference lets listeners re-read colormapLabel.
+    this.emit('volumeUpdated', {
+      volumeIndex,
+      volume: volumes[volumeIndex],
+      changes: {},
+    })
     await this.updateGLVolume()
   }
 
@@ -2670,6 +2697,9 @@ export default class NiiVueGPU extends EventTarget {
     }
     m.layers.push(newLayer)
     NVMeshLayers.compositeLayers(m.perVertexColors, m.color, m.layers, m.colors)
+    // Layer state is structural (not a MeshUpdate option diff); the mesh
+    // reference lets listeners re-read mesh.layers.
+    this.emit('meshUpdated', { meshIndex, mesh: m, changes: {} })
     await this.updateGLVolume()
     return this
   }
@@ -2684,6 +2714,9 @@ export default class NiiVueGPU extends EventTarget {
     if (!this._checkBounds(m.layers, layerIndex, 'Layer')) return this
     m.layers.splice(layerIndex, 1)
     NVMeshLayers.compositeLayers(m.perVertexColors, m.color, m.layers, m.colors)
+    // Layer state is structural (not a MeshUpdate option diff); the mesh
+    // reference lets listeners re-read mesh.layers.
+    this.emit('meshUpdated', { meshIndex, mesh: m, changes: {} })
     await this.updateGLVolume()
     return this
   }
@@ -2706,6 +2739,9 @@ export default class NiiVueGPU extends EventTarget {
     if (!this._checkBounds(m.layers, layerIndex, 'Layer')) return
     Object.assign(m.layers[layerIndex], options)
     NVMeshLayers.compositeLayers(m.perVertexColors, m.color, m.layers, m.colors)
+    // Layer state is structural (not a MeshUpdate option diff); the mesh
+    // reference lets listeners re-read mesh.layers.
+    this.emit('meshUpdated', { meshIndex, mesh: m, changes: {} })
     await this.updateGLVolume()
   }
 
@@ -3912,6 +3948,7 @@ export default class NiiVueGPU extends EventTarget {
       this.model.draw.isEnabled = true
       this._drawLut = null
       this.refreshDrawing()
+      this.emit('drawingChanged', { action: 'load' })
       return true
     } catch (err) {
       log.warn('loadDrawing failed:', err)

--- a/packages/niivue/src/NVEvents.ts
+++ b/packages/niivue/src/NVEvents.ts
@@ -57,7 +57,7 @@ export type ClipPlaneChangeDetail = { clipPlane: number[] }
 export type SliceTypeChangeDetail = { sliceType: number }
 export type PenValueChangedDetail = { penValue: number }
 export type DrawingChangedDetail = {
-  action: 'stroke' | 'create' | 'close' | 'undo'
+  action: 'stroke' | 'create' | 'close' | 'undo' | 'load' | 'update'
 }
 export type DrawingEnabledDetail = { isEnabled: boolean }
 export type PropertyChangeDetail = { property: string; value: unknown }

--- a/packages/niivue/src/control/cameraEvents.test.ts
+++ b/packages/niivue/src/control/cameraEvents.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, mock, test } from 'bun:test'
+import type NiiVueGPU from '@/NVControlBase'
+import {
+  emitOrientationChange,
+  emitPan2DChange,
+  emitScaleMultiplierChange,
+} from './cameraEvents'
+
+type Scene = {
+  azimuth?: number
+  elevation?: number
+  scaleMultiplier?: number
+  pan2Dxyzmm?: [number, number, number, number]
+}
+
+function fakeCtrl(scene: Scene) {
+  const emit = mock((_type: string, _detail?: unknown) => {})
+  const ctrl = { model: { scene }, emit } as unknown as NiiVueGPU
+  return { ctrl, emit }
+}
+
+describe('camera interaction events', () => {
+  test('emitOrientationChange mirrors the azimuth/elevation setters', () => {
+    const { ctrl, emit } = fakeCtrl({ azimuth: 110, elevation: 10 })
+    emitOrientationChange(ctrl)
+    expect(emit).toHaveBeenCalledTimes(3)
+    expect(emit).toHaveBeenNthCalledWith(1, 'azimuthElevationChange', {
+      azimuth: 110,
+      elevation: 10,
+    })
+    expect(emit).toHaveBeenNthCalledWith(2, 'change', {
+      property: 'azimuth',
+      value: 110,
+    })
+    expect(emit).toHaveBeenNthCalledWith(3, 'change', {
+      property: 'elevation',
+      value: 10,
+    })
+  })
+
+  test('emitScaleMultiplierChange emits a scaleMultiplier change', () => {
+    const { ctrl, emit } = fakeCtrl({ scaleMultiplier: 1.5 })
+    emitScaleMultiplierChange(ctrl)
+    expect(emit).toHaveBeenCalledWith('change', {
+      property: 'scaleMultiplier',
+      value: 1.5,
+    })
+  })
+
+  test('emitPan2DChange emits a pan2Dxyzmm change', () => {
+    const { ctrl, emit } = fakeCtrl({ pan2Dxyzmm: [1, 2, 3, 4] })
+    emitPan2DChange(ctrl)
+    expect(emit).toHaveBeenCalledWith('change', {
+      property: 'pan2Dxyzmm',
+      value: [1, 2, 3, 4],
+    })
+  })
+})

--- a/packages/niivue/src/control/cameraEvents.ts
+++ b/packages/niivue/src/control/cameraEvents.ts
@@ -1,0 +1,36 @@
+import type NiiVueGPU from '@/NVControlBase'
+
+/**
+ * Event emitters for interaction-driven camera changes (mouse/keyboard rotate,
+ * wheel zoom, 2D pan/zoom). These mirror what the `azimuth`/`elevation`/
+ * `scaleMultiplier`/`pan2Dxyzmm` setters emit, so a listener sees the same
+ * `azimuthElevationChange` / `change` events whether the camera moved via the
+ * public API or via direct user interaction.
+ *
+ * Kept in a leaf module (type-only controller import) so they are unit-testable
+ * under the bun test runner, unlike the controller itself.
+ */
+
+/** Emit orientation events after an interaction rotated the 3D camera. */
+export function emitOrientationChange(ctrl: NiiVueGPU): void {
+  const { azimuth, elevation } = ctrl.model.scene
+  ctrl.emit('azimuthElevationChange', { azimuth, elevation })
+  ctrl.emit('change', { property: 'azimuth', value: azimuth })
+  ctrl.emit('change', { property: 'elevation', value: elevation })
+}
+
+/** Emit a change event after an interaction changed the 3D zoom. */
+export function emitScaleMultiplierChange(ctrl: NiiVueGPU): void {
+  ctrl.emit('change', {
+    property: 'scaleMultiplier',
+    value: ctrl.model.scene.scaleMultiplier,
+  })
+}
+
+/** Emit a change event after an interaction panned/zoomed the 2D views. */
+export function emitPan2DChange(ctrl: NiiVueGPU): void {
+  ctrl.emit('change', {
+    property: 'pan2Dxyzmm',
+    value: ctrl.model.scene.pan2Dxyzmm,
+  })
+}

--- a/packages/niivue/src/control/dragModes.ts
+++ b/packages/niivue/src/control/dragModes.ts
@@ -1,4 +1,8 @@
 import { vec3 } from 'gl-matrix'
+import {
+  emitPan2DChange,
+  emitScaleMultiplierChange,
+} from '@/control/cameraEvents'
 import * as NVTransforms from '@/math/NVTransforms'
 import { DRAG_MODE, SLICE_TYPE } from '@/NVConstants'
 import type NiiVueGPU from '@/NVControlBase'
@@ -409,6 +413,7 @@ export function dragForPanZoom(ctrl: NiiVueGPU): void {
   ctrl.model.scene.pan2Dxyzmm[0] = saved[0] + (endMM[0] - startMM[0])
   ctrl.model.scene.pan2Dxyzmm[1] = saved[1] + (endMM[1] - startMM[1])
   ctrl.model.scene.pan2Dxyzmm[2] = saved[2] + (endMM[2] - startMM[2])
+  emitPan2DChange(ctrl)
 }
 
 /** Zoom 2D view based on vertical drag delta. */
@@ -423,12 +428,14 @@ export function dragForSlicer3D(ctrl: NiiVueGPU): void {
   ctrl.model.scene.pan2Dxyzmm[3] = zoom
   if (ctrl.model.interaction.isYoked3DTo2DZoom) {
     ctrl.model.scene.scaleMultiplier = zoom
+    emitScaleMultiplierChange(ctrl)
   }
 
   const mm = ctrl.model.scene2mm(ctrl.model.scene.crosshairPos)
   ctrl.model.scene.pan2Dxyzmm[0] += zoomChange * mm[0]
   ctrl.model.scene.pan2Dxyzmm[1] += zoomChange * mm[1]
   ctrl.model.scene.pan2Dxyzmm[2] += zoomChange * mm[2]
+  emitPan2DChange(ctrl)
 }
 
 /** Windowing: horizontal drag adjusts range width, vertical adjusts center. */

--- a/packages/niivue/src/control/interactions.ts
+++ b/packages/niivue/src/control/interactions.ts
@@ -1,5 +1,10 @@
 import type { mat4 } from 'gl-matrix'
 import * as Annotation from '@/annotation'
+import {
+  emitOrientationChange,
+  emitPan2DChange,
+  emitScaleMultiplierChange,
+} from '@/control/cameraEvents'
 import * as DragModes from '@/control/dragModes'
 import { computeBoundsPixelRect } from '@/control/viewBoth'
 import { addUndoBitmap, getDrawingBitmap } from '@/drawing/drawingManager'
@@ -211,22 +216,26 @@ function handleKeydown(ctrl: NiiVueGPU, e: KeyboardEvent): void {
     if (key === 'H') {
       ctrl.model.scene.azimuth =
         (((ctrl.model.scene.azimuth - 1) % 360) + 360) % 360
+      emitOrientationChange(ctrl)
       ctrl.drawScene()
     } else if (key === 'L') {
       ctrl.model.scene.azimuth =
         (((ctrl.model.scene.azimuth + 1) % 360) + 360) % 360
+      emitOrientationChange(ctrl)
       ctrl.drawScene()
     } else if (key === 'K') {
       ctrl.model.scene.elevation = Math.max(
         -90,
         Math.min(90, ctrl.model.scene.elevation - 1),
       )
+      emitOrientationChange(ctrl)
       ctrl.drawScene()
     } else if (key === 'J') {
       ctrl.model.scene.elevation = Math.max(
         -90,
         Math.min(90, ctrl.model.scene.elevation + 1),
       )
+      emitOrientationChange(ctrl)
       ctrl.drawScene()
     }
   } else {
@@ -1279,6 +1288,7 @@ export function initInteraction(ctrl: NiiVueGPU): void {
       -90,
       Math.min(90, ctrl.model.scene.elevation + deltaY * sensitivity),
     )
+    emitOrientationChange(ctrl)
     ctrl.drawScene()
   }
   ctrl._eventListeners.wheel = (e: Event) => {
@@ -1326,6 +1336,7 @@ export function initInteraction(ctrl: NiiVueGPU): void {
         const zoomChange = ctrl.model.scene.pan2Dxyzmm[3] - zoom
         if (ctrl.model.interaction.isYoked3DTo2DZoom) {
           ctrl.model.scene.scaleMultiplier = zoom
+          emitScaleMultiplierChange(ctrl)
         }
         ctrl.model.scene.pan2Dxyzmm[3] = zoom
         // Adjust pan so zoom centers on the crosshair
@@ -1333,6 +1344,7 @@ export function initInteraction(ctrl: NiiVueGPU): void {
         ctrl.model.scene.pan2Dxyzmm[0] += zoomChange * mm[0]
         ctrl.model.scene.pan2Dxyzmm[1] += zoomChange * mm[1]
         ctrl.model.scene.pan2Dxyzmm[2] += zoomChange * mm[2]
+        emitPan2DChange(ctrl)
         ctrl.drawScene()
         return
       }
@@ -1375,6 +1387,7 @@ export function initInteraction(ctrl: NiiVueGPU): void {
       0.5,
       Math.min(2.0, ctrl.model.scene.scaleMultiplier),
     )
+    emitScaleMultiplierChange(ctrl)
     ctrl.drawScene()
   }
   ctrl._eventListeners.keydown = (e: Event) =>

--- a/packages/niivue/src/extension/context.ts
+++ b/packages/niivue/src/extension/context.ts
@@ -145,6 +145,7 @@ export class NVExtensionContext {
       update(bitmap: Uint8Array): void {
         ;(drawVol.img as Uint8Array).set(bitmap)
         nv.refreshDrawing()
+        nv.emit('drawingChanged', { action: 'update' })
       },
 
       refresh(): void {


### PR DESCRIPTION
Adds more event emissions needed for the FreeBrowse UI.

`NVControlBase` Changes:
- Adds `removeVolume(volumeIndex)` to `NVControlBase` to remove a single volume

Event Changes:
- `DrawingChangedDetail.action` expanded to include `'load'` and `'update'`

Emissions Added:
- Newly added `removeVolume(volumeIndex)` announces the removal.
- Rotating the 3D camera either by dragging with the mouse or with the `HLKJ` keys now announces the new orientation.
- Zooming with the mouse wheel now announces the new zoom level.
- Panning or zooming the 2D slice views by dragging now announces the new pan/zoom position.
- Changing a volume's label colormap now announces that the volume was updated.
- Adding, removing, or editing a mesh's overlay layer now announces that the mesh was updated.
- Loading a drawing, or a plugin updating the drawing, now announces that the drawing changed.
- Moving the crosshair programatically emits the same event that moving the crosshair via UI does.  The new location is announced including the readout of which voxel it landed on and that voxel's intensity.

Other Changes:
- `cameraEvents.ts` was created to for the emission of camera change events

The camera change emissions aren't needed by FreeBrowse today, but I have got request to expose this via the UI so they have been included.

Additionally, it seems like the event convention is to emit events *after* for add/update events and *before* for removal events so the item being removed is still present when the event fires.  This convention has been documented in `AGENTS.md` and `docs/events.md`