### PR TITLE
perf(medgfx): budget Quick Look previews from the NIfTI header

### DIFF
--- a/apps/medgfx/AGENTS.md
+++ b/apps/medgfx/AGENTS.md
@@ -37,7 +37,9 @@ apps/medgfx/
 ├── scripts/
 │   ├── install-quicklook.sh       build, register, prove which binary Finder uses
 │   ├── check-preview-file-kind.sh runs the routing self-check
-│   ├── check-preview-file-kind.swift
+│   ├── check-header-budget.sh     header-first budget checks
+│   ├── check-gzip-bound.sh        gzip-bomb regression
+│   ├── *.swift                    the checks themselves
 │   ├── generate-about-authors.ts  generate About authors from medgfx Git history
 │   └── about-author-name-map.json override Git identities with display names
 ├── medgfxTests/                   (unused, Xcode-generated)
@@ -347,6 +349,24 @@ Known, deliberate, and not blocking. Each is a decision, not an oversight.
   the tree. The original iOS plan is explicit that the host should own this
   transport and that Quick Look should reuse it; in medgfx that is inverted. Do
   it when a volume is measurably slow.
+- **The budget asks the header first, and budgets what is MATERIALISED.** A
+  NIfTI header states the decoded size exactly and sits at byte 0, so a bounded
+  ~1 ms inflate answers what the streaming bound spends hundreds of ms
+  measuring. More importantly it measures the right thing: for a 4D series the
+  preview asks for one frame, and NiiVue's partial loader streams
+  `vox_offset + one frame` and cancels. Measured: a 594 MB 4D volume renders in
+  10 MB of JS heap, and a real 156 MB DWI series went from 710 ms to 0 ms.
+  Budgeting the payload had been refusing files the page handles trivially.
+
+  **This is coupled to NiiVue, not independent of it** — the same class as the
+  first-member rule above. `VolumeHeader.parse` accepts exactly the headers
+  `loadPartialNifti1` accepts: little-endian NIfTI-1, single-file (`n+1`),
+  non-RGB-vector, more than one frame. Widen one without the other and a large
+  4D file is fully inflated with no bound. 3D volumes, NIfTI-2, byte-swapped
+  headers and every non-NIfTI format still go through the streaming bound,
+  because those really are inflated whole. `scripts/check-header-budget.sh`
+  pins both halves — a 4D file over the cap must be accepted, a 3D one refused.
+
 - **The inflate bound covers the OUTER gzip member only.** It is called
   unconditionally on content (never gated on the filename — that was a real
   hole, see below), but NiiVue inflates in places this cannot see: NRRD's
@@ -369,8 +389,8 @@ Known, deliberate, and not blocking. Each is a decision, not an oversight.
   NiiVue also allocates `Float32Array(nVox3D*3)` + `Uint8Array(nVox3D*4)`, so
   for uint8 data the content-process peak is roughly **17x** what the gate
   counts. Conservative in the right direction; a real number needs a device
-  measurement. Consequence: an oversize legitimate 4D series is refused outright
-  rather than shown at frame zero.
+  measurement. (4D series are no longer the casualty of this — see the
+  header-first budget below.)
 - **Preview teardown does not release the NiiVue instance or the `WKWebView`.**
   The WebGL context, decoded volume and 3D textures live until the controller
   deallocates. Bounded by preview lifetime. `webView.load(about:blank)` is not

--- a/apps/medgfx/QuickLookPreview/GzipPeek.swift
+++ b/apps/medgfx/QuickLookPreview/GzipPeek.swift
@@ -62,6 +62,35 @@ enum GzipPeek {
         return data.distance(from: data.startIndex, to: index)
     }
 
+
+    /// Inflate (or read) a bounded prefix from the start of `url`.
+    ///
+    /// Gzip is forward-only, but a NIfTI header lives at byte 0, so no random
+    /// access is needed — the first block of the stream is all it takes.
+    /// Returns raw bytes when the file is not gzip.
+    static func prefix(ofFileAt url: URL, bytes wanted: Int) -> Data? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+        guard let head = try? handle.read(upToCount: compressedBudget), !head.isEmpty else { return nil }
+        guard let offset = deflateOffset(in: head), offset < head.count else {
+            // Not gzip: the bytes are already the header.
+            return head.prefix(wanted)
+        }
+        let deflate = head[head.index(head.startIndex, offsetBy: offset)...]
+        var out = Data(count: wanted)
+        let produced: Int = out.withUnsafeMutableBytes { dst -> Int in
+            guard let dstBase = dst.bindMemory(to: UInt8.self).baseAddress else { return 0 }
+            return deflate.withUnsafeBytes { src -> Int in
+                guard let srcBase = src.bindMemory(to: UInt8.self).baseAddress else { return 0 }
+                // A short result is success: the prefix legitimately ends
+                // mid-stream because we asked for a bounded number of bytes.
+                return compression_decode_buffer(dstBase, wanted, srcBase, deflate.count, nil, COMPRESSION_ZLIB)
+            }
+        }
+        guard produced > 0 else { return nil }
+        return out.prefix(produced)
+    }
+
     /// True when the gzip member at `url` inflates to more than `limit` bytes.
     ///
     /// The whole memory policy for compressed input, now that routing is by

