### PR TITLE
[FIX] url-nvd without calmin calmax defined

### DIFF
--- a/packages/niivue/src/NVDocument.ts
+++ b/packages/niivue/src/NVDocument.ts
@@ -13,6 +13,7 @@ import {
   type SettingsSavePolicy,
   sparsifyGroup,
 } from '@/documentSettings'
+import { urlVolumeOptions } from '@/documentVolumeOptions'
 import { getDrawingBitmap } from '@/drawing/drawingManager'
 import { encodeRLE } from '@/drawing/rle'
 import { log } from '@/logger'
@@ -889,22 +890,11 @@ export async function reconstructVolume(
       if (v.frame4D !== undefined) base.frame4D = v.frame4D
       await model.addVolume(base)
     } else if (v.url) {
-      // Load from URL
-      await model.addVolume({
-        url: v.url,
-        name: v.name,
-        colormap: v.colormap,
-        colormapNegative: v.colormapNegative,
-        opacity: v.opacity,
-        calMin: v.calMin,
-        calMax: v.calMax,
-        calMinNeg: v.calMinNeg,
-        calMaxNeg: v.calMaxNeg,
-        colormapType: v.colormapType,
-        isTransparentBelowCalMin: v.isTransparentBelowCalMin,
-        modulateAlpha: v.modulateAlpha,
-        isColorbarVisible: v.isColorbarVisible,
-      })
+      // Load from URL. Forward only the fields the document actually specifies
+      // (urlVolumeOptions drops undefined) so an omitted calMin/calMax doesn't
+      // clobber the window nii2volume computes at load, mirroring the guarded
+      // embedded branch above.
+      await model.addVolume(urlVolumeOptions(v))
     }
     // Apply post-load properties to the just-added volume
     const vol = model.volumes[model.volumes.length - 1]

--- a/packages/niivue/src/documentVolumeOptions.test.ts
+++ b/packages/niivue/src/documentVolumeOptions.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'bun:test'
+import type { NVDocumentVolume } from '@/NVDocument'
+import { urlVolumeOptions } from './documentVolumeOptions'
+
+// Guards the fix for URL-referenced document volumes losing their auto-computed
+// contrast window: reconstructVolume forwards only document-specified fields to
+// addVolume, so an omitted calMin/calMax no longer clobbers what nii2volume
+// computes (which left the volume unrendered until a manual contrast reset).
+describe('urlVolumeOptions', () => {
+  test('dropsUndefinedFieldsSoComputedWindowSurvives', () => {
+    const opts = urlVolumeOptions({
+      url: 'brain.nii.gz',
+      name: 'brain',
+      colormap: 'gray',
+    })
+    expect(opts.url).toBe('brain.nii.gz')
+    expect(opts.name).toBe('brain')
+    expect(opts.colormap).toBe('gray')
+    // The document omitted these, so they must NOT appear as undefined keys
+    // (that is exactly what clobbered the computed window).
+    expect('calMin' in opts).toBe(false)
+    expect('calMax' in opts).toBe(false)
+    expect('calMinNeg' in opts).toBe(false)
+    expect('calMaxNeg' in opts).toBe(false)
+    expect('colormapType' in opts).toBe(false)
+    expect('opacity' in opts).toBe(false)
+    expect('isColorbarVisible' in opts).toBe(false)
+  })
+
+  test('forwardsDefinedFields', () => {
+    const v: NVDocumentVolume = {
+      url: 'brain.nii.gz',
+      colormapNegative: 'winter',
+      calMin: 30,
+      calMax: 80,
+      calMinNeg: -80,
+      calMaxNeg: -30,
+      colormapType: 1,
+      isTransparentBelowCalMin: false,
+      modulateAlpha: 1,
+    }
+    const opts = urlVolumeOptions(v)
+    expect(opts.calMin).toBe(30)
+    expect(opts.calMax).toBe(80)
+    expect(opts.calMinNeg).toBe(-80)
+    expect(opts.calMaxNeg).toBe(-30)
+    expect(opts.colormapNegative).toBe('winter')
+    expect(opts.colormapType).toBe(1)
+    expect(opts.isTransparentBelowCalMin).toBe(false)
+    expect(opts.modulateAlpha).toBe(1)
+  })
+
+  test('keepsFalsyButDefinedValues', () => {
+    // 0 / false are defined and must be forwarded — a naive truthy check would
+    // wrongly drop `calMin: 0` (a valid window minimum).
+    const opts = urlVolumeOptions({
+      url: 'x.nii.gz',
+      opacity: 0,
+      calMin: 0,
+      isColorbarVisible: false,
+    })
+    expect(opts.opacity).toBe(0)
+    expect(opts.calMin).toBe(0)
+    expect(opts.isColorbarVisible).toBe(false)
+  })
+
+  test('throwsWithoutUrl', () => {
+    expect(() => urlVolumeOptions({ name: 'no-url' })).toThrow()
+  })
+})

