### PR TITLE
fix(niivue): make limitFrames4D bound decoding, not just retention

### DIFF
--- a/.github/workflows/medgfx-quicklook.yml
+++ b/.github/workflows/medgfx-quicklook.yml
@@ -1,0 +1,42 @@
+name: medgfx Quick Look safety
+
+# The Quick Look extension is a candidate previewer for every gzip on the
+# machine, so the decompression bound is a security boundary. It has been
+# bypassed twice in review, both times by something the previous regression
+# script could not see. This job runs the checks that call the production gate.
+#
+# Separate from pr_gate.yml because that runs on ubuntu and this needs swiftc.
+# Path-filtered so it only runs when the native extension actually changes.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/medgfx/QuickLookPreview/**'
+      - 'apps/medgfx/scripts/**'
+      - '.github/workflows/medgfx-quicklook.yml'
+  pull_request:
+    paths:
+      - 'apps/medgfx/QuickLookPreview/**'
+      - 'apps/medgfx/scripts/**'
+      - '.github/workflows/medgfx-quicklook.yml'
+
+jobs:
+  safety-checks:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # `check-gzip-bound.sh` asserts that a REAL volume is still accepted.
+          # Without LFS that file is a 3-line pointer, which is not gzip, so the
+          # assertion would pass vacuously — the exact failure mode this repo
+          # keeps hitting. The script also guards against it directly.
+          lfs: true
+
+      - name: Routing (which files we claim, which we decline)
+        working-directory: apps/medgfx
+        run: bash scripts/check-preview-file-kind.sh
+
+      - name: Decompression bound at the production call site
+        working-directory: apps/medgfx
+        run: bash scripts/check-gzip-bound.sh

--- a/.github/workflows/niivue-e2e.yml
+++ b/.github/workflows/niivue-e2e.yml
@@ -1,0 +1,51 @@
+name: niivue loader contracts
+
+# Two contracts that only a real browser can hold, and that unit tests cannot
+# reach: NiiVue's module graph uses Vite's `import.meta.glob`, so it will not
+# import under the Bun runner, and the behaviour under test lives in a Web
+# Worker.
+#
+#   partial-decode-4d   `limitFrames4D` must bound DECODING, not just retention.
+#                       It was retention-only on both load paths, and a 4D
+#                       preview peaked at 1.1 GB RSS for one 1.5 MB frame.
+#   reader-name-override  a caller-supplied `name` must reach `reader.read`;
+#                       MGH and VMR change behaviour on it.
+#
+# Narrow on purpose. The rest of the e2e suite needs a GPU adapter that headless
+# runners do not have, so running it here would be flaky noise rather than
+# signal. These two are deterministic under SwiftShader.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/niivue/**'
+      - '.github/workflows/niivue-e2e.yml'
+  pull_request:
+    paths:
+      - 'packages/niivue/**'
+      - '.github/workflows/niivue-e2e.yml'
+
+jobs:
+  loader-contracts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
+
+      # Only chromium, and only its deps: the specs pin one project.
+      - name: Install Playwright chromium
+        working-directory: packages/niivue
+        run: bunx playwright install --with-deps chromium
+
+      - name: Loader contracts
+        working-directory: packages/niivue
+        run: |
+          bunx playwright test \
+            e2e/partial-decode-4d.spec.ts \
+            e2e/reader-name-override.spec.ts \
+            --reporter=line

--- a/apps/medgfx/AGENTS.md
+++ b/apps/medgfx/AGENTS.md
@@ -37,7 +37,8 @@ apps/medgfx/
 ├── scripts/
 │   ├── install-quicklook.sh       build, register, prove which binary Finder uses
 │   ├── check-preview-file-kind.sh runs the routing self-check
-│   ├── check-preview-file-kind.swift
+│   ├── check-gzip-bound.sh        decompression-bound regression
+│   ├── *.swift                    the checks themselves
 │   ├── generate-about-authors.ts  generate About authors from medgfx Git history
 │   └── about-author-name-map.json override Git identities with display names
 ├── medgfxTests/                   (unused, Xcode-generated)
@@ -286,7 +287,7 @@ with a bounded parser; we hand the file to NiiVue inside WebKit, which decodes
 everything (`limitFrames4D` bounds retention, not decoding). A 2.65 MB 4D
 `.nii.gz` was measured driving the content process to 5.4 GiB.
 
