### PR TITLE
fix(dandi-demo): window streamed volumes from the coarse floor, add a UIKit crosshair

### DIFF
--- a/apps/dandi-demo/index.html
+++ b/apps/dandi-demo/index.html
@@ -358,6 +358,18 @@
         </label>
       </span>
       <span class="control">
+        <label for="crosshair"
+          title="How the UIKit crosshair marks the linked position on the deep-zoom pane">
+          Crosshair
+        </label>
+        <select id="crosshair">
+          <option value="plain">plain</option>
+          <option value="ticks">graduated</option>
+          <option value="numbers" selected>graduated + numbers</option>
+          <option value="off">off</option>
+        </select>
+      </span>
+      <span class="control">
         <label for="view" title="What the volumetric pane draws">View</label>
         <select id="view">
           <option value="render" selected>render (3D)</option>

--- a/apps/dandi-demo/src/dandi.js
+++ b/apps/dandi-demo/src/dandi.js
@@ -35,7 +35,11 @@ import NiiVue, {
 // everything that draws in the overlay. The slide renderers expose the same
 // `overlayDraw` hook the controller does, so the widget composes onto the
 // standalone deep-zoom pane exactly as it does onto a NiiVue canvas.
-import { loadDefaultFont, UIKitRulerOverlay } from '@niivue/uikit'
+import {
+  loadDefaultFont,
+  UIKitCrosshairOverlay,
+  UIKitRulerOverlay,
+} from '@niivue/uikit'
 
 const backend =
   new URLSearchParams(location.search).get('backend') === 'webgpu'
@@ -185,6 +189,7 @@ const els = {
   zoomVal: el('zoomVal'),
   fit: el('fit'),
   measure: el('measure'),
+  crosshair: el('crosshair'),
   canvas: el('nv-canvas'),
   slideCanvas: el('slide-canvas'),
   volBusy: el('volBusy'),
@@ -209,7 +214,10 @@ let slideFrame = 0
 let slideFitted = false
 let planeIndex = 0
 let planeTimer = 0
-let windowRange = [0, 1]
+// Null until a dataset load resolves one. NVChunkedVolume derives a 2%-98%
+// window from the coarse floor it builds anyway, so the demo reads the window
+// back off the volume instead of paying for a probe fetch of its own.
+let windowRange = null
 let drag = null
 let dragMoved = false
 let ruler = null
@@ -219,6 +227,11 @@ let ruler = null
 let ruleA = null
 let ruleB = null
 let hoverCss = null
+let crosshair = null
+// The volume pane's crosshair, in RAS voxels, mirrored into the slide pane. Held
+// in voxels rather than slide pixels for the same reason the ruler is held in
+// base pixels: a level swap must not move it.
+let crosshairVox = null
 
 // ---------------------------------------------------------------- utilities
 
@@ -333,10 +346,7 @@ function tileSizeForAxis(axis) {
 
 // ------------------------------------------------------------ source loading
 
-// Robust window from the COARSEST level, which is one small read: percentiles
-// rather than min/max, so a handful of hot voxels cannot flatten everything
-// else. Needed because these stores range from 1e-4 float reflectivity (OCT) to
-// raw uint16 photon counts (SPIM) -- no fixed default fits both.
+// NIfTI datatype code -> typed array, used to size a tile decode in bytes.
 const TYPED_ARRAYS = {
   2: Uint8Array,
   4: Int16Array,
@@ -344,51 +354,6 @@ const TYPED_ARRAYS = {
   16: Float32Array,
   512: Uint16Array,
   768: Uint32Array,
-}
-
-// The probe reads a CENTRED BOX, not the whole coarsest level: a terabyte store's
-// coarsest level is still 666 x 588 x 588 (460 MB), which is not a window probe,
-// it is a download. A centred box is where the sample is in every one of these
-// stores, and the percentiles are taken over a subsample so the sort stays cheap
-// whatever the box holds.
-const WINDOW_PROBE_EDGE = 128
-const WINDOW_PROBE_SAMPLES = 200000
-
-async function autoWindow(source) {
-  const index = source.levels.length - 1
-  const level = source.levels[index]
-  const Ctor = TYPED_ARRAYS[source.datatypeCode]
-  if (!Ctor) return [0, 255]
-  const texDims = level.shape.map((n) => Math.min(n, WINDOW_PROBE_EDGE))
-  const texOrigin = level.shape.map((n, a) => Math.floor((n - texDims[a]) / 2))
-  const bytes = await source.fetchChunk({
-    levelIndex: index,
-    texOrigin,
-    texDims,
-    bytesPerVoxel: Ctor.BYTES_PER_ELEMENT,
-  })
-  const aligned =
-    bytes.byteOffset % Ctor.BYTES_PER_ELEMENT === 0 ? bytes : bytes.slice()
-  const values = new Ctor(
-    aligned.buffer,
-    aligned.byteOffset,
-    aligned.byteLength / Ctor.BYTES_PER_ELEMENT,
-  )
-  const stride = Math.max(1, Math.floor(values.length / WINDOW_PROBE_SAMPLES))
-  const kept = []
-  for (let i = 0; i < values.length; i += stride) {
-    // Float stores (the OCT ones) carry NaN outside the imaged cylinder, and a
-    // NaN sorts to the end of a typed array, which would drag the high
-    // percentile with it.
-    if (Number.isFinite(values[i])) kept.push(values[i])
-  }
-  if (kept.length === 0) return [0, 255]
-  const sorted = Float64Array.from(kept).sort()
-  const at = (p) =>
-    sorted[Math.min(sorted.length - 1, Math.floor(p * sorted.length))]
-  const low = at(0.02)
-  const high = at(0.998)
-  return high > low ? [low, high] : [sorted[0], sorted[sorted.length - 1] || 1]
 }
 
 function datasetUrl(def) {
@@ -415,8 +380,10 @@ async function loadVolumetric(def, token) {
   const cv = await nv.loadChunkedVolume(chunkSource, {
     id: `${def.zarrId}#${token}`,
     name: def.label,
-    calMin: windowRange[0],
-    calMax: windowRange[1],
+    // Passing neither bound lets the core place the window from the coarse
+    // floor; passing both (a user edit, or a reload of an open dataset) is
+    // taken as "I know this store" and suppresses that.
+    ...(windowRange ? { calMin: windowRange[0], calMax: windowRange[1] } : {}),
     colormap: els.colormap.value,
     // 'focus' spends the byte budget around the crosshair, which is exactly the
     // policy that pairs with a linked deep-zoom pane: what you are inspecting in
@@ -432,6 +399,7 @@ async function loadVolumetric(def, token) {
     return
   }
   activeCv = cv
+  windowRange ??= [cv.volume.calMin, cv.volume.calMax]
   await removeVolumes(stale)
   await activeCv.applyCoarseFloor()
 }
@@ -466,7 +434,7 @@ async function removeVolumes(ids) {
 // ------------------------------------------------------------- deep-zoom pane
 
 function rebuildSlide({ keepViewport = true } = {}) {
-  if (!chunkSource) return
+  if (!chunkSource || !windowRange) return
   const axis = els.axis.value
   const previous = slide
   const viewport = keepViewport && previous ? { ...previous.viewport } : null
@@ -553,6 +521,7 @@ function renderSlide() {
     }
     slide.clampViewport(screen)
     updateRuler(screen)
+    updateCrosshair(screen)
     if (slideView.kind === 'gpu') {
       slideView.renderer.render([slide], screen)
     } else {
@@ -602,6 +571,12 @@ function onLocationChange(event) {
   if (!els.follow.checked || !chunkSource) return
   const vox = event.detail?.vox
   if (!vox) return
+  // Recorded before the plane changes: the marker is what tells you WHERE a 3D
+  // depth-pick landed in-plane, and on a slab whose short axis spans ~10 screen
+  // pixels that is the only feedback distinguishing "the pick missed" from "the
+  // pick landed on an empty edge plane".
+  crosshairVox = [vox[0], vox[1], vox[2]]
+  requestSlideRender()
   setPlane(vox[AXIS_INDEX[els.axis.value]], { fromCrosshair: true })
 }
 
@@ -802,9 +777,11 @@ function updateVolumeHud() {
     <div class="row"><span class="key">disk cache</span><span>${persistCost()}</span></div>
     <div class="row"><span class="key">workers</span><span>${workerCost()}</span></div>
     <div class="row"><span class="key">stalls</span><span>${stallCost()}</span></div>
-    <div class="row"><span class="key">window</span><span>${formatValue(
-      windowRange[0],
-    )} .. ${formatValue(windowRange[1])}</span></div>
+    <div class="row"><span class="key">window</span><span>${
+      windowRange
+        ? `${formatValue(windowRange[0])} .. ${formatValue(windowRange[1])}`
+        : '-'
+    }</span></div>
   `
 }
 
@@ -884,6 +861,79 @@ function updateRuler(screen) {
   })
 }
 
+// The crosshair marker is the UIKit crosshair widget (`UIKitCrosshairOverlay`),
+// drawn into the same slide frame as the ruler. Without it the slide pane gives
+// no feedback at all about a link from the volume pane: a 3D depth-pick that
+// lands on an empty edge plane looks identical to one that did not register.
+const CROSSHAIR_COLOR = [0.2, 1, 0.9, 0.9]
+const CROSSHAIR_LABEL_PX = 15
+// Device pixels a minor graduation aims for. Ticks much tighter than this stop
+// resolving on screen; much wider and the arms carry too few to read as a scale.
+const TARGET_TICK_PX = 22
+
+// Round a raw step up to the next 1/2/5 of its decade, the spacing a printed
+// scale would use. Without it a zoom would graduate in 3.7 um steps.
+function niceStep(raw) {
+  const decade = 10 ** Math.floor(Math.log10(raw))
+  for (const m of [1, 2, 5]) {
+    if (m * decade >= raw) return m * decade
+  }
+  return 10 * decade
+}
+
+// The crosshair's graduation, in the units the pane is actually at: micrometres
+// until a tick is worth a whole millimetre. `pxPerUnit` is per axis because
+// `pixelSpacingMM` is (the NeuN slab never downsamples z), so a tick means the
+// same distance on both arms even when the plane is anisotropic.
+function crosshairGraduation(screen) {
+  const spacing = slide.manifest.pixelSpacingMM
+  if (!spacing) return null
+  const devicePerBase = slide.viewport.scale * (screen.devicePixelRatio ?? 1)
+  // Device pixels per micrometre, per plane axis.
+  const perUm = [
+    devicePerBase / (spacing[0] * 1000),
+    devicePerBase / (spacing[1] * 1000),
+  ]
+  if (!(perUm[0] > 0) || !(perUm[1] > 0)) return null
+  // The horizontal axis sets the unit for both, so one label reads for the pair.
+  const wantUm = niceStep(TARGET_TICK_PX / perUm[0])
+  return wantUm >= 1000
+    ? {
+        units: 'mm',
+        pxPerUnit: [perUm[0] * 1000, perUm[1] * 1000],
+        unitsPerTick: wantUm / 1000,
+      }
+    : { units: 'um', pxPerUnit: perUm, unitsPerTick: wantUm }
+}
+
+// Set BEFORE the slide draws, for the same reason updateRuler is.
+function updateCrosshair(screen) {
+  if (!crosshair) return
+  // Unlinked panes navigate independently, so a marker carried over from the
+  // volume pane would point at a position this slide is not showing.
+  const mode = els.crosshair.value
+  if (!slide || !crosshairVox || !els.follow.checked || mode === 'off') {
+    crosshair.clear()
+    return
+  }
+  const [u, v] = PLANE_AXES[els.axis.value]
+  // Voxel centre, matching the floor() the slide-click inverse applies.
+  const point = { x: crosshairVox[u] + 0.5, y: crosshairVox[v] + 0.5 }
+  const dpr = screen.devicePixelRatio ?? 1
+  const graduation = mode === 'plain' ? null : crosshairGraduation(screen)
+  crosshair.setCrosshair({
+    at: slideToDevice(point, screen),
+    color: CROSSHAIR_COLOR,
+    thickness: 2 * dpr,
+    gapPx: 10 * dpr,
+    showTicks: graduation !== null,
+    showTickNumbers: graduation !== null && mode === 'numbers',
+    tickLength: 5 * dpr,
+    sizePx: CROSSHAIR_LABEL_PX * dpr,
+    ...(graduation ?? {}),
+  })
+}
+
 function clearRuler() {
   ruleA = null
   ruleB = null
@@ -955,6 +1005,8 @@ async function loadDataset() {
   slide = null
   slideView?.renderer?.clearTextures?.()
   clearRuler()
+  // A voxel index from the outgoing store means nothing in the incoming one.
+  crosshairVox = null
   // Per-brick phase timings are process-wide totals, so a dataset switch starts
   // a fresh measurement window rather than averaging two stores together.
   nv?.resetChunkTiming()
@@ -977,11 +1029,7 @@ async function loadDataset() {
       return
     }
     chunkSource = source
-    windowRange = await autoWindow(source)
-    if (token !== loadToken) return
-    els.window.value = `${formatValue(windowRange[0])},${formatValue(
-      windowRange[1],
-    )}`
+    windowRange = null
     els.axis.value = def.axis
     planeIndex = Math.floor(shape()[AXIS_INDEX[def.axis]] / 2)
     syncPlaneControl()
@@ -989,6 +1037,9 @@ async function loadDataset() {
     updateProvenance(def)
     await loadVolumetric(def, token)
     if (token !== loadToken) return
+    els.window.value = `${formatValue(windowRange[0])},${formatValue(
+      windowRange[1],
+    )}`
     // Park the crosshair on the plane the slide opens at, so the two panes agree
     // from the first frame rather than after the first click.
     const dims = shape()
@@ -1020,6 +1071,7 @@ function updateProvenance(def) {
 }
 
 function applyWindow() {
+  if (!windowRange) return
   const next = parseWindow(els.window.value, windowRange)
   const changed = next[0] !== windowRange[0] || next[1] !== windowRange[1]
   windowRange = next
@@ -1162,6 +1214,7 @@ els.measure.addEventListener('change', () => {
   if (!els.measure.checked) clearRuler()
   requestSlideRender()
 })
+els.crosshair.addEventListener('change', requestSlideRender)
 els.colormap.addEventListener('change', applyColormap)
 els.window.addEventListener('change', applyWindow)
 els.fit.addEventListener('click', () => {
@@ -1185,10 +1238,17 @@ async function main() {
   nv.scaleMultiplier = DEFAULT_3D_ZOOM
   syncZoomControl(nv.scaleMultiplier)
   slideView = await createSlideView()
-  // One font fetch for the pane. The widget owns its GPU resources on whichever
-  // backend the slide renderer came up on, so this is identical for both.
-  ruler = new UIKitRulerOverlay(await loadDefaultFont())
-  slideView.renderer.overlayDraw = (frame) => ruler.drawOverlay(frame)
+  // One font fetch for the pane, shared by both widgets (each still owns its own
+  // GPU resources on whichever backend the slide renderer came up on).
+  const font = await loadDefaultFont()
+  ruler = new UIKitRulerOverlay(font)
+  crosshair = new UIKitCrosshairOverlay(font)
+  // One hook, two widgets: the renderer exposes a single overlayDraw slot, so the
+  // pane composes them here. Crosshair last, so the marker reads over the ruler.
+  slideView.renderer.overlayDraw = (frame) => {
+    ruler.drawOverlay(frame)
+    crosshair.drawOverlay(frame)
+  }
   await loadDataset()
   // Both panes stream asynchronously with no completion event, so the HUDs poll.
   // Cheap: two innerHTML writes a few times a second.

--- a/packages/niivue/examples/range.js
+++ b/packages/niivue/examples/range.js
@@ -120,6 +120,14 @@ const SYNTHETIC_DEFAULT_WINDOW = { min: 24, max: 210 }
 //
 // A store outside the Open SciVis bucket sets `base` (an absolute URL that the
 // store id is appended to) instead of resolving through the local mirror.
+//
+// `defaultWindow` is OPTIONAL. Omit it and core derives a 2%-98% window from the
+// coarse floor it builds anyway, which is what a store nobody has characterised
+// should get. The five that keep one keep it because the comment beside each
+// records a choice percentiles cannot make: putting calMin ABOVE a background
+// shoulder (air, resin, embedding medium) so the background clips to black and
+// the whole ramp is spent on tissue. A 2nd percentile sits inside those peaks,
+// not past them.
 const HOA_BASE =
   'https://storage.googleapis.com/ucl-hip-ct-35a68e99feaae8932b1d44da0358940b/'
 const OMEZARR_STORES = {
@@ -127,19 +135,21 @@ const OMEZARR_STORES = {
     id: 'stent.ome.zarr',
     name: 'Stent OME-Zarr',
     levels: [2],
-    defaultWindow: { min: 0, max: 1200 },
   },
   pawpawsaurus: {
     id: 'pawpawsaurus.ome.zarr',
     name: 'Pawpawsaurus OME-Zarr',
     levels: [3, 2, 1, 0],
+    // A fossil skull still in its matrix, so the same shoulder problem as the
+    // biological microCT below: the derived 2%-98% window is 12075-48463, whose
+    // calMin sits inside the matrix rather than past it, and the skull washes
+    // out to flat white. calMin above the matrix spends the ramp on bone.
     defaultWindow: { min: 30269, max: 56893 },
   },
   richtmyer_meshkov: {
     id: 'richtmyer_meshkov.ome.zarr',
     name: 'Richtmyer-Meshkov OME-Zarr',
     levels: [4, 3, 2, 1, 0],
-    defaultWindow: { min: 0, max: 230 },
   },
   // Biological microCT.
   chameleon: {
@@ -663,9 +673,10 @@ function formatWindow(win) {
 
 function setDefaultWindowForSelectedSource() {
   const store = currentStore()
-  els.window.value = formatWindow(
-    store ? store.defaultWindow : SYNTHETIC_DEFAULT_WINDOW,
-  )
+  const win = store ? store.defaultWindow : SYNTHETIC_DEFAULT_WINDOW
+  // Empty means "no opinion": the load passes no calMin/calMax, core derives
+  // one, and the reload writes what it chose back into the field.
+  els.window.value = win ? formatWindow(win) : ''
 }
 
 async function fetchJson(url) {
@@ -944,7 +955,9 @@ async function loadOmezarrSource(storeDef, serial) {
     dtype,
     datatypeCode: dtypeInfo.code,
     numBitsPerVoxel: dtypeInfo.bits,
-    defaultWindow: { ...storeDef.defaultWindow },
+    defaultWindow: storeDef.defaultWindow
+      ? { ...storeDef.defaultWindow }
+      : null,
     chunkGrid,
     chunkShape,
     chunkCount: chunkGrid[0] * chunkGrid[1] * chunkGrid[2],
@@ -1875,8 +1888,9 @@ async function runReload(token, options) {
           // `name` (what the HUD/labels show) stays activeSource.name.
           id: `${activeSource.name}#${token}`,
           name: activeSource.name,
-          calMin: win.min,
-          calMax: win.max,
+          // No window means core places one from the coarse floor; supplying
+          // one suppresses that, which is what the characterised stores want.
+          ...(win ? { calMin: win.min, calMax: win.max } : {}),
           colormap: els.colormap.value,
           // Policy (where the detail goes, how many bricks it may cost) comes
           // from the named plan; only the VRAM ceiling is pinned by the demo,
@@ -1904,6 +1918,15 @@ async function runReload(token, options) {
         return
       }
       activeCv = cv
+      if (!win) {
+        // Percentiles land on long floats; the field is an editable control, so
+        // show a readable number rather than 15 significant digits.
+        const tidy = (value) => Number(value.toPrecision(6))
+        els.window.value = formatWindow({
+          min: tidy(cv.volume.calMin),
+          max: tidy(cv.volume.calMax),
+        })
+      }
       // New streamed volume is resident; drop the one(s) it displaced.
       await removeSceneVolumes(stale)
       chunkPlan = activeCv.currentPlan

--- a/packages/niivue/src/volume/NVChunkedVolume.test.ts
+++ b/packages/niivue/src/volume/NVChunkedVolume.test.ts
@@ -878,3 +878,140 @@ describe('budget plans', () => {
     expect(Math.min(...levelsOf(mgr))).toBeGreaterThanOrEqual(2)
   })
 })
+
+// --- automatic display window ---------------------------------------------
+
+/**
+ * A streamed volume is built before any voxel has been read, so its window can
+ * only be a placeholder until data arrives. These cover the derivation that
+ * replaces it, and the caller override that suppresses it.
+ */
+describe('NVChunkedVolume automatic display window', () => {
+  const COARSE = 32
+
+  /** uint8 pyramid whose coarsest level reads back as a 0..200 ramp + outliers. */
+  const rampSource = (): ChunkedVolumeSource => ({
+    datatypeCode: 2, // DT_UINT8
+    levels: [
+      { level: 0, shape: [128, 128, 128], spacing: [1, 1, 1] },
+      { level: 1, shape: [COARSE, COARSE, COARSE], spacing: [4, 4, 4] },
+    ],
+    fetchChunk: async (r: { texDims: Vec3i }) => {
+      const n = r.texDims[0] * r.texDims[1] * r.texDims[2]
+      const out = new Uint8Array(n)
+      for (let i = 0; i < n; i++) out[i] = Math.floor((i / n) * 200)
+      for (let i = Math.max(0, n - 8); i < n; i++) out[i] = 255
+      return out
+    },
+  })
+
+  /**
+   * The stub mirrors ONE controller behaviour that matters here: `addVolume`
+   * stores a SHALLOW COPY (`NVModel.prepareVolume`), so what the scene renders
+   * is a different object from the handle's `volume`. Without that, a window
+   * written only to the handle looks correct in a test and is invisible on
+   * screen.
+   */
+  function makeWindowHost(): {
+    host: NiiVue
+    updateGLCalls: () => number
+    sceneVolume: () => NVImage | undefined
+  } {
+    let updateGL = 0
+    const volumes: NVImage[] = []
+    const host = {
+      volumes,
+      addVolume: async (vol: NVImage) => {
+        volumes.push({ ...vol })
+      },
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      setBaseCoarseFloor: async () => {},
+      updateGLVolume: async () => {
+        updateGL++
+      },
+      swapVolumeChunkPlan: async () => {},
+      _registerChunkedVolume: () => {},
+      _unregisterChunkedVolume: () => {},
+      isDestroyed: false,
+    } as unknown as NiiVue
+    return {
+      host,
+      updateGLCalls: () => updateGL,
+      sceneVolume: () => volumes[0],
+    }
+  }
+
+  test('derives the window from the coarse floor instead of the 0..1 placeholder', async () => {
+    const { host, updateGLCalls, sceneVolume } = makeWindowHost()
+    const mgr = new NVChunkedVolume(host, rampSource(), { radius: 16 })
+    // The placeholder every streamed volume starts on.
+    expect(mgr.volume.calMin).toBe(0)
+    expect(mgr.volume.calMax).toBe(1)
+
+    await mgr.init()
+
+    expect(mgr.volume.calMax).toBeGreaterThan(1)
+    expect(mgr.volume.calMax).toBeGreaterThan(mgr.volume.calMin)
+    // Contrast dragging scales by this range; on the placeholder it was 1.
+    expect(mgr.volume.robustMin).toBe(mgr.volume.calMin)
+    expect(mgr.volume.robustMax).toBe(mgr.volume.calMax)
+    expect(mgr.volume.globalMax).toBe(255)
+    // The outliers sit above the robust high, which is the point of a window.
+    expect(mgr.volume.calMax).toBeLessThan(mgr.volume.globalMax as number)
+    // The scene renders a shallow copy made before the window was derived; the
+    // window is only real if it landed there too.
+    expect(sceneVolume()?.calMin).toBe(mgr.volume.calMin)
+    expect(sceneVolume()?.calMax).toBe(mgr.volume.calMax)
+    expect(sceneVolume()?.robustMax).toBe(mgr.volume.calMax)
+    // The new window has to reach the GPU, not just the model.
+    expect(updateGLCalls()).toBe(1)
+  })
+
+  test('a caller-supplied window is left alone', async () => {
+    const { host, updateGLCalls } = makeWindowHost()
+    const mgr = new NVChunkedVolume(host, rampSource(), {
+      radius: 16,
+      calMin: 12,
+      calMax: 34,
+    })
+    await mgr.init()
+    expect(mgr.volume.calMin).toBe(12)
+    expect(mgr.volume.calMax).toBe(34)
+    expect(updateGLCalls()).toBe(0)
+  })
+
+  test('supplying only one bound still counts as caller-owned', async () => {
+    const { host } = makeWindowHost()
+    const mgr = new NVChunkedVolume(host, rampSource(), {
+      radius: 16,
+      calMax: 90,
+    })
+    await mgr.init()
+    expect(mgr.volume.calMax).toBe(90)
+  })
+
+  test('falls back to a bounded probe when there is no coarse floor', async () => {
+    const { host } = makeWindowHost()
+    const mgr = new NVChunkedVolume(host, rampSource(), {
+      radius: 16,
+      coarseFloor: false,
+    })
+    await mgr.init()
+    expect(mgr.volume.calMax).toBeGreaterThan(1)
+    expect(mgr.volume.calMax).toBeGreaterThan(mgr.volume.calMin)
+  })
+
+  test('keeps the placeholder when every sampled voxel is identical', async () => {
+    const { host } = makeWindowHost()
+    const flat: ChunkedVolumeSource = {
+      ...rampSource(),
+      fetchChunk: async (r: { texDims: Vec3i }) =>
+        new Uint8Array(r.texDims[0] * r.texDims[1] * r.texDims[2]).fill(7),
+    }
+    const mgr = new NVChunkedVolume(host, flat, { radius: 16 })
+    await mgr.init()
+    expect(mgr.volume.calMin).toBe(0)
+    expect(mgr.volume.calMax).toBe(1)
+  })
+})

--- a/packages/niivue/src/volume/NVChunkedVolume.ts
+++ b/packages/niivue/src/volume/NVChunkedVolume.ts
@@ -21,7 +21,11 @@ import {
   type Vec3i,
 } from './chunking'
 import { createStreamingNVImage } from './streamingVolume'
-import { getBitsPerVoxel, getTypedArrayConstructor } from './utils'
+import {
+  getBitsPerVoxel,
+  getTypedArrayConstructor,
+  robustDisplayWindow,
+} from './utils'
 
 /**
  * Options for {@link NiiVue.loadChunkedVolume}. The plan-shaping half lives in
@@ -57,6 +61,14 @@ export interface ChunkedVolumeOptions extends BudgetPlanOptions {
  */
 const COARSE_FLOOR_MAX_VOXELS = 256 ** 3
 const COARSE_FLOOR_MAX_EDGE = 512
+
+/**
+ * Edge cap for the window probe used when there is NO coarse floor to read
+ * (the floor was disabled, or the coarsest level is over the floor caps above).
+ * A centred crop of the coarsest level, capped here, is enough to place a
+ * 2%-98% window and costs one bounded fetch.
+ */
+const WINDOW_PROBE_MAX_EDGE = 64
 
 // --- pure helpers (unit-tested; no controller needed) -----------------------
 
@@ -315,6 +327,13 @@ export class NVChunkedVolume {
   // repeat call does not re-fetch the coarse level.
   private floorVolume: NVImage | null = null
   private floorBuilt = false
+  /**
+   * True when the caller passed NEITHER `calMin` nor `calMax`, so the window is
+   * ours to derive from the data. Passing either one is taken as "I know this
+   * store", and nothing is derived.
+   */
+  private readonly wantsAutoWindow: boolean
+  private windowResolved = false
 
   constructor(
     host: NiiVue,
@@ -332,6 +351,8 @@ export class NVChunkedVolume {
     // precedence rule (knobs win). Passing no plan reproduces the pre-plan
     // defaults exactly.
     this.o = resolveBudgetPlan(options, this.planContext())
+    this.wantsAutoWindow =
+      options.calMin === undefined && options.calMax === undefined
     this.followCrosshair = this.o.focus === 'crosshair'
     this.focusFrac = Array.isArray(this.o.focus)
       ? [this.o.focus[0], this.o.focus[1], this.o.focus[2]]
@@ -391,6 +412,11 @@ export class NVChunkedVolume {
     this.host.addEventListener('viewDestroyed', this.onViewDestroyed)
     this.applyRenderCentering()
     await this.applyCoarseFloor()
+    // The floor path resolves the window for free when a floor was built. When
+    // it was not, fall back to a bounded probe so a streamed volume still opens
+    // on a window that shows the data rather than on the 0..1 placeholder.
+    if (this.wantsAutoWindow && !this.windowResolved) await this.probeWindow()
+    if (this.windowResolved && !this.disposed) await this.host.updateGLVolume()
   }
 
   /**
@@ -766,10 +792,123 @@ export class NVChunkedVolume {
         id: `${this.volumeId}:floor`,
       })
       floor.img = toVoxelView(bytes, Ctor, bytesPerVoxel, voxels)
+      // The floor IS the whole volume at its coarsest level, so it is the best
+      // window sample available and it costs no extra fetch.
+      this.applyAutoWindow(floor)
       return floor
     } catch (err) {
       log.warn('NVChunkedVolume: coarse floor unavailable', err)
       return null
+    }
+  }
+
+  /**
+   * Adopt a 2%-98% display window derived from `sample`, when the caller did
+   * not supply one.
+   *
+   * A streamed volume is constructed before a single voxel has been read, so
+   * the window it starts with can only be a placeholder (`calMin` 0 /
+   * `calMax` 1). That is meaningless for real data — a uint8 store renders
+   * saturated white, a uint16 store nearly black — which is why every consumer
+   * has had to hand-tune a window per store. Deriving it here removes that
+   * from the callers.
+   *
+   * `robustMin`/`robustMax` are set from the same pair deliberately: contrast
+   * dragging scales by `robustMax - robustMin` (`control/dragModes.ts`), which
+   * on the placeholder window is a range of 1, making the drag useless on a
+   * streamed volume.
+   */
+  private applyAutoWindow(sample: NVImage): void {
+    if (!this.wantsAutoWindow || this.windowResolved || !sample.img) return
+    let derived: [number, number, number, number]
+    try {
+      derived = robustDisplayWindow(sample.hdr, sample.img)
+    } catch (err) {
+      // calMinMax throws only for an all-non-finite sample. Keep the
+      // placeholder rather than installing a NaN window.
+      log.warn(
+        'NVChunkedVolume: no automatic window, sample has no finite voxels',
+        err,
+      )
+      return
+    }
+    const [lo, hi, globalMin, globalMax] = derived
+    if (!Number.isFinite(lo) || !Number.isFinite(hi) || hi <= lo) {
+      log.warn(
+        `NVChunkedVolume: no automatic window, sample is flat (${lo}..${hi})`,
+      )
+      return
+    }
+    // `addVolume` stores a SHALLOW COPY of the NVImage
+    // (`NVModel.prepareVolume`), and `init` has already added this volume by the
+    // time a window can be derived, so the object the scene renders is NOT
+    // `this.volume`. Address it by id the way `swapVolumeChunkPlan` does, or the
+    // derived window reaches this handle and nothing the user can see.
+    const scene = this.host.volumes?.find((v) => v.id === this.volumeId)
+    const targets = new Set<NVImage>([this.volume, sample])
+    if (scene) targets.add(scene)
+    for (const vol of targets) {
+      vol.calMin = lo
+      vol.calMax = hi
+      vol.robustMin = lo
+      vol.robustMax = hi
+      vol.globalMin = globalMin
+      vol.globalMax = globalMax
+      vol.hdr.cal_min = lo
+      vol.hdr.cal_max = hi
+    }
+    this.windowResolved = true
+    log.debug(
+      `NVChunkedVolume: auto window ${lo}..${hi} (global ${globalMin}..${globalMax})`,
+    )
+  }
+
+  /**
+   * Read a bounded centred crop of the coarsest level purely to place the
+   * window. Only used when no coarse floor exists to read instead.
+   */
+  private async probeWindow(): Promise<void> {
+    const levelIndex = this.source.levels.length - 1
+    const level = this.source.levels[levelIndex]
+    const Ctor = getTypedArrayConstructor(this.source.datatypeCode)
+    if (!Ctor || this.disposed) return
+    const texDims: Vec3i = [
+      Math.min(level.shape[0], WINDOW_PROBE_MAX_EDGE),
+      Math.min(level.shape[1], WINDOW_PROBE_MAX_EDGE),
+      Math.min(level.shape[2], WINDOW_PROBE_MAX_EDGE),
+    ]
+    const texOrigin: Vec3i = [
+      Math.floor((level.shape[0] - texDims[0]) / 2),
+      Math.floor((level.shape[1] - texDims[1]) / 2),
+      Math.floor((level.shape[2] - texDims[2]) / 2),
+    ]
+    try {
+      const bytesPerVoxel = getBitsPerVoxel(this.source.datatypeCode) / 8
+      const bytes = await this.source.fetchChunk({
+        levelIndex,
+        texOrigin,
+        texDims,
+        bytesPerVoxel,
+      })
+      if (this.disposed) return
+      const probe = createStreamingNVImage({
+        shape: texDims,
+        spacing: level.spacing,
+        datatypeCode: this.source.datatypeCode,
+        calMin: 0,
+        calMax: 1,
+        name: `${this.volume.name} window probe`,
+        id: `${this.volumeId}:window-probe`,
+      })
+      probe.img = toVoxelView(
+        bytes,
+        Ctor,
+        bytesPerVoxel,
+        texDims[0] * texDims[1] * texDims[2],
+      )
+      this.applyAutoWindow(probe)
+    } catch (err) {
+      log.warn('NVChunkedVolume: window probe unavailable', err)
     }
   }
 

--- a/packages/niivue/src/volume/utils.test.ts
+++ b/packages/niivue/src/volume/utils.test.ts
@@ -14,6 +14,7 @@ import {
   getVoxelValue,
   hdrToArrayBuffer,
   reorientDrawingToNative,
+  robustDisplayWindow,
   temporalUnitScale,
   toTypedView,
   toTypedViewOrU8,
@@ -544,5 +545,107 @@ describe('extractVoxelFid', () => {
     // t=0 only: re(v=1,p,0) = 100 + p*10.
     expect(out?.[0]).toBeCloseTo(100, 5)
     expect(out?.[2]).toBeCloseTo(110, 5)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// robustDisplayWindow
+// ---------------------------------------------------------------------------
+describe('robustDisplayWindow', () => {
+  /** A ramp 0..255 with a handful of bright outliers at the top. */
+  const rampWithOutliers = (): { hdr: NIFTIHeader; img: Uint8Array } => {
+    const dim = 16
+    const n = dim * dim * dim
+    const img = new Uint8Array(n)
+    for (let i = 0; i < n; i++) img[i] = Math.floor((i / n) * 200)
+    for (let i = n - 8; i < n; i++) img[i] = 255
+    const hdr = createNiftiHeader(
+      [dim, dim, dim],
+      [1, 1, 1],
+      [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
+      NiiDataType.DT_UINT8,
+    )
+    return { hdr, img }
+  }
+
+  test('ignores a placeholder header window that calMinMax would adopt', () => {
+    const { hdr, img } = rampWithOutliers()
+    // What createStreamingNVImage stamps on a streamed volume before any voxel
+    // has been read: the default display window, not file metadata.
+    hdr.cal_min = 0
+    hdr.cal_max = 1
+
+    // calMinMax honours it, which is the bug this helper exists to avoid.
+    expect(calMinMax(hdr, img).slice(0, 2)).toEqual([0, 1])
+
+    const [lo, hi] = robustDisplayWindow(hdr, img)
+    expect(hi).toBeGreaterThan(1)
+    expect(hi).toBeGreaterThan(lo)
+  })
+
+  test('restores the header window it borrowed', () => {
+    const { hdr, img } = rampWithOutliers()
+    hdr.cal_min = 0
+    hdr.cal_max = 1
+    robustDisplayWindow(hdr, img)
+    expect(hdr.cal_min).toBe(0)
+    expect(hdr.cal_max).toBe(1)
+  })
+
+  test('restores the header window even when the image is all non-finite', () => {
+    const dim = 4
+    const img = new Float32Array(dim * dim * dim).fill(Number.NaN)
+    const hdr = createNiftiHeader(
+      [dim, dim, dim],
+      [1, 1, 1],
+      [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
+      NiiDataType.DT_FLOAT32,
+    )
+    hdr.cal_min = 5
+    hdr.cal_max = 9
+    expect(() => robustDisplayWindow(hdr, img)).toThrow()
+    expect(hdr.cal_min).toBe(5)
+    expect(hdr.cal_max).toBe(9)
+  })
+
+  test('is not skewed inward by NaN padding', () => {
+    // Two volumes with the SAME finite data: one packed, one padded out to 4x
+    // the size with NaN, which is what a DANDI float OCT store looks like
+    // outside the imaged cylinder. The percentile target is a fraction of the
+    // voxels the histogram holds, so the padding must not change the window.
+    const finite = 4096
+    const value = (i: number) => (i / finite) * 200
+    const packed = new Float32Array(finite)
+    for (let i = 0; i < finite; i++) packed[i] = value(i)
+    const padded = new Float32Array(finite * 4).fill(Number.NaN)
+    for (let i = 0; i < finite; i++) padded[i * 4] = value(i)
+
+    const floatHdr = (dims: [number, number, number]): NIFTIHeader =>
+      createNiftiHeader(
+        dims,
+        [1, 1, 1],
+        [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
+        NiiDataType.DT_FLOAT32,
+      )
+    const packedWin = robustDisplayWindow(floatHdr([16, 16, 16]), packed).slice(
+      0,
+      2,
+    )
+    const paddedWin = robustDisplayWindow(floatHdr([16, 16, 64]), padded).slice(
+      0,
+      2,
+    )
+    // Same bin resolution over the same value range, so this is exact, not close.
+    expect(paddedWin).toEqual(packedWin)
+  })
+
+  test('reports global min/max alongside the robust pair', () => {
+    const { hdr, img } = rampWithOutliers()
+    const [lo, hi, globalMin, globalMax] = robustDisplayWindow(hdr, img)
+    expect(globalMin).toBe(0)
+    expect(globalMax).toBe(255)
+    // The outliers pull globalMax past the robust high.
+    expect(hi).toBeLessThan(globalMax)
+    expect(lo).toBeGreaterThanOrEqual(globalMin)
   })
 })

--- a/packages/niivue/src/volume/utils.ts
+++ b/packages/niivue/src/volume/utils.ts
@@ -201,19 +201,23 @@ function robustRange(
   imgRaw: TypedVoxelArray,
   start: number,
   end: number,
-): { mn: number; mx: number; nZero: number } | null {
+): { mn: number; mx: number; nZero: number; nSkip: number } | null {
   let mn = Number.POSITIVE_INFINITY
   let mx = Number.NEGATIVE_INFINITY
   let nZero = 0
+  let nSkip = 0
   for (let i = start; i < end; i++) {
     const v = imgRaw[i]
-    if (!Number.isFinite(v)) continue
+    if (!Number.isFinite(v)) {
+      nSkip++
+      continue
+    }
     if (v === 0) nZero++
     if (v < mn) mn = v
     if (v > mx) mx = v
   }
   if (!Number.isFinite(mn) || !Number.isFinite(mx)) return null
-  return { mn, mx, nZero }
+  return { mn, mx, nZero, nSkip }
 }
 
 /**
@@ -227,9 +231,16 @@ function histogramPercentiles(
   mn: number,
   mx: number,
   nZero: number,
+  nSkip: number,
 ): [number, number] {
   const nVox = end - start
-  const n2pct = Math.round((nVox - nZero) * 0.02)
+  // The population is the voxels the histogram actually holds. Zeros are
+  // excluded by the original heuristic (a large zero background would otherwise
+  // swallow the low percentile whole); non-finite voxels are excluded because
+  // they were skipped, and counting them would push BOTH percentiles inward --
+  // a store that is 80% NaN padding, as several DANDI float OCT volumes are,
+  // would get a 10%-90% window while asking for 2%-98%.
+  const n2pct = Math.round((nVox - nZero - nSkip) * 0.02)
   const nBins = 1001
   const scl = (nBins - 1) / (mx - mn)
   const hist = new Uint32Array(nBins)
@@ -275,7 +286,7 @@ export function calMinMax(
   const nVox3D = hdr.dims[1] * hdr.dims[2] * hdr.dims[3]
   const stats = robustRange(imgRaw, 0, nVox3D)
   if (!stats) throw new Error('infinite image')
-  const { mn, mx, nZero } = stats
+  const { mn, mx, nZero, nSkip } = stats
   const mnScale = r2c(mn)
   const mxScale = r2c(mx)
   if (mx === mn) return [mnScale, mxScale, mnScale, mxScale]
@@ -288,10 +299,41 @@ export function calMinMax(
       return [hdr.cal_min, hdr.cal_max, mnScale, mxScale]
     }
   }
-  const [lo, hi] = histogramPercentiles(imgRaw, 0, nVox3D, mn, mx, nZero)
+  const [lo, hi] = histogramPercentiles(imgRaw, 0, nVox3D, mn, mx, nZero, nSkip)
   if (lo === hi) return [mnScale, mxScale, mnScale, mxScale]
   const scl = (1001 - 1) / (mx - mn)
   return [r2c(lo / scl + mn), r2c(hi / scl + mn), mnScale, mxScale]
+}
+
+/**
+ * Robust display window for voxels whose header carries a PLACEHOLDER
+ * `cal_min`/`cal_max` rather than real file metadata.
+ *
+ * {@link calMinMax} honours a header window when it finds one, which is correct
+ * for a NIfTI whose author wrote it. A streamed volume's header is synthesized:
+ * `createStreamingNVImage` stamps the caller's (or the default) window onto it
+ * before a single voxel has been read, so that branch would hand back the very
+ * placeholder we are trying to replace. Neutralizing the header window forces
+ * the 2%-98% histogram path.
+ *
+ * Returns `[robustMin, robustMax, globalMin, globalMax]`, calibrated. Throws
+ * for an all-non-finite image, like {@link calMinMax}.
+ */
+export function robustDisplayWindow(
+  hdr: NIFTI1 | NIFTI2,
+  img: ArrayBuffer | TypedVoxelArray,
+): [number, number, number, number] {
+  const savedMin = hdr.cal_min
+  const savedMax = hdr.cal_max
+  // calMinMax adopts the header window only when cal_min < cal_max.
+  hdr.cal_min = 0
+  hdr.cal_max = 0
+  try {
+    return calMinMax(hdr, img)
+  } finally {
+    hdr.cal_min = savedMin
+    hdr.cal_max = savedMax
+  }
 }
 
 /**
@@ -311,11 +353,19 @@ export function calMinMaxFrame(
   const end = Math.min(offset + vol.nVox3D, imgRaw.length)
   const stats = robustRange(imgRaw, offset, end)
   if (!stats) return [0, 0, 0, 0]
-  const { mn, mx, nZero } = stats
+  const { mn, mx, nZero, nSkip } = stats
   const mnScale = r2c(mn)
   const mxScale = r2c(mx)
   if (mx === mn) return [mnScale, mxScale, mnScale, mxScale]
-  const [lo, hi] = histogramPercentiles(imgRaw, offset, end, mn, mx, nZero)
+  const [lo, hi] = histogramPercentiles(
+    imgRaw,
+    offset,
+    end,
+    mn,
+    mx,
+    nZero,
+    nSkip,
+  )
   if (lo === hi) return [mnScale, mxScale, mnScale, mxScale]
   const scl = (1001 - 1) / (mx - mn)
   return [r2c(lo / scl + mn), r2c(hi / scl + mn), mnScale, mxScale]

--- a/packages/uikit/README.md
+++ b/packages/uikit/README.md
@@ -1,14 +1,13 @@
 # @niivue/uikit
 
-UIKit: a collection of controls and widgets (rulers, and later buttons, sliders,
-panels, labels) integrated into the [NiiVue](https://github.com/niivue/niivue)
-rendering lifecycle.
+UIKit: a collection of controls and widgets (rulers, crosshairs, annotations,
+and later buttons, sliders, panels) integrated into the
+[NiiVue](https://github.com/niivue/niivue) rendering lifecycle.
 
-> **Status: base module.** This package is being stood up as the foundation for the
-> UIKit work. Today it ships the line-drawing primitives (including arrow
-> terminators). The rendering-lifecycle hook, UIKit's own line/text renderers
-> (WebGL2 + WebGPU, with a text transform), and the first widget (a ruler) land
-> next. See `docs/ruler-port.md` in `@niivue/niivue` for the design.
+> **Status: shipping widgets.** The rendering-lifecycle hook, UIKit's own
+> line/text renderers (WebGL2 + WebGPU, with a text transform), and the first
+> widgets (ruler, annotation, crosshair) are in. See `docs/ruler-port.md` in
+> `@niivue/niivue` for the design.
 
 ## Design in one paragraph
 
@@ -19,7 +18,38 @@ line/text renderers on both backends. UIKit carries a duplicated copy of the lin
 and text drawing so core stays untouched during a bake-in phase; once UIKit is
 proven, core's overlays cut over onto it and the duplicate in core is removed.
 
-## Today
+## Widgets
+
+Each widget is a pure geometry builder (spec in, plain line + text draw data out,
+unit-testable without a GPU) paired with an overlay that owns the GPU resources
+and draws that data through the lifecycle hook.
+
+| Builder | Overlay | Draws |
+| --- | --- | --- |
+| `buildRuler` | `UIKitRulerOverlay` | A measuring ruler with graduated ticks and a distance label |
+| `buildCrosshair` | `UIKitCrosshairOverlay` | A screen-space cross marking a point, optionally graduated and numbered |
+| `buildAnnotationGeometry` | `UIKitAnnotationOverlay` | Free-form annotation lines |
+
+```ts
+import { loadDefaultFont, UIKitCrosshairOverlay } from '@niivue/uikit'
+
+// One font fetch, shared by every widget on the pane.
+const crosshair = new UIKitCrosshairOverlay(await loadDefaultFont())
+renderer.overlayDraw = (frame) => crosshair.drawOverlay(frame)
+
+crosshair.setCrosshair({
+  at: [x, y],
+  gapPx: 10, // leave the pixel being pointed at uncovered
+  showTicks: true,
+  showTickNumbers: true,
+  pxPerUnit: [devicePxPerUm, devicePxPerUm], // per axis: planes can be anisotropic
+  unitsPerTick: 100,
+  units: 'um',
+})
+```
+
+The builders are usable on their own if you want the geometry but not UIKit's
+renderers:
 
 ```ts
 import { buildTerminatedLine, LineTerminator } from '@niivue/uikit'

--- a/packages/uikit/src/crosshair.test.ts
+++ b/packages/uikit/src/crosshair.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from 'bun:test'
+import { buildCrosshair } from './crosshair'
+import type { LineData } from './line'
+
+// [sx, sy, ex, ey] of a LineData record.
+function ends(line: LineData | undefined): number[] {
+  const d = line?.data
+  return [d?.[0] ?? 0, d?.[1] ?? 0, d?.[2] ?? 0, d?.[3] ?? 0]
+}
+
+// Thickness is the fifth float of the record.
+function thicknessOf(line: LineData | undefined): number {
+  return line?.data[4] ?? 0
+}
+
+describe('buildCrosshair', () => {
+  it('emits four gapped arms reaching the frame edges', () => {
+    const g = buildCrosshair({ at: [50, 40], width: 100, height: 80, gapPx: 6 })
+    expect(g.lines).toHaveLength(4)
+    expect(g.text).toHaveLength(0)
+    expect(ends(g.lines[0])).toEqual([0, 40, 44, 40])
+    expect(ends(g.lines[1])).toEqual([56, 40, 100, 40])
+    expect(ends(g.lines[2])).toEqual([50, 0, 50, 34])
+    expect(ends(g.lines[3])).toEqual([50, 46, 50, 80])
+  })
+
+  it('leaves the centre pixel uncovered', () => {
+    const g = buildCrosshair({
+      at: [50, 40],
+      width: 100,
+      height: 80,
+      gapPx: 10,
+    })
+    // No segment spans the centre on either axis.
+    for (const line of g.lines) {
+      const [sx, sy, ex, ey] = ends(line)
+      const spansX = Math.min(sx, ex) < 50 && Math.max(sx, ex) > 50
+      const spansY = Math.min(sy, ey) < 40 && Math.max(sy, ey) > 40
+      expect(spansX && spansY).toBe(false)
+    }
+  })
+
+  it('honors a finite arm length instead of reaching the edges', () => {
+    const g = buildCrosshair({
+      at: [50, 40],
+      width: 100,
+      height: 80,
+      gapPx: 6,
+      armPx: 10,
+    })
+    expect(ends(g.lines[0])).toEqual([34, 40, 44, 40])
+    expect(ends(g.lines[1])).toEqual([56, 40, 66, 40])
+  })
+
+  it('draws an unbroken cross when the gap is zero', () => {
+    const g = buildCrosshair({ at: [50, 40], width: 100, height: 80, gapPx: 0 })
+    expect(g.lines).toHaveLength(4)
+    expect(ends(g.lines[0])).toEqual([0, 40, 50, 40])
+  })
+
+  it('drops the axis whose centre is off-frame, keeping the other', () => {
+    // Panned off the left edge: the row is still meaningful, the column is not.
+    const g = buildCrosshair({ at: [-30, 40], width: 100, height: 80 })
+    expect(g.lines).toHaveLength(1)
+    const [sx, , ex] = ends(g.lines[0])
+    expect(sx).toBe(0)
+    expect(ex).toBe(100)
+  })
+
+  it('returns nothing for a non-finite centre or an empty frame', () => {
+    expect(
+      buildCrosshair({ at: [Number.NaN, 40], width: 100, height: 80 }).lines,
+    ).toHaveLength(0)
+    expect(
+      buildCrosshair({ at: [50, 40], width: 0, height: 80 }).lines,
+    ).toHaveLength(0)
+  })
+
+  it('graduates both arms of an axis outward from the centre', () => {
+    const g = buildCrosshair({
+      at: [50, 40],
+      width: 100,
+      height: 80,
+      gapPx: 0,
+      armPx: 20,
+      showTicks: true,
+      pxPerUnit: 10,
+      tickLength: 4,
+    })
+    // Two arms + 2 ticks each way on x (10, 20), same on y.
+    const xTicks = g.lines.filter((l) => ends(l)[0] === ends(l)[2])
+    // Vertical strokes: the two vertical ARMS plus the horizontal arm's ticks.
+    expect(xTicks.length).toBe(2 + 4)
+    // A tick at 10px left of centre, straddling the arm.
+    expect(ends(g.lines[2])).toEqual([40, 36, 40, 44])
+  })
+
+  it('skips graduation when no scale is supplied', () => {
+    const g = buildCrosshair({
+      at: [50, 40],
+      width: 100,
+      height: 80,
+      showTicks: true,
+    })
+    expect(g.lines).toHaveLength(4)
+  })
+
+  it('draws majors twice the length of minors', () => {
+    const g = buildCrosshair({
+      at: [50, 40],
+      width: 100,
+      height: 80,
+      gapPx: 0,
+      armPx: 50,
+      showTicks: true,
+      pxPerUnit: 5,
+      tickLength: 4,
+    })
+    // Unit 5 is the first major, at 25px from centre.
+    const major = g.lines.find((l) => ends(l)[0] === 75 && ends(l)[1] === 32)
+    expect(major).toBeDefined()
+    expect(ends(major)).toEqual([75, 32, 75, 48])
+  })
+
+  it('numbers the majors only, with the unit suffix when given', () => {
+    const g = buildCrosshair({
+      at: [50, 40],
+      width: 100,
+      height: 80,
+      gapPx: 0,
+      armPx: 50,
+      showTicks: true,
+      showTickNumbers: true,
+      pxPerUnit: 5,
+      units: 'um',
+      sizePx: 6,
+    })
+    expect(g.text.length).toBeGreaterThan(0)
+    // Distance from the centre, so both sides of an axis carry the same value.
+    expect(g.text.every((t) => /^\d+ um$/.test(t.str))).toBe(true)
+    expect(g.text.some((t) => t.str === '5 um')).toBe(true)
+    // Nothing at a minor (units 1-4).
+    expect(g.text.some((t) => t.str === '3 um')).toBe(false)
+  })
+
+  it('drops numbers that would collide, keeping the ticks', () => {
+    const dense = {
+      at: [50, 40] as const,
+      width: 100,
+      height: 80,
+      gapPx: 0,
+      armPx: 50,
+      showTicks: true,
+      showTickNumbers: true,
+      pxPerUnit: 1,
+      sizePx: 20,
+    }
+    const g = buildCrosshair(dense)
+    const roomy = buildCrosshair({ ...dense, sizePx: 4 })
+    expect(g.text.length).toBeLessThan(roomy.text.length)
+    expect(g.lines.length).toBe(roomy.lines.length)
+  })
+
+  it('spaces ticks by unitsPerTick and numbers them by distance', () => {
+    const g = buildCrosshair({
+      at: [50, 40],
+      width: 100,
+      height: 80,
+      gapPx: 0,
+      armPx: 50,
+      showTicks: true,
+      showTickNumbers: true,
+      // One unit is 1px, but ticks land every 10 units.
+      pxPerUnit: 1,
+      unitsPerTick: 10,
+      units: 'um',
+      sizePx: 6,
+      tickLength: 4,
+    })
+    // First tick 10px out, first major (fifth tick) at 50 units.
+    expect(ends(g.lines[2])).toEqual([40, 36, 40, 44])
+    // The number reads the distance, not the tick index.
+    expect(g.text.some((t) => t.str === '50 um')).toBe(true)
+    expect(g.text.some((t) => t.str === '5 um')).toBe(false)
+  })
+
+  it('keeps fractional tick values short', () => {
+    const g = buildCrosshair({
+      at: [50, 40],
+      width: 100,
+      height: 80,
+      gapPx: 0,
+      armPx: 50,
+      showTicks: true,
+      showTickNumbers: true,
+      pxPerUnit: 20,
+      unitsPerTick: 0.25,
+      sizePx: 6,
+    })
+    // Fifth tick = 1.25 units, not 1.2500000000000002.
+    expect(g.text.some((t) => t.str === '1.25')).toBe(true)
+  })
+
+  it('graduates each arm on its own scale when given a pair', () => {
+    const g = buildCrosshair({
+      at: [50, 40],
+      width: 100,
+      height: 80,
+      gapPx: 0,
+      armPx: 20,
+      showTicks: true,
+      // x every 10px, y every 5px: an anisotropic plane.
+      pxPerUnit: [10, 5],
+      tickLength: 4,
+    })
+    // Horizontal arm ticks are vertical strokes at 10px steps.
+    expect(ends(g.lines[2])).toEqual([40, 36, 40, 44])
+    // Vertical arm ticks are horizontal strokes at 5px steps.
+    const first = g.lines.find(
+      (l) => ends(l)[1] === 35 && ends(l)[1] === ends(l)[3],
+    )
+    expect(ends(first)).toEqual([46, 35, 54, 35])
+  })
+
+  it('defaults tick thickness to half the line thickness', () => {
+    const g = buildCrosshair({
+      at: [50, 40],
+      width: 100,
+      height: 80,
+      gapPx: 0,
+      armPx: 20,
+      thickness: 6,
+      showTicks: true,
+      pxPerUnit: 10,
+    })
+    expect(thicknessOf(g.lines[0])).toBe(6)
+    expect(thicknessOf(g.lines[2])).toBe(3)
+    const explicit = buildCrosshair({
+      at: [50, 40],
+      width: 100,
+      height: 80,
+      gapPx: 0,
+      armPx: 20,
+      thickness: 6,
+      tickThickness: 5,
+      showTicks: true,
+      pxPerUnit: 10,
+    })
+    expect(thicknessOf(explicit.lines[2])).toBe(5)
+  })
+})

--- a/packages/uikit/src/crosshair.ts
+++ b/packages/uikit/src/crosshair.ts
@@ -1,0 +1,287 @@
+// The UIKit crosshair widget: a screen-space cross marking one point, with a
+// hole at the centre so the pixel being pointed at is never covered by the lines
+// pointing at it, and optional graduation ticks reading distance outward from
+// that point. `buildCrosshair` is pure -- it turns a spec into plain line + text
+// draw data -- so the geometry is unit-testable and the overlay
+// (crosshairOverlay.ts) just draws it.
+//
+// This exists for hosts that render outside a NiiVue canvas and so get no
+// crosshair from the core renderer: the standalone slide viewer draws a plane of
+// a much larger volume, and without a marker there is no feedback about where a
+// linked 3D pick actually landed in it. The graduations turn that marker into a
+// scale as well, which matters on a pane that spans a 15 um voxel to a 142 mm
+// block in a few wheel turns.
+
+import { buildLine, type LineData } from './line'
+import type { RGBA, Vec2 } from './ruler'
+import type { UIKitTextItem } from './textOverlay'
+
+export interface CrosshairSpec {
+  /** Crosshair centre in screen pixels (the space the overlay draws in). */
+  at: Vec2
+  /** Frame width in the same pixel space (the overlay frame's bounds). */
+  width: number
+  /** Frame height in the same pixel space. */
+  height: number
+  color?: RGBA
+  /** Line thickness in pixels. Default 2. */
+  thickness?: number
+  /**
+   * Radius of the hole left at the centre. Default 6. Set 0 for an unbroken
+   * cross.
+   */
+  gapPx?: number
+  /**
+   * Arm length in pixels, measured outward from the edge of the gap. Omit for
+   * arms that run to the edge of the frame.
+   */
+  armPx?: number
+
+  // --- graduation ---------------------------------------------------------
+
+  /**
+   * Draw graduation ticks along the arms, every unit outward from the centre,
+   * longer (and optionally numbered) every fifth. Needs `pxPerUnit`: without a
+   * scale there is nothing to graduate against and ticks are skipped. Default
+   * false.
+   */
+  showTicks?: boolean
+  /**
+   * Screen pixels per graduation unit. Pass a pair to graduate the horizontal
+   * and vertical arms on their own scales -- these planes can be anisotropic
+   * (a slab that never downsamples one axis), and a single mean would read long
+   * on one arm and short on the other.
+   */
+  pxPerUnit?: number | readonly [number, number]
+  /**
+   * Units between minor ticks. Default 1. Set it when one unit is the wrong
+   * tick spacing at the current scale: a pane that zooms across three decades
+   * wants 100 um ticks at one end and half-micron ticks at the other, and the
+   * numbers then read the distance (`i * unitsPerTick`), not the tick count.
+   */
+  unitsPerTick?: number
+  /** Half-length of a minor tick in pixels. Default 6 (majors are twice that). */
+  tickLength?: number
+  /** Tick thickness in pixels. Default half the line thickness, minimum 1. */
+  tickThickness?: number
+  /** Number the major ticks. Default false. Needs a font on the overlay. */
+  showTickNumbers?: boolean
+  /**
+   * Unit suffix for the graduation numbers, e.g. 'um'. Omit for bare numbers.
+   * Worth setting on a pane whose scale changes with zoom, where a bare "10" is
+   * ambiguous.
+   */
+  units?: string
+  /** Graduation number height in pixels. Default 18. */
+  sizePx?: number
+  /** Number color. Defaults to the line color. */
+  textColor?: RGBA
+  /**
+   * Outline width (px) for the numbers, for readability over busy backgrounds.
+   * Default 2; the outline color auto-contrasts the text color. Set 0 to
+   * disable.
+   */
+  textOutlineWidthPx?: number
+}
+
+export interface CrosshairGeometry {
+  lines: LineData[]
+  text: UIKitTextItem[]
+}
+
+const YELLOW: RGBA = [1, 1, 0, 1]
+const DEFAULT_GAP_PX = 6
+// Cap the ticks emitted per arm so a fine scale on a long arm can't emit
+// thousands of lines.
+const MAX_TICKS = 200
+
+/** Resolve `pxPerUnit` to a positive [x, y] pair, or null when unusable. */
+function unitScale(
+  pxPerUnit: number | readonly [number, number] | undefined,
+): [number, number] | null {
+  if (pxPerUnit === undefined) return null
+  const x = typeof pxPerUnit === 'number' ? pxPerUnit : pxPerUnit[0]
+  const y = typeof pxPerUnit === 'number' ? pxPerUnit : pxPerUnit[1]
+  if (!Number.isFinite(x) || !Number.isFinite(y) || x <= 0 || y <= 0)
+    return null
+  return [x, y]
+}
+
+/**
+ * Thin the ticks to at most MAX_TICKS per arm, in 1/2/5 steps. A round step
+ * matters as much as the cap: majors are every fifth DRAWN tick, so an
+ * arbitrary step (7, say) would leave an arm with no majors and no numbers.
+ */
+function decimation(marks: number): number {
+  if (marks <= MAX_TICKS) return 1
+  const raw = marks / MAX_TICKS
+  const decade = 10 ** Math.floor(Math.log10(raw))
+  for (const m of [1, 2, 5]) {
+    if (m * decade >= raw) return m * decade
+  }
+  return 10 * decade
+}
+
+/** A tick number: whole units read plainly, fractional ones kept short. */
+function formatTickValue(value: number): string {
+  return Number.isInteger(value)
+    ? `${value}`
+    : `${Number(value.toPrecision(3))}`
+}
+
+/**
+ * Build the cross as up to four clipped segments, plus graduation ticks and
+ * numbers when a scale is supplied.
+ *
+ * An axis is drawn only when the centre lies within the frame on the OTHER axis,
+ * so a crosshair panned off the left edge still shows its horizontal line (which
+ * says "the point is on this row, off to the left") but not a stray full-height
+ * vertical line at a column that is not on screen.
+ */
+export function buildCrosshair(spec: CrosshairSpec): CrosshairGeometry {
+  const [cx, cy] = spec.at
+  const {
+    width,
+    height,
+    color = YELLOW,
+    thickness = 2,
+    showTicks = false,
+    tickLength = 6,
+    showTickNumbers = false,
+    units = '',
+    sizePx = 18,
+    textOutlineWidthPx = 2,
+  } = spec
+  const textColor = spec.textColor ?? color
+  const lines: LineData[] = []
+  const text: UIKitTextItem[] = []
+  if (!Number.isFinite(cx) || !Number.isFinite(cy)) return { lines, text }
+  if (!(width > 0) || !(height > 0)) return { lines, text }
+
+  const gapPx = spec.gapPx
+  const gap =
+    gapPx !== undefined && Number.isFinite(gapPx)
+      ? Math.max(0, gapPx)
+      : DEFAULT_GAP_PX
+  const arm = spec.armPx
+  const reach =
+    arm !== undefined && Number.isFinite(arm) && arm > 0
+      ? gap + arm
+      : Number.POSITIVE_INFINITY
+  const tickThickness = Math.max(1, spec.tickThickness ?? thickness / 2)
+  const scale = showTicks ? unitScale(spec.pxPerUnit) : null
+  const perTick = spec.unitsPerTick
+  const unitsPerTick =
+    perTick !== undefined && Number.isFinite(perTick) && perTick > 0
+      ? perTick
+      : 1
+
+  // The horizontal arm lies along x at a fixed y, the vertical along y at a
+  // fixed x. Both are built by the same code, addressed through `axis`.
+  const axes = [
+    { axis: 0, centre: cx, cross: cy, extent: width, crossExtent: height },
+    { axis: 1, centre: cy, cross: cx, extent: height, crossExtent: width },
+  ] as const
+
+  // Emit `[lo, hi]` clipped to the frame, as a segment along `axis`.
+  const segment = (
+    axis: number,
+    cross: number,
+    lo: number,
+    hi: number,
+    extent: number,
+  ): void => {
+    const a = Math.max(0, lo)
+    const b = Math.min(extent, hi)
+    if (b - a <= 0) return
+    lines.push(
+      axis === 0
+        ? buildLine(a, cross, b, cross, thickness, color)
+        : buildLine(cross, a, cross, b, thickness, color),
+    )
+  }
+
+  for (const { axis, centre, cross, extent, crossExtent } of axes) {
+    // The arm is meaningless when its fixed coordinate is off-frame.
+    if (cross < 0 || cross > crossExtent) continue
+    segment(axis, cross, centre - reach, centre - gap, extent)
+    segment(axis, cross, centre + gap, centre + reach, extent)
+    if (!scale) continue
+
+    // Distance between minor ticks, which is one unit only while the caller
+    // leaves `unitsPerTick` alone.
+    const tickPx = scale[axis] * unitsPerTick
+    // Minimum spacing between numbers so they never collide. Along a horizontal
+    // arm that is set by the widest label; stacked down a vertical arm it is set
+    // by the line height whatever the digits.
+    const furthest =
+      Math.floor(Math.max(centre, extent - centre) / tickPx) * unitsPerTick
+    const maxLabel = `${formatTickValue(furthest)}${units ? ` ${units}` : ''}`
+    const minLabelGapPx =
+      axis === 0 ? sizePx * (maxLabel.length * 0.62 + 0.8) : sizePx * 1.6
+
+    for (const dir of [-1, 1] as const) {
+      // How far this arm actually reaches: the shorter of its length and the
+      // frame edge, so ticks are never emitted for arm that was clipped away.
+      const limit = Math.min(reach, dir < 0 ? centre : extent - centre)
+      if (limit <= gap) continue
+      const marks = Math.floor(limit / tickPx)
+      const step = decimation(marks)
+      let lastLabelPx = Number.NEGATIVE_INFINITY
+      for (let i = step; i <= marks; i += step) {
+        const distPx = i * tickPx
+        // Ticks inside the hole would fill the gap back in.
+        if (distPx < gap) continue
+        const pos = centre + dir * distPx
+        const major = i % 5 === 0
+        const half = major ? tickLength * 2 : tickLength
+        // The tick is perpendicular to the arm, so it is clipped against the
+        // OTHER axis' extent.
+        const lo = Math.max(0, cross - half)
+        const hi = Math.min(crossExtent, cross + half)
+        if (hi - lo > 0) {
+          lines.push(
+            axis === 0
+              ? buildLine(pos, lo, pos, hi, tickThickness, color)
+              : buildLine(lo, pos, hi, pos, tickThickness, color),
+          )
+        }
+        if (!major || !showTickNumbers) continue
+        if (distPx - lastLabelPx < minLabelGapPx) continue
+        lastLabelPx = distPx
+        // Numbers read distance FROM the centre, so both arms of an axis carry
+        // the same values. Drawn upright on both axes (a rotated vertical-arm
+        // number would be harder to read than it is compact).
+        const value = formatTickValue(i * unitsPerTick)
+        const str = units ? `${value} ${units}` : value
+        text.push(
+          axis === 0
+            ? {
+                str,
+                x: pos,
+                y: cross,
+                sizePx,
+                align: 0.5,
+                // Below the arm: positive lift is above the line.
+                liftPx: -(half + sizePx * 0.9),
+                color: textColor,
+                outlineWidthPx: textOutlineWidthPx,
+              }
+            : {
+                str,
+                // Right of the arm, left-aligned off the end of the tick.
+                x: cross + half + sizePx * 0.4,
+                y: pos,
+                sizePx,
+                align: 0,
+                // Lower the baseline so the glyphs straddle the tick.
+                liftPx: -sizePx * 0.35,
+                color: textColor,
+                outlineWidthPx: textOutlineWidthPx,
+              },
+        )
+      }
+    }
+  }
+  return { lines, text }
+}

--- a/packages/uikit/src/crosshairOverlay.ts
+++ b/packages/uikit/src/crosshairOverlay.ts
@@ -1,0 +1,66 @@
+// A UIKit overlay that draws a crosshair (buildCrosshair) through the niivue
+// overlay hook. Set a position each time the tracked point moves and it redraws
+// on the live backend, on a NiiVue canvas (`nv.registerOverlayRenderer`) or on a
+// standalone slide pane (`renderer.overlayDraw`) alike.
+//
+// The spec is supplied WITHOUT the frame extent: the overlay fills that in from
+// the frame it is handed, so a host that resizes its canvas does not have to
+// re-set the crosshair to keep the arms reaching the new edges.
+
+import type { UIKitOverlayFrame, UIKitOverlayRenderer } from '@niivue/niivue'
+import { buildCrosshair, type CrosshairSpec } from './crosshair'
+import { UIKitLineOverlay } from './lineOverlay'
+import type { UIKitFont } from './text/font'
+import { UIKitTextOverlay } from './textOverlay'
+
+export type CrosshairPlacement = Omit<CrosshairSpec, 'width' | 'height'>
+
+export class UIKitCrosshairOverlay implements UIKitOverlayRenderer {
+  private readonly lines = new UIKitLineOverlay()
+  // Graduation numbers need a font. Without one the widget still draws the cross
+  // and its ticks, so a host that never numbers them pays for no atlas.
+  private readonly labels: UIKitTextOverlay | null
+  private placement: CrosshairPlacement | null = null
+  // Extent the current geometry was built for. The arms are clipped to the frame
+  // and the ticks stop at its edges, so a resize has to rebuild them.
+  private builtFor: [number, number] = [0, 0]
+
+  constructor(font?: UIKitFont, placement?: CrosshairPlacement) {
+    this.labels = font ? new UIKitTextOverlay(font) : null
+    if (placement) this.setCrosshair(placement)
+  }
+
+  /** Set (or move) the crosshair. Trigger a redraw via the host. */
+  setCrosshair(placement: CrosshairPlacement): void {
+    this.placement = placement
+    this.builtFor = [0, 0]
+  }
+
+  /** Clear the crosshair so nothing draws. */
+  clear(): void {
+    this.placement = null
+    this.builtFor = [0, 0]
+    this.lines.setLines([])
+    this.labels?.setItems([])
+  }
+
+  drawOverlay(frame: UIKitOverlayFrame): void {
+    const placement = this.placement
+    if (!placement) return
+    const { width, height } = frame.bounds
+    if (width !== this.builtFor[0] || height !== this.builtFor[1]) {
+      const geo = buildCrosshair({ ...placement, width, height })
+      this.lines.setLines(geo.lines)
+      this.labels?.setItems(geo.text)
+      this.builtFor = [width, height]
+    }
+    this.lines.drawOverlay(frame)
+    this.labels?.drawOverlay(frame)
+  }
+
+  /** Release GPU resources on both backends. */
+  destroy(): void {
+    this.lines.destroy()
+    this.labels?.destroy()
+  }
+}

--- a/packages/uikit/src/index.ts
+++ b/packages/uikit/src/index.ts
@@ -1,7 +1,7 @@
 // @niivue/uikit public entry. UIKit is a collection of controls/widgets that
-// integrate into NiiVue's rendering lifecycle. This is the base module; the
-// lifecycle hook, the line/text renderers, and the ruler widget land next (see
-// docs/ruler-port.md in @niivue/niivue).
+// integrate into NiiVue's rendering lifecycle. Each widget is a pure geometry
+// builder plus an overlay that owns the GPU resources and draws it (see
+// docs/ruler-port.md in @niivue/niivue for the design).
 
 // biome-ignore-all lint/performance/noBarrelFile: package entry point
 export type { AnnotationGeometryOptions } from './annotationOverlay'
@@ -9,6 +9,10 @@ export {
   buildAnnotationGeometry,
   UIKitAnnotationOverlay,
 } from './annotationOverlay'
+export type { CrosshairGeometry, CrosshairSpec } from './crosshair'
+export { buildCrosshair } from './crosshair'
+export type { CrosshairPlacement } from './crosshairOverlay'
+export { UIKitCrosshairOverlay } from './crosshairOverlay'
 export type { LineData, LineTerminators } from './line'
 export { buildLine, buildTerminatedLine, LineTerminator } from './line'
 export { UIKitLineOverlay } from './lineOverlay'


### PR DESCRIPTION
Two fixes for the DANDI demo that both turned out to belong upstream of it, plus
the demo wiring that uses them.

## 1. Window streamed volumes from the coarse floor (`niivue`)

A streamed volume had no display window of its own. `createStreamingNVImage`
stamps the caller's window (or a fixed default) onto the synthesized header
before a voxel has been read, and `calMinMax` honours a header window whenever
it finds one, so the placeholder survived and every store rendered against it.
That is right for a NIfTI whose author wrote the window, and wrong here: these
stores range from 1e-4 float reflectivity (OCT) to raw uint16 photon counts
(SPIM), and no fixed default fits both.

`NVChunkedVolume` already builds a coarse floor covering the whole volume, so
there is a representative sample in hand and no probe fetch is needed. It now
derives a 2%-98% window from that floor and applies it, unless the caller passed
`calMin`/`calMax` explicitly, which is taken as "I know this store".

New `robustDisplayWindow` neutralizes the header window so the histogram path
always runs. It also fixes the percentile population: non-finite voxels were
skipped by `robustRange` but still counted in the denominator, so a store that
is 80% NaN padding, as several DANDI float OCT volumes are, asked for 2%-98% and
got roughly 10%-90%.

## 2. A crosshair widget with optional graduations (`uikit`)

A screen-space cross marking one point, with a hole at the centre so the pixel
being pointed at is never covered by the lines pointing at it. `buildCrosshair`
is pure geometry (spec in, line + text draw data out), so it unit-tests without
a GPU, and `UIKitCrosshairOverlay` draws it through the same lifecycle hook the
ruler uses.

This exists for hosts that render outside a NiiVue canvas and so get no
crosshair from the core renderer. The standalone slide viewer draws one plane of
a much larger volume, and without a marker there is no feedback about where a
linked 3D pick landed in it.

The arms optionally carry graduation ticks, which turns the marker into a scale
as well:

| Option | Default | Effect |
| --- | --- | --- |
| `thickness` | 2 | Arm line thickness in px |
| `gapPx` | 6 | Hole at the centre. 0 draws an unbroken cross |
| `armPx` | edge of frame | Finite arm length instead of full-frame |
| `color`, `textColor` | yellow | |
| `showTicks` | false | Graduate the arms. Needs `pxPerUnit` |
| `pxPerUnit` | - | Screen px per data unit, scalar or per-axis pair |
| `unitsPerTick` | 1 | Distance between minor ticks |
| `tickLength` | 6 | Minor half-length. Majors (every 5th) are twice that |
| `tickThickness` | half `thickness`, min 1 | |
| `showTickNumbers` | false | Number the majors. Needs a font on the overlay |
| `units` | - | Suffix on every number, e.g. `um` |
| `sizePx`, `textOutlineWidthPx` | 18, 2 | Number height and readability outline |

Four of those are worth a word on why they are shaped the way they are:

- `pxPerUnit` takes a per-axis pair. These planes can be anisotropic (a slab
  that never downsamples one axis), where a single mean reads long on one arm
  and short on the other.
- `unitsPerTick` separates tick spacing from the unit, so a pane that zooms
  across three decades can graduate in 100 um steps at one end and half-micron
  steps at the other. Numbers then read the distance from the centre, not the
  tick index.
- Decimation of a fine scale on a long arm is restricted to 1/2/5 steps. The cap
  alone is not enough: majors are every fifth DRAWN tick, so an arbitrary step
  would leave an arm with no majors and so no numbers at all.
- `tickThickness` defaults to half the line thickness rather than a hardcoded 1,
  which is hairline on a hidpi pane.

Numbers that would collide are dropped while their ticks stay.

## 3. Demo wiring (`dandi-demo`)

The deep-zoom pane now mirrors the volume crosshair, composed onto the same
`overlayDraw` hook as the ruler (the renderer exposes one slot, so the pane fans
it) and sharing one font fetch with it. A Crosshair control picks plain,
graduated, graduated + numbers, or off.

The graduation is computed per frame from `pixelSpacingMM` and the viewport
scale: a 1/2/5 nice step targeting ~22 device pixels per minor tick, in
micrometres until a tick is worth a whole millimetre. `pxPerUnit` is passed per
axis, so a tick means the same distance on both arms of an anisotropic plane.

The marker is held in RAS voxels rather than slide pixels, for the same reason
the ruler is held in base pixels: a level swap must not move it. The demo's own
window probe is gone, replaced by reading the window back off the volume.

## Testing

`lint`, `typecheck`, `build` across `niivue`, `uikit`, `dandi-demo`;
`niivue:test` (1345) and `uikit:test` (53, 13 of them on the crosshair) forced
past the Nx cache; codespell clean over both packages.

Browser-verified on the dev server, both backends:

- WebGL2, `oct-small`: all four crosshair modes, and live step adaptation across
  zoom (4.36x gives 500 um majors, 9.08x gives 250 um, 16.08x gives 100 um).
- WebGL2, `neun` 30 GB slab zoomed out: the millimetre branch, 10 mm majors on
  both arms.
- Coronal (xz) plane of that slab, 10915 x 207 voxels: both arms land at the
  same physical scale on screen, which is the per-axis `pxPerUnit` pair working.
- WebGPU: identical output, all four modes.

Draft while CI runs.

Generated with [Claude Code](https://claude.com/claude-code)