--- a/packages/niivue/src/documentVolumeOptions.ts
+++ b/packages/niivue/src/documentVolumeOptions.ts
@@ -1,0 +1,44 @@
+import type { NVDocumentVolume } from '@/NVDocument'
+import type { ImageFromUrlOptions } from '@/NVTypes'
+
+/**
+ * Build the `addVolume` options for a URL-referenced document volume, forwarding
+ * only the fields the document actually specifies.
+ *
+ * `reconstructVolume`'s URL branch passes these straight into `addVolume` ->
+ * `prepareVolume`, whose `{ ...base, ...volumeDefaults, ...overrides }` merge
+ * treats an explicit `undefined` as a value and overwrites what it spreads. So a
+ * document that omits `calMin`/`calMax` (e.g. one authored before any viewer
+ * computed them) would wipe the robust window `nii2volume` derived at load,
+ * leaving the volume unrendered until a manual contrast reset. Dropping undefined
+ * fields here lets those computed defaults survive — matching how the
+ * embedded-data branch guards each field with `!== undefined`.
+ *
+ * Extracted as a standalone leaf for Bun-testability: `reconstructVolume`'s
+ * module evaluates Vite's `import.meta.glob` transitively, which the Bun test
+ * runner can't load. Uses `!== undefined` (not a truthy check) so legitimate
+ * falsy values (`calMin: 0`, `opacity: 0`, `isColorbarVisible: false`) are kept.
+ */
+export function urlVolumeOptions(v: NVDocumentVolume): ImageFromUrlOptions {
+  if (v.url === undefined) {
+    throw new Error('urlVolumeOptions requires a document volume with a url')
+  }
+  const opts: ImageFromUrlOptions = { url: v.url }
+  if (v.name !== undefined) opts.name = v.name
+  if (v.colormap !== undefined) opts.colormap = v.colormap
+  if (v.colormapNegative !== undefined)
+    opts.colormapNegative = v.colormapNegative
+  if (v.opacity !== undefined) opts.opacity = v.opacity
+  if (v.calMin !== undefined) opts.calMin = v.calMin
+  if (v.calMax !== undefined) opts.calMax = v.calMax
+  if (v.calMinNeg !== undefined) opts.calMinNeg = v.calMinNeg
+  if (v.calMaxNeg !== undefined) opts.calMaxNeg = v.calMaxNeg
+  if (v.colormapType !== undefined) opts.colormapType = v.colormapType
+  if (v.isTransparentBelowCalMin !== undefined) {
+    opts.isTransparentBelowCalMin = v.isTransparentBelowCalMin
+  }
+  if (v.modulateAlpha !== undefined) opts.modulateAlpha = v.modulateAlpha
+  if (v.isColorbarVisible !== undefined)
+    opts.isColorbarVisible = v.isColorbarVisible
+  return opts
+}


### PR DESCRIPTION
This is a fix for #83

- Reconstructing a URL-referenced volume now forwards only document-specified fields to `addVolume`, so an omitted `calMin`/`calMax` (or any other optional field) no longer overwrites the value computed at load with `undefined`, and the volume renders immediately instead of blank.
 - Defines `urlVolumeOptions(v: NVDocumentVolume): ImageFromUrlOptions` which copies only the fields that are `!== undefined` on the document volume.  Implemented in a separate file (`documentVolumeOptions.ts`) so that it is testable with bun
 - In `NVDocument.ts`, the URL branch of `reconstructVolume` now calls `await model.addVolume(urlVolumeOptions(v))`
 - Closes #83 