### PR TITLE
[FIX] byte-swap big-endian mgz image data

### DIFF
--- a/packages/dev-images/images/volumes/fs/brainmask-int.mgz
+++ b/packages/dev-images/images/volumes/fs/brainmask-int.mgz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a24541f739fd766237588fc63e73680436cd0d5ac66965bdc96f6de331192ab
+size 2417099

--- a/packages/niivue/src/volume/readers/mgh.test.ts
+++ b/packages/niivue/src/volume/readers/mgh.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { NiiDataType } from '@/NVConstants'
+import { read } from './mgh'
+
+// A real FreeSurfer INT32 (MRI_INT) volume. MGH/MGZ is big-endian, so an
+// int-typed fixture is required to exercise the byte-swap: a UCHAR .mgz would
+// decode correctly even without swapping and so would not guard the regression.
+const FIXTURE = join(
+  import.meta.dir,
+  '../../../../dev-images/images/volumes/fs',
+  'brainmask-int.mgz',
+)
+
+// Ground-truth values, computed independently by reading the file as big-endian
+// int32. The pre-fix bug (native little-endian view of big-endian bytes) turns
+// these into 0 + scattered +-tens-of-millions.
+const EXPECTED = {
+  min: 0,
+  max: 250,
+  sum: 109423756,
+  // linear RAS index of voxel [128,128,128] = i + j*256 + k*256*256
+  midIndex: 128 + 128 * 256 + 128 * 256 * 256,
+  midValue: 8,
+}
+
+describe('mgh reader (big-endian INT32 MGZ)', () => {
+  test('decodesInt32VoxelsInNativeByteOrder', async () => {
+    const buf = readFileSync(FIXTURE)
+    const { hdr, img } = await read(buf, 'brainmask-int.mgz')
+
+    expect(hdr.datatypeCode).toBe(NiiDataType.DT_INT32)
+    expect(hdr.numBitsPerVoxel).toBe(32)
+    expect(hdr.dims[1]).toBe(256)
+    expect(hdr.dims[2]).toBe(256)
+    expect(hdr.dims[3]).toBe(256)
+
+    // View the returned bytes exactly as the platform (and toTypedViewOrU8)
+    // reads them: a native Int32Array. After the fix these are the true values.
+    const bytes = img instanceof Uint8Array ? img : new Uint8Array(img)
+    const i32 = new Int32Array(
+      bytes.buffer,
+      bytes.byteOffset,
+      bytes.byteLength / 4,
+    )
+    expect(i32.length).toBe(256 * 256 * 256)
+
+    let min = Number.POSITIVE_INFINITY
+    let max = Number.NEGATIVE_INFINITY
+    let sum = 0
+    for (let i = 0; i < i32.length; i++) {
+      const v = i32[i]
+      if (v < min) {
+        min = v
+      }
+      if (v > max) {
+        max = v
+      }
+      sum += v
+    }
+
+    expect(min).toBe(EXPECTED.min)
+    // Regression guard: the buggy native-LE misread produced max > 2e9.
+    expect(max).toBe(EXPECTED.max)
+    expect(sum).toBe(EXPECTED.sum)
+    expect(i32[EXPECTED.midIndex]).toBe(EXPECTED.midValue)
+  })
+})

--- a/packages/niivue/src/volume/readers/mgh.test.ts
+++ b/packages/niivue/src/volume/readers/mgh.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { NiiDataType } from '@/NVConstants'
+import { calMinMax, toTypedViewOrU8 } from '@/volume/utils'
 import { read } from './mgh'
 
 // A real FreeSurfer INT32 (MRI_INT) volume. MGH/MGZ is big-endian, so an