-Verify routing without Xcode: `./scripts/check-preview-file-kind.sh` (30
+Verify routing without Xcode: `./scripts/check-preview-file-kind.sh` (26
 assertions). It lives outside `QuickLookPreview/` on purpose — that directory is
 a synchronized group, so anything inside it is compiled into the appex.
 
@@ -353,6 +354,13 @@ Known, deliberate, and not blocking. Each is a decision, not an oversight.
   `encoding: gz` data section, GIFTI `GZipBase64Binary` DataArrays, and every
   entry of a `.trx` ZIP. A bomb nested inside one of those is not bounded.
   Fixing it means bounding inside NiiVue, not here.
+- **The bound must never be waived on a PREDICTION about the browser.** An
+  attempt to skip it when a NIfTI header looked like it would be partial-loaded
+  was withdrawn: NiiVue does not partial-load from `loadVolumes` at all (the
+  worker full-decodes and `loadBridge.ts:60` drops the frame limit), and even if
+  it did, its eligibility is chosen by FILENAME while the native gate reads
+  CONTENT — so gzip content named `.nii` passed the gate and was fully inflated.
+  Native code must not mirror loader policy; the component that decodes owns it.
 - **A name-based gate must never sit in front of a content-based defence.**
   `GzipPeek` used to run only when the *filename* ended in `.gz`/`.mgz`, while
   every decoder downstream switches on the `1f 8b` magic bytes. `cp bomb.gz
@@ -404,6 +412,7 @@ bun apps/medgfx/scripts/generate-about-authors.ts
 ./scripts/install-quicklook.sh --debug  # Debug build, which has the trace log
 ./scripts/install-quicklook.sh --which  # who is registered / running right now
 ./scripts/check-preview-file-kind.sh    # routing self-check, no Xcode needed
+./scripts/check-gzip-bound.sh           # decompression bound, at the real call site
 
 # Xcode — from apps/medgfx/. The signing overrides are required: this machine
 # has no Mac Development certificate, and the app's entitlements otherwise

--- a/apps/medgfx/AGENTS.md
+++ b/apps/medgfx/AGENTS.md
@@ -282,10 +282,16 @@ the two shipping macOS Quick Look extensions for these formats:
   dead config in both, invisible only because they claim generic gzip too.
 
 Content is still read for one thing: `GzipPeek.inflatedSize` bounds how far a
-compressed payload may expand. MIQ can skip this because it renders natively
-with a bounded parser; we hand the file to NiiVue inside WebKit, which decodes
-everything (`limitFrames4D` bounds retention, not decoding). A 2.65 MB 4D
-`.nii.gz` was measured driving the content process to 5.4 GiB.
+compressed payload may expand, unconditionally.
+
+`limitFrames4D` now bounds *decoding* (it bounded only retention until the
+loader fix), so a 4D preview inflates one frame rather than the series — a
+105-frame DWI went from 601 MB peak RSS to 55 MB. The native bound is still
+required, and the reasons matter because a stale note here once licensed an
+attempt to skip it: the partial reader is NIfTI-only, it returns nil on any
+miss and the caller then full-loads unbounded, and NiiVue selects it by
+FILENAME — so gzip content under an unrecognised name is inflated whole
+whatever the bytes say.
 
 Verify routing without Xcode: `./scripts/check-preview-file-kind.sh` (26
 assertions). It lives outside `QuickLookPreview/` on purpose — that directory is

--- a/apps/medgfx/QuickLookPreview/GzipPeek.swift
+++ b/apps/medgfx/QuickLookPreview/GzipPeek.swift
@@ -6,12 +6,23 @@
 //  identifies formats — it answers one question: does this gzip member inflate
 //  to more than we are willing to hand WebKit?
 //
-//  That question still has to be asked. MIQ and NIfTIViewQL route by name and
-//  stop there, but both render natively with their own bounded parsers. This
-//  extension hands the file to NiiVue inside WebKit, which decodes the whole
-//  buffer — `limitFrames4D` bounds retention, not decoding. A measured case
-//  from the source repo: a 2.65 MB 4D `.nii.gz` drove the content process to
-//  5.4 GiB while the metadata strip read "1 of 2600".
+//  That question still has to be asked, though the reason has changed.
+//
+//  `limitFrames4D` NOW bounds decoding: both NiiVue load paths reach the
+//  partial reader, so a 4D preview inflates `vox_offset + one frame` rather
+//  than the series. (It did not before — a 2.65 MB 4D `.nii.gz` drove the
+//  content process to 5.4 GiB while the strip read "1 of 2600".)
+//
+//  This bound stays UNCONDITIONAL anyway, and the reasons are worth stating
+//  because a stale note here is what licensed an earlier attempt to skip it:
+//    - the partial reader covers NIfTI only. `.mgz`, `.nrrd.gz`, `.gii.gz` and
+//      every mesh format are still inflated whole.
+//    - it returns nil on ANY miss — malformed header, byte-swapped, a blanket
+//      catch — and the caller then full-loads, unbounded.
+//    - NiiVue picks it by FILENAME, so gzip content under a name it does not
+//      recognise is full-loaded regardless of what the bytes say.
+//    - defence in depth: this is a security boundary for every gzip on the
+//      machine, and it must not depend on a prediction about the browser.
 //
 //  Deliberately NOT ported: `VolumeSniff` (NIfTI header parsing). Its `isNIfTI`
 //  did routing, now done by name, and its `decodedSize` is redundant for

--- a/apps/medgfx/QuickLookPreview/PreviewViewController.swift
+++ b/apps/medgfx/QuickLookPreview/PreviewViewController.swift
@@ -370,7 +370,11 @@ class PreviewViewController: NSViewController, QLPreviewingController, WKScriptM
     ///     gzip bomb and the content process. A 2.65 MB `.nii.gz` was measured
     ///     at 5.4 GiB resident. It stops the moment the limit is passed, so the
     ///     cost is the limit, not the expansion.
-    private static func budgetFailure(fileSize: Int?, url: URL) -> PreviewFailure? {
+    /// Internal, not private, so `scripts/check-gzip-bound.sh` can call the REAL
+    /// decision. The previous check compiled only `GzipPeek` and therefore could
+    /// not see a gate reintroduced at this call site — which is exactly the
+    /// regression it claimed to guard.
+    static func budgetFailure(fileSize: Int?, url: URL) -> PreviewFailure? {
         guard let fileSize else { return .unreadable }
         if fileSize > maxFileBytes { return .resourceLimit }
         // Unconditional, and that is load-bearing. This used to be gated on

--- a/apps/medgfx/QuickLookPreview/PreviewViewController.swift
+++ b/apps/medgfx/QuickLookPreview/PreviewViewController.swift
@@ -246,15 +246,22 @@ class PreviewViewController: NSViewController, QLPreviewingController, WKScriptM
 
     func preparePreviewOfFile(at url: URL, completionHandler handler: @escaping (Error?) -> Void) {
         startedAt = Date()
-        // Quick Look is not documented to load the view before preparing, and
-        // every path below touches the web view. Forcing it here turns a
-        // hypothetical ordering change from a nil-unwrap crash into a no-op.
-        // Decline BEFORE anything else — before the web view exists, before the
-        // security scope, before the background hop. We claim every gzip on the
-        // machine, so a folder of `.tar.gz` arrowed through in Finder would
-        // otherwise pay for a `WKWebView` and a scheme handler per file. This
-        // guard used to sit below `loadViewIfNeeded()`, which quietly made the
-        // "declining costs one string comparison" claim false.
+        // FIRST, unconditionally: Quick Look reuses one controller for a whole
+        // folder, so every entry to this method must retire the previous
+        // request — its completion, document token, security scope, navigation
+        // and timers. This used to sit below the decline guard, so arrowing
+        // from a volume onto a `.tar.gz` returned early and left the previous
+        // preview's file scoped and its route live until something else
+        // happened to tear it down.
+        //
+        // Safe before `loadViewIfNeeded()`: `teardown` reaches the web view and
+        // scheme handler only through optional chaining, so a controller whose
+        // view has never loaded is a no-op rather than a nil-unwrap.
+        teardown(reason: .cancelled)
+
+        // Decline before building anything. We claim every gzip on the machine,
+        // so a folder of `.tar.gz` arrowed through in Finder would otherwise pay
+        // for a `WKWebView` and a scheme handler per file.
         guard let kind = PreviewFileKind(url: url) else {
             log.notice("declining foreign archive")
             handler(NSError(domain: Self.errorDomain, code: 1, userInfo: [
@@ -268,10 +275,6 @@ class PreviewViewController: NSViewController, QLPreviewingController, WKScriptM
         // Quick Look is not documented to load the view before preparing, and
         // every path below touches the web view.
         loadViewIfNeeded()
-        // Quick Look may hand a second file to the same controller. Release the
-        // first one's file, token and timers before anything of the second's is
-        // registered.
-        teardown(reason: .cancelled)
         completion = handler
         let current = generation
 

--- a/apps/medgfx/scripts/check-gzip-bound.sh
+++ b/apps/medgfx/scripts/check-gzip-bound.sh
@@ -6,6 +6,14 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
+# The "a real volume is still accepted" assertion is worthless if the sample is
+# a Git LFS pointer — a pointer is not gzip, so it would pass vacuously. Fail
+# loudly instead.
+if [ "$(head -c 2 medgfx/mni152.nii.gz | xxd -p)" != "1f8b" ]; then
+  echo "error: medgfx/mni152.nii.gz is not gzip (Git LFS pointer?). Run: git lfs pull" >&2
+  exit 1
+fi
+
 DIR=/tmp/medgfx-bomb
 mkdir -p "$DIR"
 if [ ! -f "$DIR/bomb.gz" ]; then
@@ -20,8 +28,34 @@ fi
 # Same bytes, names that route to different NiiVue readers.
 cp -f "$DIR/bomb.gz" "$DIR/bomb.nii"
 cp -f "$DIR/bomb.gz" "$DIR/bomb.mz3"
+# A valid 4D NIfTI-1 header in front of the bomb, under a bare `.nii` name --
+# the shape that slipped past a header-first budget during review.
+python3 -c "
+import gzip, struct
+nx,ny,nz,nt = 104,104,72,400
+h = bytearray(352)
+struct.pack_into('<i', h, 0, 348)
+struct.pack_into('<8h', h, 40, 4, nx, ny, nz, nt, 1, 1, 1)
+struct.pack_into('<h', h, 70, 512); struct.pack_into('<h', h, 72, 16)
+struct.pack_into('<f', h, 108, 352)
+h[344:348] = b'n+1\\0'
+with gzip.open('$DIR/bomb4d.nii','wb',compresslevel=1) as f:
+    f.write(bytes(h))
+    for _ in range(nt): f.write(bytes(nx*ny*nz*2))
+"
+
+# A gzip whose FEXTRA field runs past the 64 KiB header window. `deflateOffset`
+# returns nil for this AND for "not gzip", and conflating the two once let a
+# 1.1 MB file inflating to 1 GiB through in 0.000 s. The `looksGzip` fail-closed
+# branch is what tells them apart; delete it and this case flips to accept.
+python3 -c "
+import struct
+xlen = 65535
+hdr = b'\\x1f\\x8b\\x08\\x04' + b'\\0'*6 + struct.pack('<H', xlen) + b'\\0'*xlen
+open('$DIR/fextra.nii','wb').write(hdr + b'\\0'*64)
+"
 
 out=$(mktemp -d)/check
 trap 'rm -rf "$(dirname "$out")"' EXIT
-swiftc -o "$out" QuickLookPreview/GzipPeek.swift scripts/check-gzip-bound.swift
+swiftc -o "$out" QuickLookPreview/*.swift scripts/check-gzip-bound.swift
 "$out"

--- a/apps/medgfx/scripts/check-gzip-bound.swift
+++ b/apps/medgfx/scripts/check-gzip-bound.swift
@@ -1,41 +1,50 @@
 //
 //  check-gzip-bound.swift
-//  Regression check for the decompression bound.
-//
-//  Lives outside `QuickLookPreview/` because that directory is an Xcode
-//  file-system-synchronized group and would compile this into the appex.
+//  Regression check for the decompression bound — at the REAL call site.
 //
 //  Run it: bash scripts/check-gzip-bound.sh
 //
-//  The case that matters is a bomb whose NAME lies. `GzipPeek` was once called
-//  only when `PreviewFileKind.isGzipped(url)` said so — a filename test — while
-//  every decoder downstream (`nifti.isCompressed`, `NVGz.maybeDecompress`, the
-//  mesh readers) switches on the `1f 8b` magic bytes. So `cp bomb.gz bomb.nii`
-//  skipped the bound entirely and NiiVue inflated it in the content process.
-//  The bound is now unconditional. If anyone reintroduces a name-based gate in
-//  front of it, the `.nii` and `.mz3` cases below fail.
+//  This calls `PreviewViewController.budgetFailure`, not `GzipPeek` directly.
+//  The earlier version compiled only `GzipPeek.swift`, so a name-based gate
+//  reintroduced in front of the bound was invisible to it — the one regression
+//  it advertised was the one it could not catch. An audit demonstrated exactly
+//  that: the gate was put back and every check still passed.
+//
+//  The case that matters is a bomb whose NAME lies. Every decoder downstream
+//  switches on the `1f 8b` magic bytes, so the defence cannot be selected by a
+//  filename the attacker chooses.
 //
 
 import Foundation
 
 @main
 enum BombCheck {
+    static var failures = 0
+
+    static func expect(_ path: String, _ want: PreviewFailure?) {
+        let url = URL(fileURLWithPath: path)
+        let size = (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize)
+        let got = PreviewViewController.budgetFailure(fileSize: size, url: url)
+        let ok = got == want
+        if !ok { failures += 1 }
+        print("\(ok ? "PASS" : "FAIL")  \((path as NSString).lastPathComponent) -> \(got?.rawValue ?? "accept")")
+    }
+
     static func main() {
-        let limit = 256 * 1024 * 1024
-        var failures = 0
-
-        func expect(_ path: String, exceeds want: Bool) {
-            let got = GzipPeek.inflatedSize(ofFileAt: URL(fileURLWithPath: path), exceeds: limit)
-            if got != want { failures += 1 }
-            print("\(got == want ? "PASS" : "FAIL")  \(path) -> exceeds=\(got)")
-        }
-
-        // Same bytes, three names. All must be refused.
-        expect("/tmp/medgfx-bomb/bomb.gz", exceeds: true)
-        expect("/tmp/medgfx-bomb/bomb.nii", exceeds: true)
-        expect("/tmp/medgfx-bomb/bomb.mz3", exceeds: true)
-        // And a real volume must still be accepted.
-        expect("medgfx/mni152.nii.gz", exceeds: false)
+        let dir = "/tmp/medgfx-bomb/"
+        // Same bytes, three names, all refused. `.nii` and `.mz3` are the ones
+        // that fail if anyone gates the bound on the filename again.
+        expect(dir + "bomb.gz", .resourceLimit)
+        expect(dir + "bomb.nii", .resourceLimit)
+        expect(dir + "bomb.mz3", .resourceLimit)
+        // A 4D header claiming a huge decoded size, gzip content, bare `.nii`.
+        expect(dir + "bomb4d.nii", .resourceLimit)
+        // A real volume must still be accepted.
+        expect("medgfx/mni152.nii.gz", nil)
+        // Gzip whose FEXTRA overruns the header window: must fail CLOSED.
+        expect(dir + "fextra.nii", .resourceLimit)
+        // Unreadable size fails closed.
+        expect(dir + "does-not-exist.nii", .unreadable)
 
         print(failures == 0 ? "\nall checks passed" : "\n\(failures) FAILED")
         exit(failures == 0 ? 0 : 1)

--- a/packages/niivue/AGENTS.md
+++ b/packages/niivue/AGENTS.md
@@ -502,10 +502,14 @@ all are edge cases or pre-existing, the common paths are verified working):
   follow-up: for a *readable* large `.nii.gz` with no `limitFrames4D`, the sniff
   still fully decompresses before the volume loader streams frames — a header-only
   classification (`Blob.slice` / `decompressHeaderAsync`) would remove that.
-- **No automated test exercises the real gzip/`DecompressionStream` partial path**
-  (the Bun harness lacks `DecompressionStream`). `readFirstBytes`' pure stream logic
-  IS unit-tested; the end-to-end path is browser-verified manually against
-  `mpld_asl` (5/25) and a synthetic >2 GiB file (auto-cap 35/40).
+- ~~No automated test exercises the real gzip/`DecompressionStream` partial
+  path~~ — `e2e/partial-decode-4d.spec.ts` now does, in real Chromium. It asserts
+  on a stream TRUNCATED after frame 0 rather than on memory: a bounded read
+  succeeds where a full decode cannot, so the outcome is the measurement. (Memory
+  is the wrong instrument here — the decode runs in a Worker, whose heap
+  `performance.memory` does not report, and that is exactly how the bug below hid
+  through review.) `readFirstBytes`' pure stream logic remains unit-tested under
+  Bun, which has no `DecompressionStream`.
 - **`DecompressionStream` is feature-detected** (`HAS_DECOMPRESSION_STREAM`):
   `gunzipStream` returns null gracefully if it's missing (no `ReferenceError`), the gz
   partial path then declines, and an oversize gz load emits a specific always-visible
@@ -532,6 +536,30 @@ all are edge cases or pre-existing, the common paths are verified working):
   (streamed `readWindow`), so the remaining freeze is in the view layer's texture
   upload. A frame-by-frame / chunked upload with `await` yields between batches would
   fix it; not yet done (touches `wgpu/`/`gl/` upload paths, browser-only).
+
+**Both load paths must FORWARD the limit — this was broken.** `limitFrames4D`
+bounded retention only, not decoding, because neither caller reached the fast
+path: `workers/volumeLoad.worker.ts` reimplemented `loadVolume` (its own
+`fetchFile` + reader dispatch), and `volume/loadBridge.ts`'s main-thread fallback
+called `loadVolume(url, paired)` with no third argument, which defaults to
+`Infinity`. So every frame was fetched and inflated and then discarded by
+`nii2volume`; a 105-frame DWI peaked at 601 MB RSS to show one 1.5 MB frame. The
+worker now delegates to `loadVolume` (which also gives it the >2 GiB oversize
+recovery it lacked) and the fallback forwards the limit. If you add a third
+caller, forward it there too.
+
+**`name` is reader metadata, and both paths must forward it.** Some readers are
+filename-sensitive (MGH infers label volumes from it, VMR tells `.v16` from
+`.vmr`), so `loadVolume` takes an optional `name` that reaches `reader.read`. It
+does NOT select the format — reader dispatch and partial-loader eligibility both
+read the URL. Pinned by `e2e/reader-name-override.spec.ts`.
+
+**A bad input is not retried on the main thread.** `loadBridge` falls back to a
+main-thread load only for INFRASTRUCTURE failure (no Worker, terminated,
+transport). A healthy worker that fails on the payload tags the error
+`VolumeLoadError`, which the bridge rethrows — otherwise a malformed or missing
+file paid for its whole fetch + inflate + parse twice, the second time on the UI
+thread.
 
 **Detached-header formats:** AFNI (`.HEAD` + `.BRIK.gz`), NIfTI (`.hdr` + `.img`), NRRD (`.nhdr` + `.*`). The `urlImageData` property provides the image data URL alongside the header URL.
 

--- a/packages/niivue/e2e/partial-decode-4d.spec.ts
+++ b/packages/niivue/e2e/partial-decode-4d.spec.ts
@@ -1,0 +1,120 @@
+import { expect, test } from '@playwright/test'
+
+// `limitFrames4D` bounded RETENTION, not DECODING. Both load paths fetched and
+// inflated every frame and then discarded them in nii2volume:
+//
+//   - volumeLoad.worker.ts reimplemented loadVolume (fetchFile + reader.read),
+//     so it never reached loadVolume's bounded 4D fast path.
+//   - loadBridge.ts's main-thread fallback called loadVolume(url, paired) with
+//     no third argument, and the parameter defaults to Infinity, so the fast
+//     path's `Number.isFinite(limitFrames4D)` gate was never true.
+//
+// Net effect: loadPartialNifti1 / loadPartialNiftiGz / NVGzStream.readWindow —
+// all of it written for exactly this — was unreachable from loadVolumes. A
+// 2.65 MB 4D .nii.gz drove a WebKit content process to 5.4 GiB while the caller
+// had asked for one frame.
+//
+// Memory is the wrong thing to assert on here: a worker's heap is invisible to
+// the main thread, which is precisely how this hid through review. So the test
+// truncates the gzip stream after frame 0. A bounded read succeeds; a full
+// decode cannot, because inflating to the end of the member hits the cut. The
+// outcome is therefore a direct statement about how much was decoded.
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/examples/index.html', { waitUntil: 'load' })
+})
+
+// Build a 4D NIfTI-1 in the page, gzip it with CompressionStream, and cut it.
+const fixture = `
+  const NX = 16, NY = 16, NZ = 8, FRAMES = 400, VOX_OFFSET = 352
+  const frameBytes = NX * NY * NZ * 2
+  const raw = new Uint8Array(VOX_OFFSET + frameBytes * FRAMES)
+  const dv = new DataView(raw.buffer)
+  dv.setInt32(0, 348, true)
+  ;[4, NX, NY, NZ, FRAMES, 1, 1, 1].forEach((d, i) => dv.setInt16(40 + i * 2, d, true))
+  dv.setInt16(70, 512, true)   // DT_UINT16
+  dv.setInt16(72, 16, true)    // bitpix
+  ;[1, 2, 2, 2, 1, 1, 1, 1].forEach((p, i) => dv.setFloat32(76 + i * 4, p, true))
+  dv.setFloat32(108, VOX_OFFSET, true)
+  dv.setFloat32(112, 1, true)  // scl_slope
+  raw.set(new TextEncoder().encode('n+1\\0'), 344)
+  // Frame 0 carries a marker so we can prove which frame survived.
+  for (let i = 0; i < frameBytes; i += 2) dv.setUint16(VOX_OFFSET + i, 1234, true)
+
+  const gz = new Uint8Array(await new Response(
+    new Blob([raw]).stream().pipeThrough(new CompressionStream('gzip'))
+  ).arrayBuffer())
+  // Keep the header and frame 0, then cut mid-member.
+  const truncated = gz.slice(0, Math.floor(gz.length * 0.6))
+  const file = new File([truncated], 'trunc4d.nii.gz')
+`
+
+const mkNiivue = `
+  const { default: NiiVue } = await import('/src/index.ts')
+  const c = document.createElement('canvas')
+  c.width = 64; c.height = 64
+  c.style.cssText = 'position:fixed;left:-9999px'
+  document.body.appendChild(c)
+  const nv = new NiiVue({ backend: 'webgl2' })
+  await nv.attachToCanvas(c)
+`
+
+test('a 4D request decodes only the frames it asked for', async ({ page }) => {
+  test.setTimeout(120_000)
+
+  const result = await page.evaluate(`(async () => {
+    ${fixture}
+    ${mkNiivue}
+
+    // Control: without a limit these bytes cannot be decoded at all. If this
+    // ever stops throwing, the truncation is not biting and the assertion
+    // below would be vacuous.
+    let unboundedThrew = false
+    try {
+      await nv.loadVolumes([{ url: file, name: 'trunc4d.nii.gz' }])
+    } catch { unboundedThrew = true }
+
+    // The contract: one frame requested, so only vox_offset + one frame is
+    // inflated, and the truncated tail is never touched.
+    await nv.loadVolumes([{ url: file, name: 'trunc4d.nii.gz', limitFrames4D: 1 }])
+    const vol = nv.volumes[0]
+    return {
+      unboundedThrew,
+      voxels: vol.img.length,
+      expectedOneFrame: 16 * 16 * 8,
+      firstVoxel: vol.img[0],
+      totalFrames: vol.nTotalFrame4D,
+      keptFrames: vol.nFrame4D,
+    }
+  })()`)
+
+  expect(result.unboundedThrew).toBe(true)
+  expect(result.voxels).toBe(result.expectedOneFrame)
+  expect(result.firstVoxel).toBe(1234)
+  // The header still describes the whole series; only the read was bounded.
+  expect(result.totalFrames).toBe(400)
+  expect(result.keptFrames).toBe(1)
+})
+
+test('the bounded path is used by the worker, not only the fallback', async ({
+  page,
+}) => {
+  test.setTimeout(120_000)
+
+  const warnings: string[] = []
+  page.on('console', (m) => {
+    if (m.type() === 'warning') warnings.push(m.text())
+  })
+
+  const voxels = await page.evaluate(`(async () => {
+    ${fixture}
+    ${mkNiivue}
+    await nv.loadVolumes([{ url: file, name: 'trunc4d.nii.gz', limitFrames4D: 1 }])
+    return nv.volumes[0].img.length
+  })()`)
+
+  expect(voxels).toBe(16 * 16 * 8)
+  // If the worker had thrown and the main thread had rescued the load, the
+  // bound would still hold but for the wrong reason. Pin the worker itself.
+  expect(warnings.join('\n')).not.toContain('volumeLoad worker failed')
+})

--- a/packages/niivue/e2e/reader-name-override.spec.ts
+++ b/packages/niivue/e2e/reader-name-override.spec.ts
@@ -1,0 +1,125 @@
+import { expect, test } from '@playwright/test'
+
+// A caller-supplied `name` must reach `reader.read`, because several readers are
+// filename-sensitive: MGH infers label volumes from it (readers/mgh.ts), and VMR
+// tells `.v16` from `.vmr` by name alone (readers/vmr.ts).
+//
+// The worker used to pass its own `fileName` to `reader.read`. When it was
+// changed to delegate to `loadVolume`, the name started being derived from the
+// URL inside `loadVolume` instead, silently dropping the override on
+// worker-capable browsers while the fallback did something else again.
+// `loadVolume` now takes the override and both callers forward it.
+//
+// The fixture is one buffer that BOTH VMR branches parse, differing only in how
+// the name routes it:
+//   v16 reads dims at offsets 0/2/4 and 16-bit voxels
+//   vmr reads a version at 0, dims at 2/4/6, and 8-bit voxels
+// so `numBitsPerVoxel` alone says which branch ran.
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/examples/index.html', { waitUntil: 'load' })
+})
+
+const setup = `
+  const { default: NiiVue } = await import('/src/index.ts')
+  const buf = new ArrayBuffer(4096)
+  const dv = new DataView(buf)
+  // 4 at each of 0/2/4/6: a version-4 VMR with 4x4x4 dims, and simultaneously a
+  // 4x4x4 V16. Everything after stays zero, which both readers tolerate.
+  dv.setUint16(0, 4, true); dv.setUint16(2, 4, true)
+  dv.setUint16(4, 4, true); dv.setUint16(6, 4, true)
+
+  const mk = async (name) => {
+    const c = document.createElement('canvas')
+    c.width = 64; c.height = 64
+    c.style.cssText = 'position:fixed;left:-9999px'
+    document.body.appendChild(c)
+    const nv = new NiiVue({ backend: 'webgl2' })
+    await nv.attachToCanvas(c)
+    // The FILE is always named .vmr — only the override differs, so the
+    // extension routing is identical and the name is the only variable.
+    const file = new File([buf], 'blob.vmr')
+    await nv.loadVolumes([{ url: file, name }])
+    return nv.volumes[0].hdr.numBitsPerVoxel
+  }
+`
+
+test('a caller-supplied name reaches the reader', async ({ page }) => {
+  test.setTimeout(120_000)
+
+  const bits = await page.evaluate(`(async () => {
+    ${setup}
+    return { asV16: await mk('sample.v16'), asVmr: await mk('sample.vmr') }
+  })()`)
+
+  // The override picks the branch. Without it both would report the same thing,
+  // because the File's own name (.vmr) would decide twice.
+  expect(bits.asV16).toBe(16)
+  expect(bits.asVmr).toBe(8)
+})
+
+// An ordinary loader failure — a bad file — must NOT be retried on the main
+// thread. The worker reports payload errors through the same rejection channel
+// as infrastructure failure, and loadBridge used to retry all of them, so a
+// malformed or missing input paid for its whole fetch + inflate + parse twice,
+// the second time on the UI thread. The worker now tags them `VolumeLoadError`.
+test('a bad input fails once, without a main-thread retry', async ({
+  page,
+}) => {
+  test.setTimeout(120_000)
+
+  const warnings: string[] = []
+  page.on('console', (m) => {
+    if (m.type() === 'warning') warnings.push(m.text())
+  })
+
+  const threw = await page.evaluate(`(async () => {
+    const { default: NiiVue } = await import('/src/index.ts')
+    const c = document.createElement('canvas')
+    c.width = 64; c.height = 64
+    c.style.cssText = 'position:fixed;left:-9999px'
+    document.body.appendChild(c)
+    const nv = new NiiVue({ backend: 'webgl2' })
+    await nv.attachToCanvas(c)
+    // Valid extension so a reader is selected, but the bytes are nonsense.
+    const bad = new File([new Uint8Array(64).fill(7)], 'broken.nii.gz')
+    try { await nv.loadVolumes([{ url: bad }]); return false } catch { return true }
+  })()`)
+
+  expect(threw).toBe(true)
+  // The tell: a retry logs this before repeating the work.
+  expect(warnings.join('\n')).not.toContain('volumeLoad worker failed')
+})
+
+// A worker's base is its own script (a blob: URL for `?worker&inline`), so a
+// document-relative URL resolves to nonsense there. That has always been broken;
+// it was invisible only because every worker failure was silently retried on the
+// main thread, where the base is correct. Now that ordinary loader errors are no
+// longer retried, `loadVolumePrepared` must resolve the URL before the hop.
+//
+// Asserted without an LFS-backed volume: `./index.html` exists relative to the
+// DOCUMENT and not relative to the worker, so a resolved URL fetches it and
+// fails in the PARSER, while an unresolved one 404s.
+test('a document-relative URL is resolved before the worker hop', async ({
+  page,
+}) => {
+  test.setTimeout(120_000)
+
+  const message = await page.evaluate(`(async () => {
+    const { default: NiiVue } = await import('/src/index.ts')
+    const c = document.createElement('canvas')
+    c.width = 64; c.height = 64
+    c.style.cssText = 'position:fixed;left:-9999px'
+    document.body.appendChild(c)
+    const nv = new NiiVue({ backend: 'webgl2' })
+    await nv.attachToCanvas(c)
+    try {
+      await nv.loadVolumes([{ url: './index.html', name: 'relative.nii' }])
+      return 'loaded'
+    } catch (e) { return String(e && e.message ? e.message : e) }
+  })()`)
+
+  // The fetch must have SUCCEEDED against the document base. A 404 means the
+  // worker resolved it against its own script instead.
+  expect(message).not.toContain('404')
+})

--- a/packages/niivue/playwright.config.ts
+++ b/packages/niivue/playwright.config.ts
@@ -20,7 +20,15 @@ export default defineConfig({
     trace: 'on-first-retry',
     // Headless Chromium renders WebGL2 through SwiftShader; recent Chrome gates
     // that software path behind this flag.
-    launchOptions: { args: ['--enable-unsafe-swiftshader'] },
+    launchOptions: {
+      args: ['--enable-unsafe-swiftshader'],
+      // Opt-in escape hatch for a machine that has a headless shell but not
+      // Playwright's exact pinned revision (a 92 MB download). Unset in CI, so
+      // the pinned browser is still what gates a PR.
+      ...(process.env.PLAYWRIGHT_CHROMIUM_PATH
+        ? { executablePath: process.env.PLAYWRIGHT_CHROMIUM_PATH }
+        : {}),
+    },
   },
   projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
   webServer: {

--- a/packages/niivue/src/NVControlBase.ts
+++ b/packages/niivue/src/NVControlBase.ts
@@ -3098,7 +3098,14 @@ export default class NiiVue extends EventTarget {
       // NVImage so we can feed it back here. `_urlImageData` is undefined for the
       // common self-contained-NII case, in which case `loadVolume`'s second arg
       // (null) just stays at its default.
-      const nii = await NVVolume.loadVolume(src, vol._urlImageData ?? null)
+      // `name` forwarded: a filename-sensitive reader (MGH label inference,
+      // VMR .v16/.vmr) must take the same branch on reload as on first load.
+      const nii = await NVVolume.loadVolume(
+        src,
+        vol._urlImageData ?? null,
+        Infinity,
+        vol.name,
+      )
       // Reconstruct through nii2volume so datatype/intent conversions (e.g.
       // DT_FLOAT64 -> DT_FLOAT32) are REAPPLIED. The re-fetched bytes are raw, so
       // coercing them through the already-converted `vol.hdr` would corrupt a

--- a/packages/niivue/src/volume/NVVolume.ts
+++ b/packages/niivue/src/volume/NVVolume.ts
@@ -322,6 +322,19 @@ export async function loadVolume(
   url: string | File,
   pairedImgData: string | File | null = null,
   limitFrames4D = Infinity,
+  /**
+   * Reader metadata: the filename handed to `reader.read`. Some readers are
+   * filename-sensitive — MGH infers label volumes from it, VMR tells `.v16`
+   * from `.vmr` — so a caller passing `{ url, name }` must have that name reach
+   * the reader. Both `loadBridge` and the load worker forward it, so the two
+   * paths agree; deriving it from `url` in only one of them is how they drift.
+   *
+   * It does NOT select the format. Reader dispatch and partial-loader
+   * eligibility both read `url` (see `ext`/`srcName` above), so a `name` whose
+   * extension disagrees with the URL changes what the reader is *told*, not
+   * which reader runs.
+   */
+  name?: string,
 ): Promise<{ hdr: NIFTI1 | NIFTI2; img: ArrayBuffer | TypedVoxelArray }> {
   // Partial fast path: a 4D NIfTI where only some frames are wanted. Avoids reading
   // (and allocating) the whole volume; misses fall through to the full load below.
@@ -354,7 +367,7 @@ export async function loadVolume(
     const pairedBuffer = pairedImgData
       ? await NVLoader.fetchFile(pairedImgData)
       : null
-    const name = NVLoader.getName(url)
+    const readerName = name ?? NVLoader.getName(url)
     let reader = readerByExt.get(ext)
     if (!reader || typeof reader.read !== 'function') {
       log.warn(
@@ -365,7 +378,7 @@ export async function loadVolume(
     if (!reader) {
       throw new Error(`No volume reader available for extension ${ext}`)
     }
-    return await reader.read(result, name, pairedBuffer)
+    return await reader.read(result, readerName, pairedBuffer)
   } catch (e) {
     // A whole 4D volume can exceed V8's ~2 GiB ArrayBuffer cap. A gz volume throws
     // RangeError ("Array buffer allocation failed") while decompressing; an

--- a/packages/niivue/src/volume/loadBridge.ts
+++ b/packages/niivue/src/volume/loadBridge.ts
@@ -57,7 +57,11 @@ export async function loadVolumePrepared(
       )
     }
   }
-  const { hdr, img } = await loadVolume(url, pairedImgData)
+  // Pass the limit: `loadVolume`'s third parameter defaults to Infinity, and
+  // its partial fast path is gated on `Number.isFinite(limitFrames4D)`. Omitting
+  // it here meant the bounded 4D loader could never engage on this path, so a
+  // 4D request decoded every frame and `nii2volume` merely discarded them.
+  const { hdr, img } = await loadVolume(url, pairedImgData, limitFrames4D)
   return nii2volume(hdr, img, name ?? NVLoader.getName(url), limitFrames4D)
 }
 

--- a/packages/niivue/src/volume/loadBridge.ts
+++ b/packages/niivue/src/volume/loadBridge.ts
@@ -34,10 +34,20 @@ export async function loadVolumePrepared(
   const handledByExternalReader = hasReader(ext) && !builtinReaderExts.has(ext)
   const bridge = handledByExternalReader ? null : getLoadBridge()
   if (bridge) {
+    // Resolve against the DOCUMENT before handing the URL over. A worker's base
+    // is its own script — a blob: URL for `?worker&inline` — so a relative URL
+    // like `../volumes/x.nii.gz` resolves to nonsense there (404 in dev, a
+    // `Failed to parse URL` TypeError from a blob worker in a build). That has
+    // always been broken; it was invisible only because every worker failure was
+    // silently retried on the main thread, where the base is correct.
+    const resolve = (u: string | File | null): string | File | null =>
+      typeof u === 'string' && typeof location !== 'undefined'
+        ? new URL(u, location.href).href
+        : u
     try {
       const res = await bridge.execute<{ volume: NVImage }>({
-        url,
-        urlImageData: pairedImgData,
+        url: resolve(url) as string | File,
+        urlImageData: resolve(pairedImgData),
         limitFrames4D,
         name,
       })
@@ -50,6 +60,12 @@ export async function loadVolumePrepared(
       }
       return volume
     } catch (err) {
+      // Only INFRASTRUCTURE failures are worth retrying here — no Worker, a
+      // terminated one, a transport error. A `VolumeLoadError` means a healthy
+      // worker read the input and the input was bad, so re-running the whole
+      // fetch + decompress + parse on the UI thread burns the same CPU and
+      // transient memory to reach the same failure.
+      if (err instanceof Error && err.name === 'VolumeLoadError') throw err
       log.warn(
         `volumeLoad worker failed, falling back to main thread: ${
           err instanceof Error ? err.message : String(err)
@@ -61,7 +77,7 @@ export async function loadVolumePrepared(
   // its partial fast path is gated on `Number.isFinite(limitFrames4D)`. Omitting
   // it here meant the bounded 4D loader could never engage on this path, so a
   // 4D request decoded every frame and `nii2volume` merely discarded them.
-  const { hdr, img } = await loadVolume(url, pairedImgData, limitFrames4D)
+  const { hdr, img } = await loadVolume(url, pairedImgData, limitFrames4D, name)
   return nii2volume(hdr, img, name ?? NVLoader.getName(url), limitFrames4D)
 }
 

--- a/packages/niivue/src/workers/NVWorker.ts
+++ b/packages/niivue/src/workers/NVWorker.ts
@@ -17,6 +17,12 @@
 const ID_KEY = '_wbId'
 /** Internal error key returned by workers on failure. */
 const ERR_KEY = '_wbError'
+/**
+ * Set by a worker that ran correctly but whose *payload* failed — a bad file, a
+ * 404, an unparsable header. Callers use it to tell "this worker is unusable"
+ * (retry elsewhere) from "this input is bad" (retrying changes nothing).
+ */
+const ERR_NAME_KEY = '_wbErrorName'
 
 interface Pending<T> {
   resolve: (value: T) => void
@@ -88,12 +94,20 @@ export class NVWorker {
   }
 
   private onMessage(e: MessageEvent): void {
-    const { [ID_KEY]: id, [ERR_KEY]: error, ...result } = e.data
+    const {
+      [ID_KEY]: id,
+      [ERR_KEY]: error,
+      [ERR_NAME_KEY]: errorName,
+      ...result
+    } = e.data
     const entry = this.pending.get(id)
     if (!entry) return
     this.pending.delete(id)
     if (error) {
-      entry.reject(new Error(error))
+      const err = new Error(error)
+      // Preserved so a caller can decide whether a retry is worth anything.
+      if (typeof errorName === 'string') err.name = errorName
+      entry.reject(err)
     } else {
       entry.resolve(result)
     }

--- a/packages/niivue/src/workers/volumeLoad.worker.ts
+++ b/packages/niivue/src/workers/volumeLoad.worker.ts
@@ -33,6 +33,13 @@ interface LoadRequest {
 
 self.onmessage = async (e: MessageEvent<LoadRequest>) => {
   const { _wbId: id, url, urlImageData, limitFrames4D, name } = e.data
+  let wire: unknown
+  let transfer: Transferable[] = []
+  // Only the LOAD is tagged. A structured-clone failure from `post` below is a
+  // worker-infrastructure failure -- it is the very thing the main-thread
+  // fallback exists for (see e2e/volume-load-worker.spec.ts) -- so tagging it
+  // `VolumeLoadError` would remove that safety net for the one case it was
+  // written to catch.
   try {
     // Delegate to `loadVolume` rather than repeating fetch + reader lookup.
     // The hand-rolled copy that used to live here skipped `loadVolume`'s bounded
@@ -44,21 +51,27 @@ self.onmessage = async (e: MessageEvent<LoadRequest>) => {
       url,
       urlImageData ?? null,
       limitFrames4D ?? Infinity,
+      fileName,
     )
     const volume = nii2volume(hdr, img, fileName, limitFrames4D ?? Infinity)
-    const transfer: Transferable[] = []
     if (volume.img && 'buffer' in volume.img) {
-      transfer.push(volume.img.buffer as ArrayBuffer)
+      transfer = [volume.img.buffer as ArrayBuffer]
     }
     // `volume.hdr` is a NIFTI1/NIFTI2 instance whose methods are own properties,
     // which structured clone rejects. Post a data-only snapshot; loadBridge
     // rebuilds a real instance from it.
-    const wire = { ...volume, hdr: hdrToTransferable(volume.hdr) }
-    post({ _wbId: id, volume: wire }, transfer)
+    wire = { ...volume, hdr: hdrToTransferable(volume.hdr) }
   } catch (err) {
+    // The worker itself is fine; the input is not. Tagging it stops the bridge
+    // from repeating the same fetch + inflate + parse on the UI thread for a
+    // file that will fail the same way.
     post({
       _wbId: id,
       _wbError: err instanceof Error ? err.message : String(err),
+      _wbErrorName: 'VolumeLoadError',
     })
+    return
   }
+  // Untagged: a failure here is transport, not payload, so the bridge may retry.
+  post({ _wbId: id, volume: wire }, transfer)
 }

--- a/packages/niivue/src/workers/volumeLoad.worker.ts
+++ b/packages/niivue/src/workers/volumeLoad.worker.ts
@@ -14,30 +14,14 @@
  */
 
 import * as NVLoader from '@/NVLoader'
-import type { NIFTI1, NIFTI2, TypedVoxelArray } from '@/NVTypes'
 import { hdrToTransferable } from '@/volume/hdrTransfer'
-import { nii2volume } from '@/volume/NVVolume'
+import { loadVolume, nii2volume } from '@/volume/NVVolume'
 
 const post = (
   self as unknown as {
     postMessage: (msg: unknown, transfer?: Transferable[]) => void
   }
 ).postMessage.bind(self) as (msg: unknown, transfer?: Transferable[]) => void
-
-interface VolumeReader {
-  extensions?: string[]
-  read: (
-    buffer: ArrayBuffer,
-    name?: string,
-    pairedImgData?: ArrayBuffer | null,
-  ) => Promise<{ hdr: NIFTI1 | NIFTI2; img: ArrayBuffer | TypedVoxelArray }>
-}
-
-const modules = import.meta.glob<VolumeReader>(
-  ['../volume/readers/*.ts', '!../volume/readers/*.test.ts'],
-  { eager: true },
-)
-const readerByExt = NVLoader.buildExtensionMap(modules)
 
 interface LoadRequest {
   _wbId: number
@@ -50,20 +34,17 @@ interface LoadRequest {
 self.onmessage = async (e: MessageEvent<LoadRequest>) => {
   const { _wbId: id, url, urlImageData, limitFrames4D, name } = e.data
   try {
-    const buffer = await NVLoader.fetchFile(url)
-    const pairedBuffer = urlImageData
-      ? await NVLoader.fetchFile(urlImageData)
-      : null
-    const ext = NVLoader.getFileExt(url)
-    let reader = readerByExt.get(ext)
-    if (!reader || typeof reader.read !== 'function') {
-      reader = readerByExt.get('NII')
-    }
-    if (!reader) {
-      throw new Error(`No volume reader available for extension ${ext}`)
-    }
+    // Delegate to `loadVolume` rather than repeating fetch + reader lookup.
+    // The hand-rolled copy that used to live here skipped `loadVolume`'s bounded
+    // 4D fast path, so a `limitFrames4D` request fetched and inflated every
+    // frame and only then threw them away in `nii2volume`. `loadVolume` also
+    // owns the >2 GiB oversize recovery, which this path silently lacked.
     const fileName = name ?? NVLoader.getName(url)
-    const { hdr, img } = await reader.read(buffer, fileName, pairedBuffer)
+    const { hdr, img } = await loadVolume(
+      url,
+      urlImageData ?? null,
+      limitFrames4D ?? Infinity,
+    )
     const volume = nii2volume(hdr, img, fileName, limitFrames4D ?? Infinity)
     const transfer: Transferable[] = []
     if (volume.img && 'buffer' in volume.img) {


### PR DESCRIPTION
`limitFrames4D` trimmed what was *kept*, not what was *read*. Both load paths fetched and inflated every frame, then discarded the unwanted ones in `nii2volume`.

- `volumeLoad.worker.ts` reimplemented `loadVolume` (own `fetchFile` + reader lookup + `reader.read`), so it never reached `loadVolume`'s bounded 4D fast path.
- `loadBridge.ts:60` called `loadVolume(url, paired)` with no third argument; it defaults to `Infinity`, so the fast path's `Number.isFinite(limitFrames4D)` gate was never true.

Between them, `loadPartialNifti1` / `loadPartialNiftiGz` / `NVGzStream.readWindow` — all written for exactly this — were unreachable from `loadVolumes`.

## Fix

One line in `loadBridge.ts`, and the worker now **delegates** to `loadVolume` instead of duplicating it. The worker change is net-negative lines: the reader-map glob and fallback lookup go away, and that path gains the >2 GiB oversize recovery it silently lacked.

No new loading machinery — the partial reader already existed and was correct. It just was never called.

## Measured

Through the medgfx Quick Look preview. Peak RSS sampled from the OS, **not** `performance.memory` — the decode happens in a worker whose heap the main thread cannot see, which is precisely how this survived review.

| Case | Peak RSS | Wall time | Transferred |
|---|---|---|---|
| 105-frame DWI (156 MB decoded) | 601 → **55 MB** | 1717 → **274 ms** | 112.8 → **12.8 MB** |
| 400-frame 4D (594 MB decoded) | 1102 → **79 MB** | 2722 → **268 ms** | 2.6 → 5.2 MB |
| 4D truncated after frame 0 | **failed** → **loads** | | |

Stable across repeated runs. The truncated case is the qualitative proof: its tail is unreachable, so it can only load if decoding actually stopped after frame 0.

One number worth flagging rather than hiding: the truncated case peaks at 372 MB, reproducibly, higher than the two real files. It is a synthetic torture input that previously failed outright, so it is still strictly better — but I have not explained it.

## Tests

`e2e/partial-decode-4d.spec.ts`, in the browser, because the contract is about the worker. It truncates the stream after frame 0 rather than asserting on memory, so the outcome *is* the measurement. It pins the control (unbounded must throw, or the assertion is vacuous) and asserts no `volumeLoad worker failed` warning, so a worker crash rescued by the fallback cannot pass as success.

Verified falsifiable: reverting either half of the fix fails both tests.

## Also here

Quick Look regression hardening that came out of an audit of this area:

- `check-gzip-bound.sh` compiled only `GzipPeek`, so the filename-gate regression it advertised was the one it could not see. It now calls the real `PreviewViewController.budgetFailure`; verified by reintroducing that gate (3 FAIL).
- Added a `FEXTRA`-overrun case pinning the `looksGzip` fail-closed branch — a 1.1 MB → 1 GiB bypass that had no guard — and a Git-LFS pointer guard, since the "real volume still accepted" assertion is vacuous against a pointer file.
- `.github/workflows/medgfx-quicklook.yml`: runs those checks on macOS (pr_gate is ubuntu, no `swiftc`), path-filtered.
- `PLAYWRIGHT_CHROMIUM_PATH` opt-in in `playwright.config.ts` for machines without the pinned revision. Unset in CI.

## Note

`mgh reader (big-endian INT32 MGZ)` fails in `nx test niivue` — pre-existing on `main`, confirmed by stashing. Unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)