### PR TITLE
fix(niivue): publish ctrl.view only after init() resolves

### DIFF
--- a/packages/niivue/e2e/attach-before-load.spec.ts
+++ b/packages/niivue/e2e/attach-before-load.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from '@playwright/test'
+
+// niivue/mono#61: loading a volume while attachToCanvas was still initializing threw
+// `createBindGroup ... 'buffer' ... Required member is undefined` and left a random
+// subset of canvases blank. attachToCanvas assigned ctrl.view before awaiting
+// view.init(), so the `if (!this.view) return` guard in updateGLVolume waved the load
+// through to a view whose device already existed but whose buffers did not.
+//
+// The concurrent-load test only reproduces where a real WebGPU adapter exists (a
+// headed run, or a GPU-backed runner). Headless chromium reports no adapter, so init
+// fails at its first step and the WebGL2 fallback serves the load. The view-publishing
+// test holds the invariant in either environment.
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/examples/index.html', { waitUntil: 'load' })
+})
+
+// Import NiiVue and expose a factory for throwaway offscreen canvases.
+const setup = `
+  const { default: NiiVue } = await import('/src/index.ts')
+  const mkCanvas = () => {
+    const c = document.createElement('canvas')
+    c.width = 64; c.height = 64
+    c.style.cssText = 'position:fixed;left:-9999px'
+    document.body.appendChild(c)
+    return c
+  }
+`
+
+test('attachToCanvas does not publish the view until init resolves', async ({
+  page,
+}) => {
+  test.setTimeout(90_000)
+
+  const r = await page.evaluate(`(async () => {
+    ${setup}
+    const nv = new NiiVue({ backend: 'webgpu' })
+    const attaching = nv.attachToCanvas(mkCanvas())
+    const during = nv.view
+    await attaching
+    return { duringIsNull: during === null, afterIsSet: nv.view !== null }
+  })()`)
+
+  expect(r.duringIsNull).toBe(true)
+  expect(r.afterIsSet).toBe(true)
+})
+
+test('a volume loaded concurrently with attach still loads', async ({
+  page,
+}) => {
+  test.setTimeout(90_000)
+
+  const r = await page.evaluate(`(async () => {
+    ${setup}
+    const nv = new NiiVue({ backend: 'webgpu' })
+    const attaching = nv.attachToCanvas(mkCanvas())
+    let error = null
+    const loading = nv
+      .loadVolumes([{ url: '/volumes/mni152.nii.gz' }])
+      .catch((e) => { error = e.message })
+    await Promise.all([attaching, loading])
+    return { error, volumes: nv.volumes.length }
+  })()`)
+
+  expect(r.error).toBeNull()
+  expect(r.volumes).toBe(1)
+})

--- a/packages/niivue/src/control/viewBoth.ts
+++ b/packages/niivue/src/control/viewBoth.ts
@@ -154,6 +154,11 @@ export async function attachToCanvas(
   const order: ('webgpu' | 'webgl2')[] =
     ctrl.opts.backend === 'webgl2' ? ['webgl2'] : ['webgpu', 'webgl2']
   let lastError: unknown
+  // ctrl.view is the readiness signal every GPU-touching path tests
+  // (`if (!this.view) return`), so it is published only once init() resolves.
+  // Exposing it earlier lets a concurrent load reach half-built buffers (#61).
+  let view: NVViewGL | NVViewGPU | null = null
+  ctrl.view = null
   for (let i = 0; i < order.length; i++) {
     const backend = order[i]
     ctrl.opts.backend = backend
@@ -173,26 +178,26 @@ export async function attachToCanvas(
         `${order[i - 1]} backend unavailable; falling back to ${backend}`,
       )
     }
-    ctrl.view =
+    const candidate =
       backend === 'webgl2'
         ? new NVViewGL(canvas, ctrl.model, ctrl.opts)
         : new NVViewGPU(canvas, ctrl.model, ctrl.opts)
     try {
-      await ctrl.view.init() // Single async entry point
+      await candidate.init() // Single async entry point
+      view = candidate
       break
     } catch (error) {
       lastError = error
       log.error(`Failed to initialize ${backend} view:`, error)
       try {
-        ctrl.view?.destroy()
+        candidate.destroy()
       } catch {
         // a view that failed mid-init may not destroy cleanly; ignore
       }
-      ctrl.view = null
     }
   }
+  ctrl.view = view
 
