### PR TITLE
[codex] fix medgfx inspector styling and backend defaults

### DIFF
--- a/apps/medgfx/medgfx/ContentView.swift
+++ b/apps/medgfx/medgfx/ContentView.swift
@@ -74,7 +74,11 @@ struct ContentView: View {
         .sheet(isPresented: sheetBinding) {
             #if os(iOS)
             NavigationStack {
-                InspectorContainer(model: model, panels: InspectorPanels.all)
+                InspectorContainer(
+                    model: model,
+                    panels: InspectorPanels.all,
+                    fillsAvailableWidth: true
+                )
                     .navigationTitle("Inspector")
                     .navigationBarTitleDisplayMode(.inline)
                     .toolbar {

--- a/apps/medgfx/medgfx/Inspector/InspectorContainer.swift
+++ b/apps/medgfx/medgfx/Inspector/InspectorContainer.swift
@@ -14,12 +14,18 @@ import SwiftUI
 struct InspectorContainer: View {
     let model: NiiVueModel
     let panels: [AnyInspectorPanel]
+    let fillsAvailableWidth: Bool
 
     @State private var selection: String
 
-    init(model: NiiVueModel, panels: [AnyInspectorPanel]) {
+    init(
+        model: NiiVueModel,
+        panels: [AnyInspectorPanel],
+        fillsAvailableWidth: Bool = false
+    ) {
         self.model = model
         self.panels = panels
+        self.fillsAvailableWidth = fillsAvailableWidth
         _selection = State(initialValue: panels.first?.id ?? "")
     }
 
@@ -52,7 +58,11 @@ struct InspectorContainer: View {
                 }
             }
         }
-        .frame(minWidth: 280, idealWidth: 320, maxWidth: 380)
+        .frame(
+            minWidth: 280,
+            idealWidth: fillsAvailableWidth ? nil : 320,
+            maxWidth: fillsAvailableWidth ? .infinity : 380
+        )
         #if os(macOS)
         .background(.regularMaterial)
         #else

--- a/apps/medgfx/web/src/main.ts
+++ b/apps/medgfx/web/src/main.ts
@@ -11,6 +11,7 @@ function $<T extends HTMLElement>(id: string): T {
 const canvas = $<HTMLCanvasElement>('gl1')
 
 const nv = new NiiVue({
+  backend: 'webgl2',
   backgroundColor: [0, 0, 0, 1],
   isColorbarVisible: false,
   // On by default. NiiVue's own default is 0; this is the value the Chrome

--- a/apps/medgfx/web/src/quicklook.ts
+++ b/apps/medgfx/web/src/quicklook.ts
@@ -471,10 +471,9 @@ async function main(): Promise<void> {
     nv = new NiiVue({
       logLevel: 'warn',
       backgroundColor: [0, 0, 0, 1],
-      // Same reasoning as the app: naming a backend lets the constructor
-      // downgrade to webgl2 up front instead of failing an init and swapping in
-      // a fresh canvas. WKWebView has no navigator.gpu today.
-      backend: 'webgpu',
+      // WKWebView does not expose navigator.gpu, so request WebGL2 directly
+      // instead of relying on NiiVue's WebGPU-to-WebGL2 downgrade.
+      backend: 'webgl2',
       isOrientCubeVisible: false,
       isRadiological: false, // "neurological orientation" from the product contract
       showRender: SHOW_RENDER.ALWAYS,


### PR DESCRIPTION
- Fix the two-tone iOS inspector sheet background.
- Default the medgfx app and Quick Look previews to WebGL 2.
- Validate iOS/macOS builds and all 89 Quick Look preview checks.
- Closes #95.
- Closes #96.