--- a/apps/medgfx/QuickLookPreview/PreviewViewController.swift
+++ b/apps/medgfx/QuickLookPreview/PreviewViewController.swift
@@ -382,6 +382,45 @@ class PreviewViewController: NSViewController, QLPreviewingController, WKScriptM
         // anyway. The attacker picks the name, so the name cannot select the
         // defence. `inflatedSize` already returns false for non-gzip input, so
         // the cost for an ordinary uncompressed file is one 64 KiB read.
+        //
+        // FIRST, though, ask the header. A NIfTI header states the decoded size
+        // exactly and sits at byte 0, so a ~1 ms bounded inflate can answer what
+        // the streaming bound spends hundreds of milliseconds measuring — and it
+        // answers a better question, because for a 4D series the preview never
+        // materialises the whole payload.
+        if let header = VolumeHeader.read(atFileURL: url) {
+            if header.partialLoadEligible {
+                // NiiVue's partial loader streams `vox_offset + one frame` and
+                // cancels, so the rest of the series is never inflated. Budget
+                // what is actually allocated. Measured: a 594 MB 4D volume
+                // renders in 10 MB of JS heap; budgeting the payload refused it.
+                //
+                // COUPLED, not independent — the same caveat as the first-member
+                // rule in `GzipPeek`. This is only safe while NiiVue's
+                // `loadPartialNifti1` preconditions hold, which is why
+                // `VolumeHeader.parse` accepts exactly the headers that loader
+                // accepts (little-endian NIfTI-1, single-file, non-RGB-vector,
+                // more than one frame). Widen one without the other and a large
+                // 4D file is fully inflated with no bound. The partial loader
+                // also needs `DecompressionStream`, guaranteed on our
+                // deployment target; on an older WebKit it would fall back to a
+                // full load that this budget does not cover.
+                if header.firstFrameBytes > maxDecodedBytes {
+                    log.error("one frame exceeds the decoded budget")
+                    return .resourceLimit
+                }
+                return nil
+            }
+            // Full load: everything the header describes gets inflated. Refuse
+            // early when the header alone is already over budget — no point
+            // streaming a payload we know we will reject.
+            if header.allFramesBytes > maxDecodedBytes {
+                log.error("header claims \(header.allFramesBytes / (1024 * 1024)) MB decoded")
+                return .resourceLimit
+            }
+            // Header says it fits, but a header can lie about what follows it,
+            // so fall through to the payload bound below.
+        }
         if GzipPeek.inflatedSize(ofFileAt: url, exceeds: maxDecodedBytes) {
             log.error("gzip payload exceeds the decoded budget")
             return .resourceLimit

--- a/apps/medgfx/QuickLookPreview/VolumeHeader.swift
+++ b/apps/medgfx/QuickLookPreview/VolumeHeader.swift
@@ -1,0 +1,111 @@
+//
+//  VolumeHeader.swift
+//  What a NIfTI header says will actually be materialised.
+//
+//  The point is not to identify the format — `PreviewFileKind` does that by
+//  name. The point is that a NIfTI header states the decoded size exactly, in
+//  the first 348 bytes (NIfTI-1) or 540 (NIfTI-2), and those bytes sit at the
+//  very start of the stream. Gzip is forward-only, but byte 0 needs no random
+//  access, so a ~1 ms bounded inflate answers a question the streaming bound
+//  otherwise spends hundreds of milliseconds on.
+//
+//  It also answers a BETTER question. `GzipPeek.inflatedSize` measures what the
+//  file CONTAINS. For a 4D series the preview never materialises that — it asks
+//  NiiVue for one frame, and NiiVue's partial loader streams `vox_offset + one
+//  frame` and cancels. Measured: a 594 MB 4D volume renders in 10 MB of JS heap.
+//  Budgeting the whole payload refused files the page handles trivially.
+//
+//  Anything this cannot describe — NIfTI-2, byte-swapped, `.mgz`, `.nrrd.gz`,
+//  `.gii.gz`, meshes — falls back to the streaming bound, which is unchanged.
+//
+
+import Foundation
+
+struct VolumeHeader {
+    /// Where image data starts: the header plus any extensions.
+    let voxOffset: Int
+    /// Bytes in ONE 3D frame.
+    let frameBytes: Int
+    /// Frames across dim[4..6]. 1 for a plain 3D volume.
+    let totalFrames: Int
+    /// True when NiiVue's partial 4D loader will engage for this file, so only
+    /// the first frame is ever inflated. See `partialLoadEligible` below.
+    let partialLoadEligible: Bool
+
+    /// What the content process allocates when only frame zero is wanted.
+    var firstFrameBytes: Int { voxOffset + frameBytes }
+    /// What it allocates when the whole file must be inflated.
+    var allFramesBytes: Int { voxOffset + frameBytes * totalFrames }
+
+    /// Bytes to inflate before parsing. Covers a NIfTI-2 header (540) with room
+    /// for a NIfTI-1 header plus a small extension.
+    static let prefixBytes = 1024
+
+    /// Parse a NIfTI-1 header from `data`, or nil if it is not one.
+    ///
+    /// **Little-endian NIfTI-1 only, deliberately.** This is not laziness about
+    /// byte order — it is the precondition for the fast path being *correct*.
+    /// `loadPartialNifti1` in NiiVue rejects a byte-swapped or NIfTI-2 header
+    /// and falls back to a full load, so for those the whole payload really is
+    /// inflated and the streaming bound is the honest measure. Widening this
+    /// parser without widening NiiVue's would under-count.
+    static func parse(_ data: Data) -> VolumeHeader? {
+        let bytes = [UInt8](data)
+        guard bytes.count >= 348 else { return nil }
+
+        func i32(_ o: Int) -> Int32 {
+            Int32(bytes[o]) | Int32(bytes[o + 1]) << 8 | Int32(bytes[o + 2]) << 16 | Int32(bytes[o + 3]) << 24
+        }
+        func i16(_ o: Int) -> Int16 { Int16(bytes[o]) | Int16(bytes[o + 1]) << 8 }
+        func f32(_ o: Int) -> Float { Float(bitPattern: UInt32(bitPattern: i32(o))) }
+
+        // 348 little-endian is the whole gate. A byte-swapped file reads as
+        // 0x5C010000 here and is declined, which is what we want.
+        guard i32(0) == 348 else { return nil }
+        // `n+1\0` — a single-file NIfTI. A detached `ni1\0` pair has its image
+        // in a sibling we neither claim nor can read.
+        guard bytes[344] == 0x6E, bytes[345] == 0x2B, bytes[346] == 0x31 else { return nil }
+
+        let dim = (0...7).map { Int(i16(40 + $0 * 2)) }
+        let bitpix = Int(i16(72))
+        // dim[0] is the rank; a value outside 1...7 means a header we should not
+        // be doing arithmetic on.
+        guard dim[0] >= 1, dim[0] <= 7, bitpix > 0, bitpix % 8 == 0 else { return nil }
+
+        // A dimension of 0 is written by some tools where 1 is meant; clamping
+        // matches how NiiVue computes `nVox3D`/`nTotal`.
+        func extent(_ i: Int) -> Int { dim[i] > 1 ? dim[i] : 1 }
+        let nVox3D = extent(1) * extent(2) * extent(3)
+        let frames = extent(4) * extent(5) * extent(6)
+        guard nVox3D > 0, frames > 0 else { return nil }
+
+        // Overflow is the reason these are checked rather than multiplied
+        // blindly: dims are attacker-controlled and 16-bit each, so a crafted
+        // header can otherwise wrap Int on the multiply.
+        let (frameBytes, frameOverflow) = nVox3D.multipliedReportingOverflow(by: bitpix / 8)
+        guard !frameOverflow else { return nil }
+
+        let voxOffset = Int(f32(108))
+        // vox_offset is an integer byte count stored as a float. Reject NaN,
+        // negatives, sub-header values and anything past the prefix we read.
+        guard f32(108).isFinite, voxOffset >= 348, voxOffset <= prefixBytes else { return nil }
+
+        let intentCode = Int(i16(68))
+        // Intent 1007 is NIFTI_INTENT_VECTOR (RGB vector); NiiVue declines the
+        // partial path for it because dim4 is components, not time.
+        let eligible = frames > 1 && intentCode != 1007
+
+        return VolumeHeader(
+            voxOffset: voxOffset,
+            frameBytes: frameBytes,
+            totalFrames: frames,
+            partialLoadEligible: eligible
+        )
+    }
+
+    /// Read and parse the header of the file at `url`, inflating if needed.
+    static func read(atFileURL url: URL) -> VolumeHeader? {
+        guard let data = GzipPeek.prefix(ofFileAt: url, bytes: prefixBytes) else { return nil }
+        return parse(data)
+    }
+}

--- a/apps/medgfx/scripts/check-header-budget.sh
+++ b/apps/medgfx/scripts/check-header-budget.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Header-first budget: 4D over the cap is accepted, 3D over the cap is refused.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+out=$(mktemp -d)/check
+trap 'rm -rf "$(dirname "$out")"' EXIT
+swiftc -o "$out" QuickLookPreview/GzipPeek.swift QuickLookPreview/VolumeHeader.swift \
+  scripts/check-header-budget.swift
+"$out"

--- a/apps/medgfx/scripts/check-header-budget.swift
+++ b/apps/medgfx/scripts/check-header-budget.swift
@@ -1,0 +1,124 @@
+//
+//  check-header-budget.swift
+//  The header-first budget: what gets accepted, what still gets refused.
+//
+//  Run it: bash scripts/check-header-budget.sh
+//
+//  The pairs below are the whole point. A 4D series over the cap must be
+//  ACCEPTED (only one frame is ever inflated), while a 3D volume over the same
+//  cap must still be REFUSED (the whole thing is). If someone widens
+//  `VolumeHeader.parse` past what NiiVue's partial loader accepts, the 3D cases
+//  are what fail.
+//
+
+import Foundation
+
+@main
+enum HeaderBudgetCheck {
+    static let cap = 256 * 1024 * 1024
+    static var failures = 0
+
+    /// Minimal single-file NIfTI-1, little-endian.
+    static func nifti1(dims: [Int16], bitpix: Int16 = 16, intent: Int16 = 0,
+                       magic: String = "n+1", sizeofHdr: Int32 = 348) -> Data {
+        var h = [UInt8](repeating: 0, count: 352)
+        func put32(_ v: Int32, _ o: Int) {
+            let u = UInt32(bitPattern: v)
+            for i in 0..<4 { h[o + i] = UInt8((u >> (8 * UInt32(i))) & 0xFF) }
+        }
+        func put16(_ v: Int16, _ o: Int) {
+            let u = UInt16(bitPattern: v)
+            h[o] = UInt8(u & 0xFF); h[o + 1] = UInt8((u >> 8) & 0xFF)
+        }
+        put32(sizeofHdr, 0)
+        for (i, d) in dims.enumerated() where i < 8 { put16(d, 40 + i * 2) }
+        put16(intent, 68)
+        put16(512, 70)          // DT_UINT16
+        put16(bitpix, 72)
+        put32(Int32(bitPattern: Float(352).bitPattern), 108)  // vox_offset
+        for (i, c) in magic.utf8.enumerated() { h[344 + i] = c }
+        return Data(h)
+    }
+
+    static func expect(_ name: String, _ data: Data,
+                       eligible: Bool?, firstFrameMB: Int?, allMB: Int?) {
+        guard let h = VolumeHeader.parse(data) else {
+            let ok = eligible == nil
+            if !ok { failures += 1 }
+            print("\(ok ? "PASS" : "FAIL")  \(name) -> not a parseable NIfTI-1")
+            return
+        }
+        guard let wantEligible = eligible else {
+            failures += 1
+            print("FAIL  \(name) -> parsed, but should not have")
+            return
+        }
+        var ok = h.partialLoadEligible == wantEligible
+        if let f = firstFrameMB { ok = ok && h.firstFrameBytes / 1048576 == f }
+        if let a = allMB { ok = ok && h.allFramesBytes / 1048576 == a }
+        if !ok { failures += 1 }
+        print("\(ok ? "PASS" : "FAIL")  \(name) -> eligible=\(h.partialLoadEligible)"
+              + " frame=\(h.firstFrameBytes / 1048576)MB all=\(h.allFramesBytes / 1048576)MB")
+    }
+
+    /// What `budgetFailure` would decide, given only the header.
+    static func verdict(_ h: VolumeHeader) -> String {
+        if h.partialLoadEligible { return h.firstFrameBytes > cap ? "refuse" : "accept" }
+        return h.allFramesBytes > cap ? "refuse" : "defer-to-payload-bound"
+    }
+
+    static func expectVerdict(_ name: String, _ data: Data, _ want: String) {
+        guard let h = VolumeHeader.parse(data) else {
+            failures += 1; print("FAIL  \(name) -> unparseable"); return
+        }
+        let got = verdict(h)
+        if got != want { failures += 1 }
+        print("\(got == want ? "PASS" : "FAIL")  \(name) -> \(got)")
+    }
+
+    static func main() {
+        // 104x104x72 uint16 = 1.49 MB per frame.
+        let shape: [Int16] = [4, 104, 104, 72]
+
+        // THE CASE THIS CHANGE EXISTS FOR: 400 frames = 594 MB total, over the
+        // cap, but one frame is 1.49 MB. Must be accepted.
+        expect("4D 400 frames", nifti1(dims: shape + [400]),
+               eligible: true, firstFrameMB: 1, allMB: 594)
+        expectVerdict("4D 400 frames verdict", nifti1(dims: shape + [400]), "accept")
+
+        // The real dataset that prompted this: 105 frames, 156 MB.
+        expectVerdict("4D 105 frames verdict", nifti1(dims: shape + [105]), "accept")
+
+        // THE GUARD: a 3D volume over the cap is fully inflated, so it must NOT
+        // take the fast path. 700x700x700 uint16 = 654 MB.
+        expect("3D oversize", nifti1(dims: [3, 700, 700, 700]),
+               eligible: false, firstFrameMB: nil, allMB: 654)
+        expectVerdict("3D oversize verdict", nifti1(dims: [3, 700, 700, 700]), "refuse")
+
+        // An ordinary 3D volume defers to the payload bound, which is what
+        // catches a lying header.
+        expectVerdict("3D ordinary verdict", nifti1(dims: [3, 104, 104, 72]),
+                      "defer-to-payload-bound")
+
+        // Headers NiiVue's partial loader declines must not take the fast path.
+        expect("RGB vector 4D", nifti1(dims: shape + [3], intent: 1007),
+               eligible: false, firstFrameMB: nil, allMB: nil)
+        expect("detached ni1", nifti1(dims: shape + [400], magic: "ni1"),
+               eligible: nil, firstFrameMB: nil, allMB: nil)
+        expect("NIfTI-2 sizeof_hdr", nifti1(dims: shape + [400], sizeofHdr: 540),
+               eligible: nil, firstFrameMB: nil, allMB: nil)
+        expect("byte-swapped", nifti1(dims: shape + [400], sizeofHdr: 0x5C01_0000),
+               eligible: nil, firstFrameMB: nil, allMB: nil)
+
+        // Malformed headers must be declined, not arithmetic'd on.
+        expect("bitpix 0", nifti1(dims: shape + [400], bitpix: 0),
+               eligible: nil, firstFrameMB: nil, allMB: nil)
+        expect("rank 0", nifti1(dims: [0, 104, 104, 72, 400]),
+               eligible: nil, firstFrameMB: nil, allMB: nil)
+        expect("truncated", Data([UInt8](repeating: 0, count: 100)),
+               eligible: nil, firstFrameMB: nil, allMB: nil)
+
+        print(failures == 0 ? "\nall checks passed" : "\n\(failures) FAILED")
+        exit(failures == 0 ? 0 : 1)
+    }
+}


### PR DESCRIPTION
The decode budget inflated the whole payload to measure it. That is slow, and it measures the wrong thing: for a 4D series the preview asks NiiVue for one frame, and its partial loader streams `vox_offset + one frame` and cancels — the rest is never materialised.

A NIfTI header states the decoded size exactly and sits at byte 0, so a bounded ~1 ms inflate answers it directly. Forward-only streams are fine; no random access needed.

## Measured

| | before | after |
|---|---|---|
| 156 MB DWI series (105 frames) | 710 ms | **0 ms** |
| 594 MB 4D volume (400 frames) | **refused** | accepted, renders in 10 MB JS heap |
| gzip bomb as `.gz` / `.nii` / `.mz3` | refused | refused |
| 3D volume over the cap | refused | refused |

## Coupling — the thing to review

This is coupled to NiiVue, not independent of it. `VolumeHeader.parse` accepts exactly the headers `loadPartialNifti1` accepts: little-endian NIfTI-1, single-file `n+1`, non-RGB-vector, more than one frame. **Widen one without the other and a large 4D file is fully inflated with no bound.**

Everything else — 3D volumes, NIfTI-2, byte-swapped, `.mgz`, `.nrrd.gz`, `.gii.gz`, meshes — keeps the streaming bound unchanged, because those really are inflated whole. A header that fits but lies about its payload still falls through to it.

`scripts/check-header-budget.sh` pins both halves: a 4D file over the cap must be accepted, a 3D one refused.

## Verified

`check-header-budget` · `check-gzip-bound` · `check-preview-file-kind` · 89/89 web e2e · lint · typecheck · boundaries · both 4D files previewed in Finder against a build-stamped binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)