### PR TITLE
Single view layout

### DIFF
--- a/packages/niivue/AGENTS.md
+++ b/packages/niivue/AGENTS.md
@@ -10,9 +10,16 @@ NiiVue is a WebGPU-based neuroimaging visualization library (volumes + meshes) w
 
 Package manager is **Bun**. Never use `npm`/`npx`/`pnpm`/`yarn`.
 
+The version is pinned in `.bun-version` (every workflow reads it via
+`oven-sh/setup-bun`'s `bun-version-file`); match it locally with
+`curl -fsSL https://bun.sh/install | bash -s "bun-v$(cat .bun-version)"`. An older
+Bun silently diverges: it rewrites `bun.lock` to an older format, does not hoist
+`bun-types` (so several projects fail `typecheck` with TS2688), and lacks
+`DecompressionStream`, which fails any test that decodes a gzipped fixture.
+
 ```bash
 bun install                          # Install dependencies
-bun run dev                          # Hot-reload dev server at localhost:8080
+bun run dev                          # Hot-reload dev server at localhost:5273
 bun run build                        # Library build to ./dist (vite.config.lib.ts, ES)
 bun run build:examples               # Examples site build (vite.config.examples.ts)
 bun run deploy                       # Production examples-site build (GitHub Pages)
@@ -33,7 +40,7 @@ bunx nx lint niivue
 
 **Before committing**, run `bun run lint:fix && bun run typecheck` (or `bunx nx lint niivue && bunx nx typecheck niivue`).
 
-`bun run dev` uses a Vite plugin (`vite.config.dev.js`) to redirect `import '../dist/niivue.js'` to source for HMR, so the same HTML/JS files work in dev and production.
+`bun run dev` serves `examples/` from source (the pages `import '../src/index.ts'`), so dev and the examples build run the same files.
 
 Library packaging: `bun run build` emits `dist/niivue.js` (both backends), `dist/niivue.webgpu.js` (WebGPU-only), and `dist/niivue.webgl2.js` (WebGL2-only), exported as `@niivue/niivue`, `@niivue/niivue/webgpu`, and `@niivue/niivue/webgl2`.
 
@@ -216,7 +223,7 @@ The model is organized into 8 semantic config groups:
 | Group | Purpose | Example properties |
 |-------|---------|-------------------|
 | `scene` | Camera, crosshair, clip planes, background | `azimuth`, `elevation`, `backgroundColor`, `scaleMultiplier` |
-| `layout` | Slice type, mosaic, multiplanar, hero, tiling | `sliceType`, `mosaicString`, `heroFraction`, `isRadiological` |
+| `layout` | Slice type, mosaic, multiplanar, hero, tiling | `sliceType`, `mosaicString`, `heroFraction`, `isRadiological`, `isSingleViewFillCanvas` |
 | `ui` | Visual chrome: colorbars, orient labels, fonts | `isColorbarVisible`, `crosshairWidth`, `fontScale`, `placeholderText` |
 | `volume` | Global volume rendering settings | `illumination`, `isNearestInterpolation`, `outlineWidth` |
 | `mesh` | Global mesh rendering settings | `xRay`, `thicknessOn2D` |
@@ -367,6 +374,13 @@ Each `SliceTile` caches `mvpMatrix`, `planeNormal`, and `planePoint` during rend
 
 The built-in wheel zoom (`control/interactions.ts`, `isPanZoomMode` branch) anchors on `crosshairPos`. It holds that point still by calling `NVTransforms.zoomPan2DAbout`, which is the exact inverse of the window `calculateMvpMatrix2D` builds: `pan' = (zoom / newZoom) * (d + pan) - d` with `d = anchorMM - extentCentre`. Keep the two in step — a change to the ortho window's zoom or pan handling must be mirrored there, or the crosshair drifts again (issue #68).
 
+**`pan2Dxyzmm` is a `vec4` (Float32Array) — never test a value read back out of it
+for exact equality** (0.4 returns 0.40000000596). `stepZoom2D`
+(`src/math/NVTransforms.ts`) detects a stalled zoom notch with
+`Math.abs(next - zoom) < ZOOM_2D_SNAP / 2`, not `next === zoom`: the float32
+round-trip made the equality unreachable, jamming the wheel zoom at 0.4 in both
+directions. Pinned by `bothEndsOfTheRangeAreReachable` in `NVTransforms.test.ts`.
+
 ## Format extensibility
 
 All format readers use Vite's `import.meta.glob` for automatic discovery. To add a new reader:
@@ -375,6 +389,12 @@ All format readers use Vite's `import.meta.glob` for automatic discovery. To add
 3. Auto-registered at build time — no manual wiring needed
 
 Shared utilities: `NVLoader.buildExtensionMap()` (extension→module maps), `NVGz.maybeDecompress()` (transparent gzip).
+
+**A reader's input may be a Node `Buffer`, whose `slice()` is `subarray()`.** Take
+`.buffer` only from a fresh copy (`new Uint8Array(raw.subarray(a, b)).buffer`), or
+the caller receives the whole underlying allocation instead of the slice (and, for
+a small pooled Buffer, at a non-zero `byteOffset`). Browser loads never hit this —
+fetch yields offset-0 buffers — so `mgh.test.ts` passes a `Buffer` explicitly.
 
 Same pattern for: mesh readers (`mesh/readers/`), volume readers (`volume/readers/`), tract readers (`mesh/tracts/readers/`), connectome readers (`mesh/connectome/readers/`), layer readers (`mesh/layers/readers/`), volume transforms (`volume/transforms/`).
 
@@ -1300,7 +1320,49 @@ Pure-data layout engine in `view/NVSliceLayout.ts`. Computes `SliceTile[]` from 
 
 Priority: mosaic string > render-only > single slice > hero layout > multiplanar.
 
+The scale ruler (`view/NVRuler.ts`) takes px-per-mm from `mmPerPixel2D` so it
+tracks the 2D zoom (`pan2Dxyzmm` is threaded in by both renderers), and reads
+`screen.fovMM` as tile-local `[u, v, depth]`. Pinned by `view/NVRuler.test.ts`.
+
 **`SliceTile`** key fields: `leftTopWidthHeight`, `axCorSag`, `screen` (ortho mm bounds), `azimuth`/`elevation`, `sliceMM` (mosaic mm position), `renderOrientation`, `crossLines`, `showLabels`. Cached `mvpMatrix`/`planeNormal`/`planePoint` populated during render for picking.
+
+### Single-slice canvas fill (`isSingleViewFillCanvas`, default **true**)
+
+A lone AXIAL/CORONAL/SAGITTAL tile takes the whole canvas instead of being
+letterboxed to the slice's aspect ratio; the stored mm window
+(`screen.mnMM`/`mxMM`/`fovMM`, in-plane indices 0 and 1) is widened about its own
+centre by the same ratio. Scale (mm-per-pixel) and centre are unchanged — the slice
+lands on identical pixels — only the clipping rect grows, so a zoom spends the old
+letterbox margins on image instead of cropping them away. Excluded: multiplanar,
+render, mosaic, hero, custom layouts.
+
+- **The widened span is stored PRE-zoom**, and the fill branch is taken only for a
+  positive finite fit scale. A window sized from the live zoom reintroduces the
+  crosshair drift of issue #68 (`zoomPan2DAbout` assumes a fixed window that zoom
+  narrows); a zero/infinite scale puts NaN mm bounds in the projection. A filled
+  slice also leaves `fitSlicesAndGraph` no letterbox slack to give the 4D graph.
+  All pinned in `view/NVSliceLayout.test.ts`.
+- **`fovMM` stays the DATA's span; only `mnMM`/`mxMM` widen.** They are equal on
+  every other tile. Chrome that must size against the image rather than the empty
+  margin reads `fovMM` (the scale ruler does, or its bar outgrows a small volume);
+  anything projecting the window reads `mnMM`/`mxMM`.
+- **No edge-voxel smear into the new margins.** Both backends draw a unit quad in
+  TEXTURE space (`gl/sliceShader.ts`, `wgpu/slice.wgsl`), so its corners are the
+  volume's mm extents and sampler wrap mode is unreachable.
+- **The whole canvas is a live tile.** `hitTest`/`screenSlicePick` clamp to the
+  TILE, which used to equal the volume extents, so picks in the former letterbox
+  margin land outside the volume. `setCrosshairPos` clamps frac to [0,1] and
+  `buildDragReleaseInfo` clamps voxels to `dimsRAS` (its mm fields stay unclamped —
+  they describe the real gesture), but a PEN stroke straying into blank margin
+  paints the boundary voxel rather than missing, because `drawPoint` clamps.
+- **Old documents reopen filled.** `documentSettings.fillGroup` writes
+  `LAYOUT_DEFAULTS` for any key a document omits, and `loadDocument` resets an
+  explicit `false` unless called with `{ fill: 'current' }`. Standard for every
+  layout default; noted because this one is visible.
+- **Plumbing follows the `isRadiological` pattern**; NVDocument serializes the
+  layout group generically. Model-to-config mapping lives ONCE in
+  `NVSliceLayout.fitSlicesFromModel`, which both renderers call — a flag threaded
+  into one backend is a parity break.
 
 ### Mosaic string format
 

--- a/packages/niivue/README.md
+++ b/packages/niivue/README.md
@@ -41,8 +41,8 @@ in production is one well-predicted branch per call site. See
 
 ### Development Workflows
 
-- **`bun run dev`** — Runs the `demos/` pages with hot reloading. A Vite plugin intercepts `import '../dist/niivue.js'` and redirects it to source, so demo scripts stay identical to the deployed versions but get full HMR. Asset directories in `demos/` are symlinked to `public/` on first run.
-- **`bun run demo`** — Builds the library to `demos/dist/`, copies assets, and serves with `http-server`. Use this to test the actual built output or before deploying to GitHub Pages.
+- **`bun run dev`** — Serves the `examples/` pages from source with hot reloading at `localhost:5273`. The pages `import '../src/index.ts'` directly, so dev and the deployed build run the same files. On-demand sample data (OME-Zarr, DICOM-WSI) is downloaded into `public/` if missing.
+- **`bun run demo`** — Builds the examples site to `dist/` and serves it with `http-server`. Use this to test the actual built output or before deploying to GitHub Pages.
 
 ## Usage
 
@@ -201,7 +201,7 @@ bunx nx test niivue
 
 ### Architecture
 
-The codebase is written in **TypeScript** and follows an MVC pattern with dual rendering backends (WebGPU and WebGL2). See [CLAUDE.md](CLAUDE.md) for detailed architecture documentation, directory structure, code style, and module naming conventions.
+The codebase is written in **TypeScript** and follows an MVC pattern with dual rendering backends (WebGPU and WebGL2). See [AGENTS.md](AGENTS.md) for detailed architecture documentation, directory structure, code style, and module naming conventions.
 
 ### Dependencies
 

--- a/packages/niivue/docs/api.md
+++ b/packages/niivue/docs/api.md
@@ -82,7 +82,7 @@ nv1.drawPenValue = 3
 `azimuth`, `elevation`, `crosshairPos`, `pan2Dxyzmm`, `scaleMultiplier`, `gamma`, `backgroundColor`, `clipPlaneColor`, `isClipPlaneCutaway`
 
 **Layout** (no prefix -- delegate to `model.layout`):
-`sliceType`, `mosaicString`, `showRender`, `multiplanarType`, `heroFraction`, `heroSliceType`, `isEqualSize`, `isMosaicCentered`, `tileMargin`, `isRadiological`
+`sliceType`, `mosaicString`, `showRender`, `multiplanarType`, `heroFraction`, `heroSliceType`, `isEqualSize`, `isMosaicCentered`, `tileMargin`, `isRadiological`, `isSingleViewFillCanvas`
 
 **UI** (no prefix -- delegate to `model.ui`):
 `isColorbarVisible`, `isOrientCubeVisible`, `isOrientationTextVisible`, `is3DCrosshairVisible`, `isGraphVisible`, `isRulerVisible`, `isCrossLinesVisible`, `isLegendVisible`, `isPositionInMM`, `isMeasureUnitsVisible`, `isThumbnailVisible`, `thumbnailUrl`, `placeholderText`, `crosshairColor`, `crosshairGap`, `crosshairWidth`, `fontColor`, `fontScale`, `fontMinSize`, `selectionBoxColor`, `measureLineColor`, `measureTextColor`, `rulerWidth`, `graphNormalizeValues`, `graphIsRangeCalMinMax`

--- a/packages/niivue/examples/vox.gestures.html
+++ b/packages/niivue/examples/vox.gestures.html
@@ -20,9 +20,9 @@
       &nbsp;
       <label for="secondaryDrag">Secondary (right)</label>
       <select id="secondaryDrag">
-        <option value="1" selected>contrast</option>
+        <option value="1">contrast</option>
         <option value="2">measurement</option>
-        <option value="3">pan</option>
+        <option value="3" selected>pan</option>
         <option value="4">slicer3D</option>
         <option value="5">callbackOnly</option>
         <option value="6">roiSelection</option>
@@ -32,16 +32,19 @@
       </select>
       &nbsp;
       <select id="sliceType">
-        <option value="0">Axial</option>
+        <option value="0" selected>Axial</option>
         <option value="1">Coronal</option>
         <option value="2">Sagittal</option>
         <option value="4">Render</option>
-        <option value="3" selected>A+C+S+R</option>
+        <option value="3">A+C+S+R</option>
       </select>
       &nbsp;
       <button type="button" id="clearRulersBtn" title="Erase completed distance measurements only">Clear Rulers</button>
       <button type="button" id="clearAnglesBtn" title="Erase completed angles only">Clear Angles</button>
       <button type="button" id="clearAllBtn" title="Erase both">Clear Both</button>
+      &nbsp;
+      <label for="fillCheck">Fill Canvas</label>
+      <input type="checkbox" id="fillCheck" checked/>
       &nbsp;
       <label for="webgpuCheck">WebGPU</label>
       <input type="checkbox" id="webgpuCheck" checked/>
@@ -62,7 +65,10 @@
       // Read the element rather than `this`: the startup call below is a bare
       // call, and a module is strict mode, so `this` would be undefined.
       sliceType.onchange = () => {
-        nv1.sliceType = parseInt(sliceType.value, 10)
+        const type = parseInt(sliceType.value, 10)
+        nv1.sliceType = type
+        // Fill Canvas only governs a lone 2D slice (axial/coronal/sagittal).
+        fillCheck.disabled = type > 2
       }
       // Rulers and angles clear independently, so erasing one kind leaves the
       // other on screen; clearMeasurements() still drops both at once.
@@ -71,6 +77,9 @@
       clearAllBtn.onclick = () => nv1.clearMeasurements()
       function handleLocationChange(data) {
         document.getElementById('location').innerHTML = `&nbsp;&nbsp;${data.string}`
+      }
+      fillCheck.onchange = function () {
+        nv1.isSingleViewFillCanvas = this.checked
       }
       webgpuCheck.onchange = async function () {
         await nv1.reinitializeView({ backend: this.checked ? 'webgpu' : 'webgl2' })
@@ -94,7 +103,7 @@
       const nv1 = new NiiVue({
         backgroundColor: [0.2, 0.2, 0.2, 1],
         isColorbarVisible: true,
-        secondaryDragMode: DRAG_MODE.contrast,
+        secondaryDragMode: DRAG_MODE.pan,
         primaryDragMode: DRAG_MODE.crosshair,
       })
       nv1.addEventListener('locationChange', (e) => handleLocationChange(e.detail))

--- a/packages/niivue/src/NVConstants.ts
+++ b/packages/niivue/src/NVConstants.ts
@@ -292,6 +292,7 @@ export const LAYOUT_DEFAULTS: LayoutConfig = {
   isMosaicCentered: true,
   margin: 0,
   isRadiological: false,
+  isSingleViewFillCanvas: true,
   customLayout: null,
 }
 

--- a/packages/niivue/src/NVControlBase.ts
+++ b/packages/niivue/src/NVControlBase.ts
@@ -946,6 +946,23 @@ export default class NiiVue extends EventTarget {
   }
 
   /**
+   * Let a single 2D slice (axial, coronal or sagittal alone) use the whole
+   * canvas rather than a tile letterboxed to the slice's aspect ratio. The
+   * slice draws at the same scale and position either way; filling only means a
+   * zoomed view spends the margins on image instead of clipping them away.
+   * @default `true`
+   * @example nv1.isSingleViewFillCanvas = false
+   */
+  get isSingleViewFillCanvas(): boolean {
+    return this.model.layout.isSingleViewFillCanvas
+  }
+  set isSingleViewFillCanvas(v: boolean) {
+    this.model.layout.isSingleViewFillCanvas = v
+    this.emit('change', { property: 'isSingleViewFillCanvas', value: v })
+    this.drawScene()
+  }
+
+  /**
    * Get or set a custom tile layout. When set to a non-empty array this
    * overrides all built-in layout modes (multiplanar, mosaic, hero).
    * Each tile specifies a slice type and a normalized [left, top, width, height]

--- a/packages/niivue/src/NVModel.ts
+++ b/packages/niivue/src/NVModel.ts
@@ -181,6 +181,9 @@ export default class NVModel {
       ...(options.isRadiological !== undefined && {
         isRadiological: options.isRadiological,
       }),
+      ...(options.isSingleViewFillCanvas !== undefined && {
+        isSingleViewFillCanvas: options.isSingleViewFillCanvas,
+      }),
       ...(options.customLayout !== undefined && {
         customLayout: options.customLayout ?? null,
       }),

--- a/packages/niivue/src/NVTypes.ts
+++ b/packages/niivue/src/NVTypes.ts
@@ -632,6 +632,8 @@ export type LayoutConfig = {
   isMosaicCentered: boolean
   margin: number
   isRadiological: boolean
+  /** Let a single 2D slice tile fill the canvas instead of letterboxing it. */
+  isSingleViewFillCanvas: boolean
   customLayout: CustomLayoutTile[] | null
 }
 
@@ -1077,6 +1079,7 @@ export type NiiVueOptions = {
   isMosaicCentered?: boolean
   tileMargin?: number
   isRadiological?: boolean
+  isSingleViewFillCanvas?: boolean
   customLayout?: CustomLayoutTile[] | null
 
   // UI

--- a/packages/niivue/src/control/dragModes.ts
+++ b/packages/niivue/src/control/dragModes.ts
@@ -115,11 +115,18 @@ export function buildDragReleaseInfo(ctrl: NiiVue): DragReleaseInfo | null {
   const vol = ctrl.model.getVolumes()[0]
   let voxStart: [number, number, number] = [0, 0, 0]
   let voxEnd: [number, number, number] = [0, 0, 0]
-  if (vol) {
-    const sv = NVTransforms.mm2vox(vol, startMM)
-    const ev = NVTransforms.mm2vox(vol, endMM)
-    voxStart = [Math.round(sv[0]), Math.round(sv[1]), Math.round(sv[2])]
-    voxEnd = [Math.round(ev[0]), Math.round(ev[1]), Math.round(ev[2])]
+  const dims = vol?.dimsRAS
+  if (vol && dims) {
+    // Voxel indices, and the tile can now extend past the volume, so a drag
+    // released in the margin would report an out-of-range index. The mm fields
+    // stay unclamped -- they describe the real gesture.
+    const clamp = (v: vec3): [number, number, number] => [
+      Math.max(0, Math.min(dims[1] - 1, Math.round(v[0]))),
+      Math.max(0, Math.min(dims[2] - 1, Math.round(v[1]))),
+      Math.max(0, Math.min(dims[3] - 1, Math.round(v[2]))),
+    ]
+    voxStart = clamp(NVTransforms.mm2vox(vol, startMM))
+    voxEnd = clamp(NVTransforms.mm2vox(vol, endMM))
   }
 
   const mmLength = vec3.distance(

--- a/packages/niivue/src/gl/NVViewGL.ts
+++ b/packages/niivue/src/gl/NVViewGL.ts
@@ -614,40 +614,11 @@ export default class NVGlview {
       screenSlices = this.screenSlices
       graphWidth = baseGraphWidth
     } else {
-      // No spatial view (a signal-only scene, OR the user chose
-      // SLICE_TYPE.NONE): skip all spatial tiles so no slices, crosshairs, or
-      // orientation labels render; the signal graph fills the instance area on
-      // its own. Otherwise lay out the slices and let the graph reclaim any
-      // horizontal slack.
-      const spatialHidden = md.isSpatialViewHidden()
-      const fit = spatialHidden
-        ? {
-            screenSlices: [] as NVSliceLayout.SliceTile[],
-            graphWidth: baseGraphWidth,
-          }
-        : NVSliceLayout.fitSlicesAndGraph(
-            {
-              canvasWH: [
-                canvasWidth - legendWidth - baseGraphWidth,
-                canvasHeight - cbHeight,
-              ],
-              sliceType: md.layout.sliceType,
-              tileMargin: md.layout.margin,
-              extentsMin: md.extentsMin,
-              extentsMax: md.extentsMax,
-              isRadiologicalConvention: md.layout.isRadiological,
-              multiplanarLayout: md.layout.multiplanarType,
-              multiplanarShowRender: md.layout.showRender,
-              sliceMosaicString: md.layout.mosaicString,
-              heroImageFraction: md.layout.heroFraction,
-              heroSliceType: md.layout.heroSliceType,
-              isMultiplanarEqualSize: md.layout.isEqualSize,
-              isCrossLines: md.ui.isCrossLinesVisible,
-              isCenterMosaic: md.layout.isMosaicCentered,
-              customLayout: md.layout.customLayout,
-            },
-            baseGraphWidth,
-          )
+      const fit = NVSliceLayout.fitSlicesFromModel(
+        md,
+        [canvasWidth - legendWidth - baseGraphWidth, canvasHeight - cbHeight],
+        baseGraphWidth,
+      )
       graphWidth = fit.graphWidth
       screenSlices = fit.screenSlices
       this.screenSlices = screenSlices
@@ -1422,7 +1393,7 @@ export default class NVGlview {
             this.fontRenderer.buildText(s, x, y, sc, c, ax, ay, bc),
           buildLine,
           md.ui.fontColor,
-          md.scene.backgroundColor,
+          md.scene.pan2Dxyzmm,
         )
         if (rulerResult) {
           labels.push(...rulerResult.labels)

--- a/packages/niivue/src/math/NVTransforms.test.ts
+++ b/packages/niivue/src/math/NVTransforms.test.ts
@@ -933,13 +933,17 @@ describe('stepZoom2D', () => {
   })
 
   test('bothEndsOfTheRangeAreReachable', () => {
-    let zoom = 1
-    for (let i = 0; i < 200 && zoom > ZOOM_2D_MIN; i++)
-      zoom = stepZoom2D(zoom, -1)
-    expect(zoom).toBe(ZOOM_2D_MIN)
-    for (let i = 0; i < 200 && zoom < ZOOM_2D_MAX; i++)
-      zoom = stepZoom2D(zoom, 1)
-    expect(zoom).toBe(ZOOM_2D_MAX)
+    // Second pass through fround: scene.pan2Dxyzmm is a vec4, so 0.4 comes back
+    // as 0.40000000596 and an exact stall test jammed the wheel there.
+    for (const f of [(x: number) => x, Math.fround]) {
+      let zoom = f(1)
+      for (let i = 0; i < 200 && zoom > ZOOM_2D_MIN; i++)
+        zoom = f(stepZoom2D(zoom, -1))
+      expect(zoom).toBe(f(ZOOM_2D_MIN))
+      for (let i = 0; i < 200 && zoom < ZOOM_2D_MAX; i++)
+        zoom = f(stepZoom2D(zoom, 1))
+      expect(zoom).toBe(f(ZOOM_2D_MAX))
+    }
   })
 
   test('lowEndStepsAreReversible', () => {

--- a/packages/niivue/src/math/NVTransforms.ts
+++ b/packages/niivue/src/math/NVTransforms.ts
@@ -176,16 +176,21 @@ const ZOOM_2D_SNAP = 0.1
  * back to 0.5, and every zoom below that is fixed in BOTH directions -- 0.2
  * moves to neither 0.18 nor 0.22. So the wheel could never take the view below
  * half size and could never leave a smaller zoom set from code, even though the
- * range says 0.1. When the snap lands back on the zoom we started from, step one
- * whole snap increment instead; the multiplicative feel is untouched everywhere
- * the proportional step is already larger than that.
+ * range says 0.1. When the snap does not move the zoom by at least half a step,
+ * take one whole snap increment instead; the multiplicative feel is untouched
+ * everywhere the proportional step is already larger than that.
+ *
+ * The stall test uses a tolerance, not `===`: the caller keeps the zoom in a
+ * `vec4` and 0.4 comes back as 0.40000000596, which `===` reads as "moved".
  */
 export function stepZoom2D(zoom: number, direction: number): number {
   if (!Number.isFinite(zoom) || zoom <= 0) return ZOOM_2D_MIN
   const dir = Math.sign(direction)
   if (dir === 0) return zoom
   let next = Math.round(zoom * (1 + 0.1 * dir) * 10) / 10
-  if (next === zoom) next = Math.round((zoom + ZOOM_2D_SNAP * dir) * 10) / 10
+  if (Math.abs(next - zoom) < ZOOM_2D_SNAP / 2) {
+    next = Math.round((zoom + ZOOM_2D_SNAP * dir) * 10) / 10
+  }
   return Math.max(ZOOM_2D_MIN, Math.min(ZOOM_2D_MAX, next))
 }
 

--- a/packages/niivue/src/view/NVRuler.test.ts
+++ b/packages/niivue/src/view/NVRuler.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from 'bun:test'
+import { vec3 } from 'gl-matrix'
+import type { GlyphBatch } from './NVFont'
+import type { LineData } from './NVLine'
+import { buildRuler } from './NVRuler'
+import {
+  type SliceLayoutConfig,
+  type SliceTile,
+  screenSlicesLayout,
+} from './NVSliceLayout'
+
+// Anisotropic on purpose: with a cube every orientation has the same in-plane
+// spans, which is exactly what hid the sagittal axis bug.
+const RANGE: [number, number, number] = [180, 216, 180]
+
+function cfg(over: Partial<SliceLayoutConfig> = {}): SliceLayoutConfig {
+  return {
+    canvasWH: [2000, 400],
+    extentsMin: vec3.fromValues(0, 0, 0),
+    extentsMax: vec3.fromValues(...RANGE),
+    sliceType: 0,
+    ...over,
+  }
+}
+
+// In-plane [u, v] mm spans per orientation, straight from the extents.
+const inPlane = (sliceType: number): [number, number] =>
+  sliceType === 0
+    ? [RANGE[0], RANGE[1]]
+    : sliceType === 1
+      ? [RANGE[0], RANGE[2]]
+      : [RANGE[1], RANGE[2]]
+
+// Record the geometry buildRuler emits: the bar's pixel width, the mm it claims
+// to represent, and the px-per-mm those imply.
+function measure(
+  sliceType: number,
+  fill: boolean,
+  zoom: number,
+  over: Partial<SliceLayoutConfig> = {},
+): { pxPerMM: number; barPx: number; label: string } {
+  const tiles = screenSlicesLayout(
+    cfg({ sliceType, isSingleViewFillCanvas: fill, ...over }),
+  )
+  const lines: Array<[number, number]> = []
+  let label = ''
+  buildRuler(
+    tiles,
+    (s: string) => {
+      label = s
+      return {} as GlyphBatch
+    },
+    (x0: number, _y0: number, x1: number) => {
+      lines.push([x0, x1])
+      return {} as LineData
+    },
+    [1, 1, 1, 1],
+    [0, 0, 0, zoom],
+  )
+  const m = /^(\d+) (cm|mm)$/.exec(label)
+  if (!m) throw new Error(`no ruler drawn (label: "${label}")`)
+  const barPx =
+    Math.max(...lines.map((l) => l[1])) - Math.min(...lines.map((l) => l[0]))
+  const labelMM = Number(m[1]) * (m[2] === 'cm' ? 10 : 1)
+  return { pxPerMM: barPx / labelMM, barPx, label }
+}
+
+describe('buildRuler', () => {
+  test('barIsSizedByTheImage_notTheEmptyMarginAFilledTileAdds', () => {
+    // A filled tile is the whole canvas, so sizing on tile width alone let the
+    // bar outgrow a small volume: a 4 mm cube drew a 10 mm bar 2.5x wider than
+    // the slice. Filling must not change the chosen length.
+    const small = {
+      extentsMax: vec3.fromValues(4, 4, 4),
+      canvasWH: [2000, 400] as [number, number],
+    }
+    const boxed = measure(0, false, 1, small)
+    const filled = measure(0, true, 1, small)
+    // px-per-mm alone does not catch this -- it is right either way. The bar's
+    // chosen length is what ran away.
+    expect(filled.label).toBe(boxed.label)
+    expect(filled.barPx).toBeCloseTo(boxed.barPx, 6)
+  })
+
+  test('ignoresTilesThatAreNotAPlainSlice', () => {
+    // slicePanUV indexes by orientation; a render or foreign tile used to be
+    // skipped and must not throw the whole frame instead.
+    for (const axCorSag of [4, 3, undefined]) {
+      const [tile] = screenSlicesLayout(cfg())
+      expect(() =>
+        buildRuler(
+          [{ ...tile, axCorSag } as SliceTile],
+          () => ({}) as GlyphBatch,
+          () => ({}) as LineData,
+          [1, 1, 1, 1],
+          [0, 0, 0, 1],
+        ),
+      ).not.toThrow()
+    }
+  })
+
+  test('barLengthMatchesItsLabelInEveryOrientation', () => {
+    // Truth is independent of the implementation: the fit scale is what maps
+    // the slice onto the tile, and the 2D zoom multiplies it. Filling changes
+    // the tile and the mm window together, so it must not change the scale.
+    for (const sliceType of [0, 1, 2]) {
+      const [u, v] = inPlane(sliceType)
+      const fit = Math.min(2000 / u, 400 / v)
+      for (const fill of [false, true]) {
+        for (const zoom of [1, 3]) {
+          expect(measure(sliceType, fill, zoom).pxPerMM).toBeCloseTo(
+            fit * zoom,
+            6,
+          )
+        }
+      }
+    }
+  })
+})

--- a/packages/niivue/src/view/NVRuler.ts
+++ b/packages/niivue/src/view/NVRuler.ts
@@ -1,14 +1,16 @@
+import { mmPerPixel2D } from '@/math/NVTransforms'
 import { SLICE_TYPE } from '@/NVConstants'
 import type { BuildTextFn, GlyphBatch } from './NVFont'
 import type { BuildLineFn, LineData } from './NVLine'
-import type { SliceTile } from './NVSliceLayout'
+import { type SliceTile, slicePanUV } from './NVSliceLayout'
 
-// In-plane axis indices per orientation: [u, v] (depth axis excluded)
-const IN_PLANE: Record<number, [number, number]> = {
-  [SLICE_TYPE.AXIAL]: [0, 1],
-  [SLICE_TYPE.CORONAL]: [0, 2],
-  [SLICE_TYPE.SAGITTAL]: [1, 2],
-}
+// slicePanUV indexes by orientation, so anything else (RENDER, or a tile from
+// an externally assigned screenSlices) would throw rather than draw no ruler.
+const IS_2D: number[] = [
+  SLICE_TYPE.AXIAL,
+  SLICE_TYPE.CORONAL,
+  SLICE_TYPE.SAGITTAL,
+]
 
 // Nice ruler lengths to try, in descending order (in current unit)
 const NICE_VALUES = [10, 5, 2, 1]
@@ -21,15 +23,12 @@ function selectRulerTile(tiles: SliceTile[]): SliceTile | null {
   let best: SliceTile | null = null
   let bestSpan = 0
   for (const tile of tiles) {
-    if (tile.axCorSag === SLICE_TYPE.RENDER) continue
+    if (!IS_2D.includes(tile.axCorSag)) continue
     if (!tile.screen || !tile.leftTopWidthHeight) continue
-    const axes = IN_PLANE[tile.axCorSag]
-    if (!axes) continue
+    // fovMM is tile-local [u, v, depth], never world XYZ: buildScreens already
+    // remapped it, and world axes read sagittal's vertical span as horizontal.
     const fov = tile.screen.fovMM
-    const span = Math.max(
-      Math.abs(fov[axes[0]] as number),
-      Math.abs(fov[axes[1]] as number),
-    )
+    const span = Math.max(Math.abs(fov[0]), Math.abs(fov[1]))
     if (span > bestSpan) {
       bestSpan = span
       best = tile
@@ -78,25 +77,31 @@ export function buildRuler(
   buildText: BuildTextFn,
   buildLine: BuildLineFn,
   fontColor: number[],
-  _backColor: number[],
+  pan2Dxyzmm: ArrayLike<number>,
 ): RulerResult | null {
   const tile = selectRulerTile(tiles)
   if (!tile?.screen || !tile.leftTopWidthHeight) return null
 
-  const axes = IN_PLANE[tile.axCorSag]
-  if (!axes) return null
-
-  const fov = tile.screen.fovMM
-  // Use the horizontal (u-axis) FOV for ruler sizing since we draw horizontally
-  const hFovMM = Math.abs(fov[axes[0]] as number)
   const [tileLeft, tileTop, tileWidth, tileHeight] = tile.leftTopWidthHeight
 
-  const ruler = chooseRulerSize(hFovMM)
+  // Size against what is on screen: the 2D zoom narrows the ortho window, so
+  // tileWidth / fovMM would mislabel the bar by the zoom factor.
+  const mmPerPx = mmPerPixel2D(
+    tile.screen.mnMM,
+    tile.screen.mxMM,
+    tile.leftTopWidthHeight,
+    slicePanUV(pan2Dxyzmm, tile.axCorSag),
+  )
+  if (!(mmPerPx > 0)) return null
+
+  // Cap by the DATA span too: a filled tile is the whole canvas, so sizing on
+  // it alone grows the bar past the image whenever the volume is small.
+  const ruler = chooseRulerSize(
+    Math.min(tileWidth * mmPerPx, Math.abs(tile.screen.fovMM[0])),
+  )
   if (!ruler) return null
 
-  // Convert mm to pixels
-  const pxPerMM = tileWidth / hFovMM
-  const rulerPx = ruler.lengthMM * pxPerMM
+  const rulerPx = ruler.lengthMM / mmPerPx
 
   const segments = 5
   const segPx = rulerPx / segments

--- a/packages/niivue/src/view/NVSliceLayout.test.ts
+++ b/packages/niivue/src/view/NVSliceLayout.test.ts
@@ -7,6 +7,7 @@ import {
   fitSlicesAndGraph,
   type SliceLayoutConfig,
   type SliceTile,
+  screenSlicesLayout,
 } from './NVSliceLayout'
 
 // Wide pane (2000x400) with a cube volume: a single-orientation slice is ~square
@@ -24,9 +25,20 @@ function cfg(over: Partial<SliceLayoutConfig> = {}): SliceLayoutConfig {
 describe('fitSlicesAndGraph', () => {
   test('singleAxial_graphReclaimsHorizontalSlack', () => {
     const base = 200
-    const { screenSlices, graphWidth } = fitSlicesAndGraph(cfg(), base)
+    const { screenSlices, graphWidth } = fitSlicesAndGraph(
+      cfg({ isSingleViewFillCanvas: false }),
+      base,
+    )
     expect(screenSlices.length).toBeGreaterThanOrEqual(1)
     expect(graphWidth).toBeGreaterThan(base)
+  })
+
+  test('singleAxialFillingTheCanvas_leavesNoSlackToReclaim', () => {
+    // The slack the graph used to take is now the slice's, so the graph keeps
+    // its base width rather than both laying claim to the same pixels.
+    const base = 200
+    const { graphWidth } = fitSlicesAndGraph(cfg(), base)
+    expect(graphWidth).toBe(base)
   })
 
   test('noGraph_returnsZeroWidthAndUnchangedSlices', () => {
@@ -123,5 +135,81 @@ describe('crosshairRadiusMM', () => {
         leftTopWidthHeight: [0, 0, 360, 360],
       } as unknown as SliceTile),
     ).toBe(0)
+  })
+})
+
+describe('isSingleViewFillCanvas', () => {
+  const mmPerPx = (t: SliceTile, axis: 0 | 1): number => {
+    const s = t.screen as { mnMM: vec3; mxMM: vec3 }
+    const ltwh = t.leftTopWidthHeight as number[]
+    return (s.mxMM[axis] - s.mnMM[axis]) / ltwh[2 + axis]
+  }
+  const centre = (t: SliceTile, axis: 0 | 1): number => {
+    const s = t.screen as { mnMM: vec3; mxMM: vec3 }
+    return (s.mnMM[axis] + s.mxMM[axis]) / 2
+  }
+
+  test('off_letterboxesToTheSliceAspect', () => {
+    const [tile] = screenSlicesLayout(cfg({ isSingleViewFillCanvas: false }))
+    // Cube volume in a 2000x400 pane: a square tile centered horizontally.
+    expect(tile.leftTopWidthHeight).toEqual([800, 0, 400, 400])
+  })
+
+  test('onTakesTheWholeCanvas', () => {
+    const [tile] = screenSlicesLayout(cfg())
+    expect(tile.leftTopWidthHeight).toEqual([0, 0, 2000, 400])
+  })
+
+  test('fillingChangesNeitherTheScaleNorTheCentreOfTheSlice', () => {
+    // The whole point: the slice lands on the same pixels either way. Only the
+    // clipping rect grows, so a zoom eats the margin instead of the image.
+    // Swept over all three orientations with ANISOTROPIC extents and both pane
+    // aspects -- on a cube in a wide pane only axis 0 moves, so a swapped U/V
+    // index in fillScreen would pass unnoticed.
+    const extentsMax = vec3.fromValues(20, 10, 40)
+    for (const sliceType of [0, 1, 2]) {
+      for (const canvasWH of [
+        [2000, 400],
+        [400, 2000],
+        [400, 400],
+      ] as [number, number][]) {
+        const over = { sliceType, canvasWH, extentsMax }
+        const [boxed] = screenSlicesLayout(
+          cfg({ ...over, isSingleViewFillCanvas: false }),
+        )
+        const [filled] = screenSlicesLayout(cfg(over))
+        for (const axis of [0, 1] as const) {
+          expect(mmPerPx(filled, axis)).toBeCloseTo(mmPerPx(boxed, axis), 10)
+          expect(centre(filled, axis)).toBeCloseTo(centre(boxed, axis), 10)
+        }
+      }
+    }
+  })
+
+  test('degenerateSliceAreaKeepsFiniteBounds', () => {
+    // No room to fill: widening by the fit scale would be a divide by zero and
+    // NaN mm bounds reach the projection matrix.
+    for (const wh of [
+      [0, 400],
+      [-50, 400],
+    ] as [number, number][]) {
+      const [tile] = screenSlicesLayout(cfg({ canvasWH: wh }))
+      const scr = tile.screen as { mnMM: vec3; mxMM: vec3; fovMM: vec3 }
+      for (const axis of [0, 1]) {
+        expect(Number.isFinite(scr.mnMM[axis])).toBe(true)
+        expect(Number.isFinite(scr.mxMM[axis])).toBe(true)
+        expect(scr.mxMM[axis]).toBeGreaterThan(scr.mnMM[axis])
+      }
+    }
+  })
+
+  test('multiplanarIgnoresTheFlag', () => {
+    const off = screenSlicesLayout(
+      cfg({ sliceType: 3, isSingleViewFillCanvas: false }),
+    )
+    const on = screenSlicesLayout(cfg({ sliceType: 3 }))
+    expect(on.map((t) => t.leftTopWidthHeight)).toEqual(
+      off.map((t) => t.leftTopWidthHeight),
+    )
   })
 })

--- a/packages/niivue/src/view/NVSliceLayout.ts
+++ b/packages/niivue/src/view/NVSliceLayout.ts
@@ -62,6 +62,7 @@ export type SliceLayoutConfig = {
   isMultiplanarEqualSize?: boolean
   isCrossLines?: boolean
   isCenterMosaic?: boolean
+  isSingleViewFillCanvas?: boolean
   customLayout?: CustomLayoutTile[] | null
 }
 
@@ -200,6 +201,24 @@ const cloneScreen = (s: ScreenInfo): ScreenInfo => ({
   mxMM: vec3.clone(s.mxMM),
   fovMM: vec3.clone(s.fovMM),
 })
+
+/**
+ * Widen the in-plane mm window about its own centre: scale and centre hold.
+ *
+ * `fovMM` deliberately keeps the DATA's span while `mnMM`/`mxMM` become the
+ * wider ortho window -- the two are equal for every other tile. Chrome that
+ * should size against the image rather than the empty margin (the scale ruler)
+ * reads `fovMM`; anything projecting the window reads `mnMM`/`mxMM`.
+ */
+const fillScreen = (s: ScreenInfo, spans: [number, number]): ScreenInfo => {
+  const out = cloneScreen(s)
+  spans.forEach((span, i) => {
+    const centre = (s.mnMM[i] + s.mxMM[i]) / 2
+    out.mnMM[i] = centre - span / 2
+    out.mxMM[i] = centre + span / 2
+  })
+  return out
+}
 
 // Tile mm dimensions (in-plane width x height) for an orientation
 const tileDimsMM = (
@@ -823,6 +842,7 @@ export function fitSlicesAndGraph(
 ): { screenSlices: SliceTile[]; graphWidth: number } {
   const screenSlices = screenSlicesLayout(config)
   if (baseGraphWidth <= 0) return { screenSlices, graphWidth: 0 }
+  // A filled single slice uses the slack itself, so the graph keeps base width.
   const single =
     (config.sliceType === NVConstants.SLICE_TYPE.AXIAL ||
       config.sliceType === NVConstants.SLICE_TYPE.CORONAL ||
@@ -843,6 +863,45 @@ export function fitSlicesAndGraph(
     }),
     graphWidth: baseGraphWidth + (baseW - usedW),
   }
+}
+
+/**
+ * Both renderers' slice-layout step. Emits no tiles when the spatial view is
+ * hidden (signal-only scene, or `SLICE_TYPE.NONE`), so nothing spatial renders
+ * and the graph has the area to itself. The model-to-config mapping lives here
+ * and nowhere else: a flag threaded into one backend's copy is a parity break.
+ *
+ * @param paneWH - the slice area: canvas minus the legend, graph and colorbar
+ */
+export function fitSlicesFromModel(
+  model: NVModel,
+  paneWH: [number, number],
+  baseGraphWidth: number,
+): { screenSlices: SliceTile[]; graphWidth: number } {
+  if (model.isSpatialViewHidden()) {
+    return { screenSlices: [], graphWidth: baseGraphWidth }
+  }
+  return fitSlicesAndGraph(
+    {
+      canvasWH: paneWH,
+      sliceType: model.layout.sliceType,
+      tileMargin: model.layout.margin,
+      extentsMin: model.extentsMin,
+      extentsMax: model.extentsMax,
+      isRadiologicalConvention: model.layout.isRadiological,
+      multiplanarLayout: model.layout.multiplanarType,
+      multiplanarShowRender: model.layout.showRender,
+      sliceMosaicString: model.layout.mosaicString,
+      heroImageFraction: model.layout.heroFraction,
+      heroSliceType: model.layout.heroSliceType,
+      isMultiplanarEqualSize: model.layout.isEqualSize,
+      isCrossLines: model.ui.isCrossLinesVisible,
+      isCenterMosaic: model.layout.isMosaicCentered,
+      isSingleViewFillCanvas: model.layout.isSingleViewFillCanvas,
+      customLayout: model.layout.customLayout,
+    },
+    baseGraphWidth,
+  )
 }
 
 export function screenSlicesLayout(config: SliceLayoutConfig): SliceTile[] {
@@ -889,11 +948,23 @@ export function screenSlicesLayout(config: SliceLayoutConfig): SliceTile[] {
       throw new Error('Missing fovMM for slice')
     }
     const zoom = Math.min(canvasWH[0] / fov[0], canvasWH[1] / fov[1])
-    const w = fov[0] * zoom
-    const h = fov[1] * zoom
+    // Fill needs a usable fit scale: zero or infinite gives NaN mm bounds.
+    const fill =
+      (config.isSingleViewFillCanvas ?? true) &&
+      Number.isFinite(zoom) &&
+      zoom > 0
+    const w = fill ? canvasWH[0] : fov[0] * zoom
+    const h = fill ? canvasWH[1] : fov[1] * zoom
     return [
       {
         ...screens[idx],
+        // Spans are stored PRE-zoom: calculateMvpMatrix2D divides by it (#68).
+        ...(fill && {
+          screen: fillScreen(screens[idx].screen as ScreenInfo, [
+            w / zoom,
+            h / zoom,
+          ]),
+        }),
         leftTopWidthHeight: [
           (canvasWH[0] - w) / 2,
           (canvasWH[1] - h) / 2,

--- a/packages/niivue/src/volume/readers/mgh.test.ts
+++ b/packages/niivue/src/volume/readers/mgh.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { gunzipSync } from 'node:zlib'
 import { NiiDataType } from '@/NVConstants'
 import { calMinMax, toTypedViewOrU8 } from '@/volume/utils'
 import { read } from './mgh'
@@ -26,8 +27,9 @@ const EXPECTED = {
   midValue: 8,
 }
 
-describe('mgh reader (big-endian INT32 MGZ)', () => {
+describe('mgh reader (big-endian INT32)', () => {
   test('decodesInt32VoxelsInNativeByteOrder', async () => {
+    // Straight from the .mgz, so the reader's own gzip branch is covered.
     const buf = readFileSync(FIXTURE)
     const { hdr, img } = await read(buf, 'brainmask-int.mgz')
 
@@ -71,5 +73,23 @@ describe('mgh reader (big-endian INT32 MGZ)', () => {
     expect(max).toBe(EXPECTED.max)
     expect(sum).toBe(EXPECTED.sum)
     expect(i32[EXPECTED.midIndex]).toBe(EXPECTED.midValue)
+  })
+
+  test('acceptsANodeBufferWithoutHandingBackItsWholeAllocation', async () => {
+    // A Buffer's slice() is subarray(), so taking `.buffer` off it returns the
+    // entire underlying allocation rather than the image. gunzipSync gives a
+    // real Buffer; a .mgh name skips the gzip branch so this exercises only the
+    // slicing. The reader must also leave the caller's bytes unswapped.
+    const raw = gunzipSync(readFileSync(FIXTURE))
+    const firstVoxelByte = raw[raw.length - 1]
+    const { hdr, img } = await read(raw, 'brainmask-int.mgh')
+
+    expect(img).toBeInstanceOf(ArrayBuffer)
+    expect((img as ArrayBuffer).byteLength).toBe(256 * 256 * 256 * 4)
+    const i32 = toTypedViewOrU8(img, hdr.datatypeCode)
+    expect(i32).toBeInstanceOf(Int32Array)
+    expect((i32 as Int32Array).length).toBe(256 * 256 * 256)
+    expect((i32 as Int32Array)[EXPECTED.midIndex]).toBe(EXPECTED.midValue)
+    expect(raw[raw.length - 1]).toBe(firstVoxelByte)
   })
 })

--- a/packages/niivue/src/volume/readers/mgh.ts
+++ b/packages/niivue/src/volume/readers/mgh.ts
@@ -174,8 +174,11 @@ export async function read(
   const nBytesPerVoxel = hdr.numBitsPerVoxel / 8
   const nVoxels = width * height * depth * hdr.dims[4]
   const expectedBytes = nVoxels * nBytesPerVoxel
-  // Return only the raw image data buffer
-  const imgRaw = raw.slice(hdr.vox_offset, hdr.vox_offset + expectedBytes)
+  // Copy: a Node Buffer's slice() is subarray(), so imgRaw.buffer would be the
+  // whole underlying allocation, not the image.
+  const imgRaw = new Uint8Array(
+    raw.subarray(hdr.vox_offset, hdr.vox_offset + expectedBytes),
+  )
   // MGH/MGZ image data is big-endian. Downstream typed-array views read in
   // platform-native byte order, so on little-endian hosts swap multi-byte
   // samples (INT16/INT32/FLOAT32) to native order; single-byte UCHAR needs none.

--- a/packages/niivue/src/wgpu/NVViewGPU.ts
+++ b/packages/niivue/src/wgpu/NVViewGPU.ts
@@ -923,40 +923,11 @@ export default class NVView {
       screenSlices = this.screenSlices
       graphWidth = baseGraphWidth
     } else {
-      // No spatial view (a signal-only scene, OR the user chose
-      // SLICE_TYPE.NONE): skip all spatial tiles so no slices, crosshairs, or
-      // orientation labels render; the signal graph fills the instance area on
-      // its own. Otherwise lay out the slices and let the graph reclaim any
-      // horizontal slack.
-      const spatialHidden = md.isSpatialViewHidden()
-      const fit = spatialHidden
-        ? {
-            screenSlices: [] as NVSliceLayout.SliceTile[],
-            graphWidth: baseGraphWidth,
-          }
-        : NVSliceLayout.fitSlicesAndGraph(
-            {
-              canvasWH: [
-                canvasWidth - legendWidth - baseGraphWidth,
-                canvasHeight - cbHeight,
-              ],
-              sliceType: md.layout.sliceType,
-              tileMargin: md.layout.margin,
-              extentsMin: md.extentsMin,
-              extentsMax: md.extentsMax,
-              isRadiologicalConvention: md.layout.isRadiological,
-              multiplanarLayout: md.layout.multiplanarType,
-              multiplanarShowRender: md.layout.showRender,
-              sliceMosaicString: md.layout.mosaicString,
-              heroImageFraction: md.layout.heroFraction,
-              heroSliceType: md.layout.heroSliceType,
-              isMultiplanarEqualSize: md.layout.isEqualSize,
-              isCrossLines: md.ui.isCrossLinesVisible,
-              isCenterMosaic: md.layout.isMosaicCentered,
-              customLayout: md.layout.customLayout,
-            },
-            baseGraphWidth,
-          )
+      const fit = NVSliceLayout.fitSlicesFromModel(
+        md,
+        [canvasWidth - legendWidth - baseGraphWidth, canvasHeight - cbHeight],
+        baseGraphWidth,
+      )
       graphWidth = fit.graphWidth
       screenSlices = fit.screenSlices
       this.screenSlices = screenSlices
@@ -1784,7 +1755,7 @@ export default class NVView {
             this.fontRenderer.buildText(s, x, y, sc, c, ax, ay, bc),
           buildLine,
           md.ui.fontColor,
-          md.scene.backgroundColor,
+          md.scene.pan2Dxyzmm,
         )
         if (rulerResult) {
           labels.push(...rulerResult.labels)


### PR DESCRIPTION
Add boolean option isSingleViewFillCanvas (true by default) that allows zoomed in 2D slices to use the full canvas real estate. This only impacts single slice views, not multiplanar tiles.

Feature required for [parity with pre-1.0 NiiVue versions](https://github.com/niivue/mono/issues/139).

Once merged, the feature will be showcased in the [gestures live demo](https://niivue.github.io/mono/examples/vox.gestures.html).