-  const view = ctrl.view
   if (!view) {
     // Every available backend failed. Don't leave the controller registered, and
     // restore the originally requested backend so a later retry starts fresh.
@@ -310,6 +315,7 @@ export async function recreateView(
   // 1. Destroy current view
   ctrl.emit('viewDestroyed')
   ctrl.view?.destroy()
+  ctrl.view = null
   // 2. Clear GPU resources from model (keeps mesh/volume data)
   ctrl.model.clearAllGPUResources()
   // 3. Remove event listeners from old canvas
@@ -325,21 +331,13 @@ export async function recreateView(
     replaceCanvasElement(ctrl)
   }
   // 6. Create new view with current settings
-  if (ctrl.opts.backend === 'webgl2') {
-    ctrl.view = new NVViewGL(
-      ctrl.canvas as HTMLCanvasElement,
-      ctrl.model,
-      ctrl.opts,
-    )
-  } else {
-    ctrl.view = new NVViewGPU(
-      ctrl.canvas as HTMLCanvasElement,
-      ctrl.model,
-      ctrl.opts,
-    )
-  }
-  // 7. Initialize the new view
-  await ctrl.view.init()
+  const view =
+    ctrl.opts.backend === 'webgl2'
+      ? new NVViewGL(ctrl.canvas as HTMLCanvasElement, ctrl.model, ctrl.opts)
+      : new NVViewGPU(ctrl.canvas as HTMLCanvasElement, ctrl.model, ctrl.opts)
+  // 7. Initialize the new view, publishing it only once init() resolves
+  await view.init()
+  ctrl.view = view
   // 7b. Reload thumbnail if it was active before recreation
   if (ctrl.opts.thumbnail && ctrl.model.ui.isThumbnailVisible) {
     await ctrl.view.loadThumbnail(ctrl.opts.thumbnail as string)

--- a/packages/niivue/src/control/viewWebGL2.ts
+++ b/packages/niivue/src/control/viewWebGL2.ts
@@ -48,24 +48,28 @@ export async function attachToCanvas(
   ctrl.canvas = canvas
   clearCanvasMessage(canvas)
   registerCanvasInstance(ctrl, canvas)
-  ctrl.view = new NVViewGL(canvas, ctrl.model, ctrl.opts)
+  // Publish ctrl.view only once init() resolves; a view exposed mid-init is
+  // indistinguishable from a ready one to `if (!this.view) return` callers (#61).
+  const view = new NVViewGL(canvas, ctrl.model, ctrl.opts)
+  ctrl.view = null
   try {
-    await ctrl.view.init()
+    await view.init()
+    ctrl.view = view
     if (ctrl.opts.thumbnail) {
       ctrl.model.ui.isThumbnailVisible = true
       ctrl.model.ui.thumbnailUrl = ctrl.opts.thumbnail as string
-      await ctrl.view.loadThumbnail(ctrl.model.ui.thumbnailUrl)
+      await view.loadThumbnail(ctrl.model.ui.thumbnailUrl)
     }
     initInteraction(ctrl)
     setupDragAndDrop(ctrl)
     setupResizeHandler(ctrl)
-    ctrl.view.resize()
+    view.resize()
     return ctrl
   } catch (error) {
     log.error('Failed to initialize view:', error)
     // Tear down the partially-initialized view so a retry starts clean.
     try {
-      ctrl.view?.destroy()
+      view.destroy()
     } catch {
       // a view that failed mid-init may not destroy cleanly; ignore
     }
@@ -77,6 +81,7 @@ export async function attachToCanvas(
 
 export async function recreateView(ctrl: NiiVue): Promise<void> {
   ctrl.view?.destroy()
+  ctrl.view = null
   ctrl.model.clearAllGPUResources()
   removeInteractionListeners(ctrl)
   if (ctrl.resizeObserver) {
@@ -89,8 +94,9 @@ export async function recreateView(ctrl: NiiVue): Promise<void> {
   const newCanvas = oldCanvas.cloneNode(false) as HTMLCanvasElement
   parent?.replaceChild(newCanvas, oldCanvas)
   ctrl.canvas = newCanvas
-  ctrl.view = new NVViewGL(ctrl.canvas, ctrl.model, ctrl.opts)
-  await ctrl.view.init()
+  const view = new NVViewGL(ctrl.canvas, ctrl.model, ctrl.opts)
+  await view.init()
+  ctrl.view = view
   if (ctrl.opts.thumbnail && ctrl.model.ui.isThumbnailVisible) {
     await ctrl.view.loadThumbnail(ctrl.opts.thumbnail as string)
   }

--- a/packages/niivue/src/control/viewWebGPU.ts
+++ b/packages/niivue/src/control/viewWebGPU.ts
@@ -48,25 +48,29 @@ export async function attachToCanvas(
   ctrl.canvas = canvas
   clearCanvasMessage(canvas)
   registerCanvasInstance(ctrl, canvas)
-  ctrl.view = new NVViewGPU(canvas, ctrl.model, ctrl.opts)
+  // Publish ctrl.view only once init() resolves; a view exposed mid-init is
+  // indistinguishable from a ready one to `if (!this.view) return` callers (#61).
+  const view = new NVViewGPU(canvas, ctrl.model, ctrl.opts)
+  ctrl.view = null
   try {
-    await ctrl.view.init()
+    await view.init()
+    ctrl.view = view
     if (ctrl.opts.thumbnail) {
       ctrl.model.ui.isThumbnailVisible = true
       ctrl.model.ui.thumbnailUrl = ctrl.opts.thumbnail as string
-      await ctrl.view.loadThumbnail(ctrl.model.ui.thumbnailUrl)
+      await view.loadThumbnail(ctrl.model.ui.thumbnailUrl)
     }
     initInteraction(ctrl)
     setupDragAndDrop(ctrl)
     setupResizeHandler(ctrl)
-    ctrl.view.resize()
+    view.resize()
     return ctrl
   } catch (error) {
     log.error('Failed to initialize view:', error)
     // Tear down the partially-initialized view so a retry starts clean (no leaked
     // GPU/context resources, no stale ctrl.view).
     try {
-      ctrl.view?.destroy()
+      view.destroy()
     } catch {
       // a view that failed mid-init may not destroy cleanly; ignore
     }
@@ -79,6 +83,7 @@ export async function attachToCanvas(
 
 export async function recreateView(ctrl: NiiVue): Promise<void> {
   ctrl.view?.destroy()
+  ctrl.view = null
   ctrl.model.clearAllGPUResources()
   removeInteractionListeners(ctrl)
   if (ctrl.resizeObserver) {
@@ -92,8 +97,9 @@ export async function recreateView(ctrl: NiiVue): Promise<void> {
   const newCanvas = oldCanvas.cloneNode(false) as HTMLCanvasElement
   parent?.replaceChild(newCanvas, oldCanvas)
   ctrl.canvas = newCanvas
-  ctrl.view = new NVViewGPU(ctrl.canvas, ctrl.model, ctrl.opts)
-  await ctrl.view.init()
+  const view = new NVViewGPU(ctrl.canvas, ctrl.model, ctrl.opts)
+  await view.init()
+  ctrl.view = view
   if (ctrl.opts.thumbnail && ctrl.model.ui.isThumbnailVisible) {
     await ctrl.view.loadThumbnail(ctrl.opts.thumbnail as string)
   }


### PR DESCRIPTION
Fixes #61.

Calling `loadVolumes()` / `addVolume()` while `attachToCanvas()` is still initializing throws:

```
TypeError: Failed to execute 'createBindGroup' on 'GPUDevice': ... Failed to read
the 'buffer' property from 'GPUBufferBinding': Required member is undefined.
```

Downstream this surfaced as a random subset of tiles reading "Failed to load image" when adding images one after another (21 of 48 in the original report). Same symptom, same cause.

## Root cause

`attachToCanvas` assigned `ctrl.view` before awaiting `view.init()`:

```ts
ctrl.view = new NVViewGPU(canvas, ctrl.model, ctrl.opts)
await ctrl.view.init()
```

`ctrl.view` is the readiness signal every GPU-touching path tests. `updateGLVolume` and `updateVolumeAffineOnly` both guard with `if (!this.view) return`, which is already true the instant attach *starts*. `addVolume()` ends in `updateGLVolume()`, so a load racing attach was waved straight through to a half-built view.

Inside that view, `NVViewGPU.updateBindGroups()` guards on `device` alone, then dereferences `this.buffers.lineStorage`. `_initWebGPU()` sets `device` early; `_createResources()` assigns `buffers.lineStorage` last, after eight awaited renderer inits. Everything in between is the window.

Every load races it. A failure only appears when the coin lands badly, which is why slow volumes and many live canvases make it frequent.

## The fix

Build the view into a local and publish it only once `init()` resolves, in both `attachToCanvas` and `recreateView` across `viewBoth.ts`, `viewWebGPU.ts` and `viewWebGL2.ts`.

This makes the guard that already exists in ~23 places mean what it says, rather than gating one call site. No new API surface: `await nv.attachToCanvas(canvas)` is already the readiness promise.

The resulting early return is safe because init self-heals. `NVViewGPU.init()` ends with its own `updateBindGroups()` and `NVViewGL.init()` with `_updateBindings()`, both of which read `model.getVolumes()`, and `attachToCanvas` ends with `view.resize()`, which renders. A volume added during init is still uploaded and drawn, verified by the second test below.

`recreateView` now also clears `ctrl.view` next to the `destroy()` that orphans it, rather than leaving a reference to a destroyed view.

## Tests

New `e2e/attach-before-load.spec.ts`:

| | pre-fix headless | pre-fix headed | post-fix |
| --- | --- | --- | --- |
| view is not published until init resolves | fail | fail | pass |
| concurrent load still loads | pass | **fail, with the #61 error** | pass |

The concurrent-load test only reproduces where a real WebGPU adapter exists. Headless chromium exposes `navigator.gpu` but `requestAdapter()` returns null, so init fails at its first step and the WebGL2 fallback serves the load cleanly. I tried `--enable-unsafe-webgpu`, `--use-angle=swiftshader`, `--enable-features=Vulkan` and the full `chromium` channel; no adapter under any of them. That constraint is written into the spec header. The view-publishing test discriminates in both environments, so the regression stays guarded either way.

To see the original failure:

```bash
cd packages/niivue && bunx playwright test attach-before-load --headed
```

## Verification

- e2e 21/21 headed, 21/21 headless
- unit 796 pass, 0 fail
- `nx run niivue:lint`, `:typecheck`, `:build` clean
- `check-boundaries` clean, codespell clean (CI's exact invocation)

## Note on scope

Two things I had also flagged while diagnosing this turned out to be fixed already on main: the `isBusy` try/finally in `updateBindGroups`, and the WebGL2 fallback when `requestAdapter()` returns null. This PR is only the remaining race.