@@ -36,15 +37,20 @@ describe('mgh reader (big-endian INT32 MGZ)', () => {
     expect(hdr.dims[2]).toBe(256)
     expect(hdr.dims[3]).toBe(256)
 
-    // View the returned bytes exactly as the platform (and toTypedViewOrU8)
-    // reads them: a native Int32Array. After the fix these are the true values.
-    const bytes = img instanceof Uint8Array ? img : new Uint8Array(img)
-    const i32 = new Int32Array(
-      bytes.buffer,
-      bytes.byteOffset,
-      bytes.byteLength / 4,
-    )
+    // Exercise the same conversion and range calculation used by nii2volume.
+    // Returning Uint8Array from the reader would bypass this conversion and
+    // incorrectly treat each byte as a voxel.
+    expect(img).toBeInstanceOf(ArrayBuffer)
+    const i32 = toTypedViewOrU8(img, hdr.datatypeCode)
+    expect(i32).toBeInstanceOf(Int32Array)
+    if (!(i32 instanceof Int32Array)) {
+      throw new Error('Expected MGH INT32 data to become an Int32Array')
+    }
     expect(i32.length).toBe(256 * 256 * 256)
+
+    const [, , globalMin, globalMax] = calMinMax(hdr, img)
+    expect(globalMin).toBe(EXPECTED.min)
+    expect(globalMax).toBe(EXPECTED.max)
 
     let min = Number.POSITIVE_INFINITY
     let max = Number.NEGATIVE_INFINITY

--- a/packages/niivue/src/volume/readers/mgh.ts
+++ b/packages/niivue/src/volume/readers/mgh.ts
@@ -8,6 +8,37 @@ import type { NIFTI1, NIFTI2, TypedVoxelArray } from '@/NVTypes'
 export const extensions = ['mgh', 'mgz']
 export const type = 'nii'
 
+/**
+ * True on little-endian platforms (every browser). MGH/MGZ image data is stored
+ * big-endian, but the typed-array views built downstream (toTypedViewOrU8) read
+ * in platform-native byte order — so on little-endian hosts multi-byte samples
+ * must be swapped to native order first.
+ */
+function isPlatformLittleEndian(): boolean {
+  return new Uint8Array(new Uint32Array([1]).buffer)[0] === 1
+}
+
+/** Reverse the byte order of every `elemSize`-byte sample in place (2 or 4). */
+function swapBytesInPlace(bytes: Uint8Array, elemSize: number): void {
+  const n = bytes.length
+  if (elemSize === 2) {
+    for (let i = 0; i + 1 < n; i += 2) {
+      const t = bytes[i]
+      bytes[i] = bytes[i + 1]
+      bytes[i + 1] = t
+    }
+  } else if (elemSize === 4) {
+    for (let i = 0; i + 3 < n; i += 4) {
+      let t = bytes[i]
+      bytes[i] = bytes[i + 3]
+      bytes[i + 3] = t
+      t = bytes[i + 1]
+      bytes[i + 1] = bytes[i + 2]
+      bytes[i + 2] = t
+    }
+  }
+}
+
 export async function read(
   buffer: ArrayBuffer | Uint8Array,
   filename: string,
@@ -145,6 +176,15 @@ export async function read(
   const expectedBytes = nVoxels * nBytesPerVoxel
   // Return only the raw image data buffer
   const imgRaw = raw.slice(hdr.vox_offset, hdr.vox_offset + expectedBytes)
+  // MGH/MGZ image data is big-endian. Downstream typed-array views read in
+  // platform-native byte order, so on little-endian hosts swap multi-byte
+  // samples (INT16/INT32/FLOAT32) to native order; single-byte UCHAR needs none.
+  // Without this, e.g. an INT32 aseg decodes to garbage (old niivue byte-swapped
+  // in optimizeFreeSurferLabels).
+  if (nBytesPerVoxel > 1 && isPlatformLittleEndian()) {
+    swapBytesInPlace(imgRaw, nBytesPerVoxel)
+  }
+  hdr.littleEndian = isPlatformLittleEndian()
   // label detection based on:
   // https://github.com/pwighton/mgz-optimize/blob/main/mgz_optimize.py
   // option 1: detect label by version number

--- a/packages/niivue/src/volume/readers/mgh.ts
+++ b/packages/niivue/src/volume/readers/mgh.ts
@@ -245,7 +245,10 @@ export async function read(
     isLabel = mgLabelFiles.some((label) => filename.includes(label))
   }
   return {
-    img: imgRaw,
+    // Readers must return raw multi-byte data as an ArrayBuffer so nii2volume
+    // converts it to the typed array selected by hdr.datatypeCode. Returning
+    // Uint8Array here would make downstream code treat every byte as a voxel.
+    img: imgRaw.buffer,
     hdr: hdr,
   }
 }


### PR DESCRIPTION
This is a fix #81

- Two helper functions have been added to `volume/readers/mgh.ts`:
  - `isPlatformLittleEndian()`
  - `swapBytesInPlace(bytes, elemSize)`
- When `nBytesPerVoxel > 1` and `isPlatformLittleEndian()`, `swapBytesInPlace` is called
- `hdr.littleEndian` is set to `isPlatformLittleEndian()`
- A new volume `./packages/dev-images/images/volumes/fs/brainmask-int.mgz` has been added to the LFS for testing
  - It is simply `./packages/dev-images/images/volumes/fs/brainmask.mgz`, converted to INTs
- New tests using `brainmask-int.mgz` have been created
- Closes #81 