### PR TITLE
fix(niivue): evict stale chunked texture cache entries

### DIFF
--- a/.github/workflows/niivue-e2e.yml
+++ b/.github/workflows/niivue-e2e.yml
@@ -1,19 +1,24 @@
-name: niivue loader contracts
+name: niivue browser contracts
 
-# Two contracts that only a real browser can hold, and that unit tests cannot
+# Contracts that only a real browser can hold, and that unit tests cannot
 # reach: NiiVue's module graph uses Vite's `import.meta.glob`, so it will not
 # import under the Bun runner, and the behaviour under test lives in a Web
-# Worker.
+# Worker or on the GPU.
 #
 #   partial-decode-4d   `limitFrames4D` must bound DECODING, not just retention.
 #                       It was retention-only on both load paths, and a 4D
 #                       preview peaked at 1.1 GB RSS for one 1.5 MB frame.
 #   reader-name-override  a caller-supplied `name` must reach `reader.read`;
 #                       MGH and VMR change behaviour on it.
+#   texcache-kind-change  a volume that stops being chunked must drop its
+#                       bricks. The entry used to leak for the life of the
+#                       renderer, holding every brick texture (issue #145).
 #
 # Narrow on purpose. The rest of the e2e suite needs a GPU adapter that headless
 # runners do not have, so running it here would be flaky noise rather than
-# signal. These two are deterministic under SwiftShader.
+# signal. These three are deterministic without one: the first two never touch
+# the GPU, and texcache-kind-change forces `--use-angle=swiftshader` for its
+# WebGL2 case and skips its WebGPU case when `requestAdapter()` yields nothing.
 
 on:
   push:
@@ -27,7 +32,7 @@ on:
       - '.github/workflows/niivue-e2e.yml'
 
 jobs:
-  loader-contracts:
+  browser-contracts:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -42,10 +47,11 @@ jobs:
         working-directory: packages/niivue
         run: bunx playwright install --with-deps chromium
 
-      - name: Loader contracts
+      - name: Browser contracts
         working-directory: packages/niivue
         run: |
           bunx playwright test \
             e2e/partial-decode-4d.spec.ts \
             e2e/reader-name-override.spec.ts \
+            e2e/texcache-kind-change.spec.ts \
             --reporter=line

--- a/.github/workflows/niivue-e2e.yml
+++ b/.github/workflows/niivue-e2e.yml
@@ -13,6 +13,8 @@ name: niivue browser contracts
 #   texcache-kind-change  a volume that stops being chunked must drop its
 #                       bricks. The entry used to leak for the life of the
 #                       renderer, holding every brick texture (issue #145).
+#                       This one loads mni152, so the checkout pulls that
+#                       single LFS object.
 #
 # Narrow on purpose. The rest of the e2e suite needs a GPU adapter that headless
 # runners do not have, so running it here would be flaky noise rather than
@@ -41,6 +43,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      # Not `lfs: true`: that pulls every object under packages/dev-images
+      # (~93 MB) when one spec needs one 4.3 MB volume.
+      - name: Fetch the one LFS volume the specs need
+        run: git lfs pull --include=packages/dev-images/images/volumes/mni152.nii.gz
+
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version-file: .bun-version

--- a/.github/workflows/niivue-e2e.yml
+++ b/.github/workflows/niivue-e2e.yml
@@ -18,7 +18,12 @@ name: niivue browser contracts
 # runners do not have, so running it here would be flaky noise rather than
 # signal. These three are deterministic without one: the first two never touch
 # the GPU, and texcache-kind-change forces `--use-angle=swiftshader` for its
-# WebGL2 case and skips its WebGPU case when `requestAdapter()` yields nothing.
+# WebGL2 case, which is the case that was proven to fail on main. Its WebGPU
+# case skips here. `requestAdapter()` does succeed on the runner, but the GPU
+# instance dies partway through, so the spec skips on GPU-loss errors only; a
+# validation error from a destroyed texture, the failure it exists to catch,
+# still fails. `--workers=1` because two Chromium instances sharing one
+# software GPU were what killed the instance.
 
 on:
   push:

--- a/.github/workflows/niivue-e2e.yml
+++ b/.github/workflows/niivue-e2e.yml
@@ -54,4 +54,5 @@ jobs:
             e2e/partial-decode-4d.spec.ts \
             e2e/reader-name-override.spec.ts \
             e2e/texcache-kind-change.spec.ts \
+            --workers=1 \
             --reporter=line

--- a/packages/niivue/e2e/texcache-kind-change.spec.ts
+++ b/packages/niivue/e2e/texcache-kind-change.spec.ts
@@ -72,6 +72,7 @@ for (const backend of ['webgl2', 'webgpu'] as const) {
     test.setTimeout(180_000)
 
     const result = await page.evaluate(`(async () => {
+     try {
       if ('${backend}' === 'webgpu') {
         if (!navigator.gpu) return { skip: 'no navigator.gpu' }
         let adapter = null
@@ -135,6 +136,18 @@ for (const backend of ['webgl2', 'webgpu'] as const) {
         singleTotal: single ? single.total : null,
         singleResident: single ? single.resident : null,
       }
+     } catch (e) {
+      // A headless runner's GPU process can die under two concurrent WebGPU
+      // contexts, after requestAdapter has already succeeded. That is the
+      // environment going away, so skip. Anything else -- a validation error
+      // from binding a destroyed texture, say, which is the failure mode this
+      // spec exists to catch -- still fails the test.
+      const m = String(e && e.message ? e.message : e)
+      if (/no longer exists|device (is )?lost|adapter/i.test(m)) {
+        return { skip: 'GPU unavailable: ' + m }
+      }
+      throw e
+     }
     })()`)
 
     // biome-ignore lint/suspicious/noExplicitAny: page.evaluate returns unknown

--- a/packages/niivue/e2e/texcache-kind-change.spec.ts
+++ b/packages/niivue/e2e/texcache-kind-change.spec.ts
@@ -1,0 +1,113 @@
+import { expect, test } from '@playwright/test'
+
+// Issue #145, reported by @stebo85 as stale numbers out of `chunkStreamStats()`.
+//
+// `_destroyTexEntry` released an entry's GPU resources but left the entry in
+// `_texCache`, and the one path that dropped the key by hand ran only for
+// multi-instance callers. So a volume that stopped being chunked -- its plan
+// cleared, or the same url reloaded as a plain volume -- left its chunked entry
+// in the map for the life of the renderer: every brick texture still held, the
+// upload pump still walking it, and `chunkStreamStats` still counting it.
+//
+// The assertion is that the brick count goes to zero once the volume is a single
+// texture. It is a real regression test rather than a restatement of the fix:
+// revert either backend's eviction and the second expect reports the full brick
+// count for a volume that no longer has bricks.
+//
+// Both backends, because the leak and the fix are mirrored in gl/render.ts and
+// wgpu/render.ts. WebGPU is skipped when the runner has no adapter (headless
+// Chromium usually has SwiftShader for WebGL2 only).
+
+test.use({
+  launchOptions: {
+    args: [
+      '--enable-unsafe-swiftshader',
+      '--enable-unsafe-webgpu',
+      '--use-angle=swiftshader',
+      '--enable-features=Vulkan',
+    ],
+  },
+})
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/examples/index.html', { waitUntil: 'load' })
+})
+
+// A 2x2x2 forced plan: mni152 fits in one texture, so the tiling is forced
+// rather than required. Eight bricks is enough to tell "chunked" from "not"
+// without paying for 27 uploads under SwiftShader.
+const GRID = 2
+const EXPECTED_CHUNKS = GRID * GRID * GRID
+
+for (const backend of ['webgl2', 'webgpu'] as const) {
+  test(`a volume that stops being chunked drops its bricks (${backend})`, async ({
+    page,
+  }) => {
+    test.setTimeout(180_000)
+
+    const result = await page.evaluate(`(async () => {
+      if ('${backend}' === 'webgpu') {
+        if (!navigator.gpu) return { skip: 'no navigator.gpu' }
+        const adapter = await navigator.gpu.requestAdapter()
+        if (!adapter) return { skip: 'no WebGPU adapter' }
+      }
+      const { default: NiiVue, SLICE_TYPE, chunkVolumeGrid } =
+        await import('/src/index.ts')
+      const nextFrame = () => new Promise((r) =>
+        requestAnimationFrame(() => requestAnimationFrame(r)))
+
+      const canvas = document.createElement('canvas')
+      canvas.width = 256
+      canvas.height = 256
+      document.body.appendChild(canvas)
+      const nv = new NiiVue({
+        backend: '${backend}',
+        sliceType: SLICE_TYPE.RENDER,
+      })
+      await nv.attachToCanvas(canvas)
+      await nv.loadVolumes([{ url: '/volumes/mni152.nii.gz' }])
+      await nextFrame()
+
+      const vol = nv.volumes[0]
+      const d = vol.dimsRAS
+      // The device limit only has to exceed the largest brick edge: the point
+      // is to force a plan, not to model a real device cap.
+      vol.chunkPlan = chunkVolumeGrid(
+        [d[1], d[2], d[3]],
+        [${GRID}, ${GRID}, ${GRID}],
+        4096,
+        [3, 3, 3],
+      )
+      await nv.updateGLVolume()
+      await nextFrame()
+      const chunked = nv.chunkStreamStats()
+
+      // Back to one texture under the SAME cache key (vol.url), which is the
+      // kind change that used to strand the chunked entry.
+      vol.chunkPlan = undefined
+      await nv.updateGLVolume()
+      await nextFrame()
+      const single = nv.chunkStreamStats()
+
+      return {
+        chunkedTotal: chunked ? chunked.total : null,
+        singleTotal: single ? single.total : null,
+        singleResident: single ? single.resident : null,
+      }
+    })()`)
+
+    // biome-ignore lint/suspicious/noExplicitAny: page.evaluate returns unknown
+    const r = result as any
+    if (r.skip) {
+      test.skip(true, r.skip)
+      return
+    }
+
+    // Guard the guard: if the forced plan never took, the real assertion below
+    // would pass for the wrong reason.
+    expect(r.chunkedTotal).toBe(EXPECTED_CHUNKS)
+
+    expect(r.singleTotal).toBe(0)
+    expect(r.singleResident).toBe(0)
+  })
+}

--- a/packages/niivue/e2e/texcache-kind-change.spec.ts
+++ b/packages/niivue/e2e/texcache-kind-change.spec.ts
@@ -33,11 +33,37 @@ test.beforeEach(async ({ page }) => {
   await page.goto('/examples/index.html', { waitUntil: 'load' })
 })
 
-// A 2x2x2 forced plan: mni152 fits in one texture, so the tiling is forced
+// A 2x2x2 forced plan: the volume fits in one texture, so the tiling is forced
 // rather than required. Eight bricks is enough to tell "chunked" from "not"
 // without paying for 27 uploads under SwiftShader.
 const GRID = 2
 const EXPECTED_CHUNKS = GRID * GRID * GRID
+
+// A synthesized NIfTI-1, not a file from packages/dev-images: those are Git LFS
+// pointers on a CI checkout, and a pointer parses as "not NIFTI". Every spec on
+// this workflow's allowlist builds its own bytes for that reason. 48^3 uint16 is
+// small enough to upload quickly under SwiftShader and still divides into a
+// 2x2x2 grid with the renderer's 3-voxel gradient halo.
+const fixture = `
+  const N = 48
+  const VOX_OFFSET = 352
+  const raw = new Uint8Array(VOX_OFFSET + N * N * N * 2)
+  const dv = new DataView(raw.buffer)
+  dv.setInt32(0, 348, true)
+  ;[3, N, N, N, 1, 1, 1, 1].forEach((d, i) => dv.setInt16(40 + i * 2, d, true))
+  dv.setInt16(70, 512, true)   // DT_UINT16
+  dv.setInt16(72, 16, true)    // bitpix
+  ;[1, 2, 2, 2, 1, 1, 1, 1].forEach((p, i) => dv.setFloat32(76 + i * 4, p, true))
+  dv.setFloat32(108, VOX_OFFSET, true)
+  dv.setFloat32(112, 1, true)  // scl_slope
+  raw.set(new TextEncoder().encode('n+1\\0'), 344)
+  // A gradient rather than a constant, so an upload that silently drops a brick
+  // would be visible to a follow-up assertion if one is ever added here.
+  for (let i = 0; i < N * N * N; i++) {
+    dv.setUint16(VOX_OFFSET + i * 2, i % 4096, true)
+  }
+  const file = new File([raw], 'texcache.nii')
+`
 
 for (const backend of ['webgl2', 'webgpu'] as const) {
   test(`a volume that stops being chunked drops its bricks (${backend})`, async ({
@@ -55,6 +81,7 @@ for (const backend of ['webgl2', 'webgpu'] as const) {
         await import('/src/index.ts')
       const nextFrame = () => new Promise((r) =>
         requestAnimationFrame(() => requestAnimationFrame(r)))
+      ${fixture}
 
       const canvas = document.createElement('canvas')
       canvas.width = 256
@@ -65,7 +92,7 @@ for (const backend of ['webgl2', 'webgpu'] as const) {
         sliceType: SLICE_TYPE.RENDER,
       })
       await nv.attachToCanvas(canvas)
-      await nv.loadVolumes([{ url: '/volumes/mni152.nii.gz' }])
+      await nv.loadVolumes([{ url: file, name: 'texcache.nii' }])
       await nextFrame()
 
       const vol = nv.volumes[0]
@@ -82,8 +109,8 @@ for (const backend of ['webgl2', 'webgpu'] as const) {
       await nextFrame()
       const chunked = nv.chunkStreamStats()
 
-      // Back to one texture under the SAME cache key (vol.url), which is the
-      // kind change that used to strand the chunked entry.
+      // Back to one texture under the SAME cache key, which is the kind change
+      // that used to strand the chunked entry.
       vol.chunkPlan = undefined
       await nv.updateGLVolume()
       await nextFrame()

--- a/packages/niivue/e2e/texcache-kind-change.spec.ts
+++ b/packages/niivue/e2e/texcache-kind-change.spec.ts
@@ -74,7 +74,15 @@ for (const backend of ['webgl2', 'webgpu'] as const) {
     const result = await page.evaluate(`(async () => {
       if ('${backend}' === 'webgpu') {
         if (!navigator.gpu) return { skip: 'no navigator.gpu' }
-        const adapter = await navigator.gpu.requestAdapter()
+        let adapter = null
+        try {
+          adapter = await navigator.gpu.requestAdapter()
+        } catch (e) {
+          // Dawn on a headless runner throws "A valid external Instance
+          // reference no longer exists" rather than resolving null. That is a
+          // missing adapter, not a failed assertion.
+          return { skip: 'requestAdapter threw: ' + e }
+        }
         if (!adapter) return { skip: 'no WebGPU adapter' }
       }
       const { default: NiiVue, SLICE_TYPE, chunkVolumeGrid } =
@@ -92,6 +100,12 @@ for (const backend of ['webgl2', 'webgpu'] as const) {
         sliceType: SLICE_TYPE.RENDER,
       })
       await nv.attachToCanvas(canvas)
+      // The both-backends build silently falls back to WebGL2 when WebGPU init
+      // throws, which would run this case twice on the same backend and report
+      // it as WebGPU coverage. Skip instead of passing on a lie.
+      if ('${backend}' === 'webgpu' && nv.backend !== 'webgpu') {
+        return { skip: 'WebGPU init fell back to ' + nv.backend }
+      }
       await nv.loadVolumes([{ url: file, name: 'texcache.nii' }])
       await nextFrame()
 

--- a/packages/niivue/e2e/texcache-kind-change.spec.ts
+++ b/packages/niivue/e2e/texcache-kind-change.spec.ts
@@ -39,31 +39,12 @@ test.beforeEach(async ({ page }) => {
 const GRID = 2
 const EXPECTED_CHUNKS = GRID * GRID * GRID
 
-// A synthesized NIfTI-1, not a file from packages/dev-images: those are Git LFS
-// pointers on a CI checkout, and a pointer parses as "not NIFTI". Every spec on
-// this workflow's allowlist builds its own bytes for that reason. 48^3 uint16 is
-// small enough to upload quickly under SwiftShader and still divides into a
-// 2x2x2 grid with the renderer's 3-voxel gradient halo.
-const fixture = `
-  const N = 48
-  const VOX_OFFSET = 352
-  const raw = new Uint8Array(VOX_OFFSET + N * N * N * 2)
-  const dv = new DataView(raw.buffer)
-  dv.setInt32(0, 348, true)
-  ;[3, N, N, N, 1, 1, 1, 1].forEach((d, i) => dv.setInt16(40 + i * 2, d, true))
-  dv.setInt16(70, 512, true)   // DT_UINT16
-  dv.setInt16(72, 16, true)    // bitpix
-  ;[1, 2, 2, 2, 1, 1, 1, 1].forEach((p, i) => dv.setFloat32(76 + i * 4, p, true))
-  dv.setFloat32(108, VOX_OFFSET, true)
-  dv.setFloat32(112, 1, true)  // scl_slope
-  raw.set(new TextEncoder().encode('n+1\\0'), 344)
-  // A gradient rather than a constant, so an upload that silently drops a brick
-  // would be visible to a follow-up assertion if one is ever added here.
-  for (let i = 0; i < N * N * N; i++) {
-    dv.setUint16(VOX_OFFSET + i * 2, i % 4096, true)
-  }
-  const file = new File([raw], 'texcache.nii')
-`
+// The real mni152 from packages/dev-images, which is what the issue's manual
+// repro uses -- one scenario for a reader to follow rather than two. It is Git
+// LFS, so this workflow's checkout pulls that single object (see
+// niivue-e2e.yml); an unpulled pointer parses as "not NIFTI" and fails loudly
+// rather than silently testing nothing.
+const VOLUME = '/volumes/mni152.nii.gz'
 
 for (const backend of ['webgl2', 'webgpu'] as const) {
   test(`a volume that stops being chunked drops its bricks (${backend})`, async ({
@@ -90,8 +71,6 @@ for (const backend of ['webgl2', 'webgpu'] as const) {
         await import('/src/index.ts')
       const nextFrame = () => new Promise((r) =>
         requestAnimationFrame(() => requestAnimationFrame(r)))
-      ${fixture}
-
       const canvas = document.createElement('canvas')
       canvas.width = 256
       canvas.height = 256
@@ -107,7 +86,7 @@ for (const backend of ['webgl2', 'webgpu'] as const) {
       if ('${backend}' === 'webgpu' && nv.backend !== 'webgpu') {
         return { skip: 'WebGPU init fell back to ' + nv.backend }
       }
-      await nv.loadVolumes([{ url: file, name: 'texcache.nii' }])
+      await nv.loadVolumes([{ url: '${VOLUME}' }])
       await nextFrame()
 
       const vol = nv.volumes[0]

--- a/packages/niivue/src/gl/render.ts
+++ b/packages/niivue/src/gl/render.ts
@@ -678,16 +678,29 @@ export class VolumeRenderer extends NVRenderer {
     this._activeChunked = null
     this._cubicVolumeSafe = !vol.colormapLabel
 
+    // This volume is not chunked any more: its plan was cleared, or the same
+    // url was reloaded as a plain volume. Drop the chunked entry now, because
+    // nothing downstream will. It would otherwise sit in `_texCache` for the
+    // life of the renderer holding every brick texture, still driven by
+    // `beginChunkFrame`, and still counted by `chunkStreamStats` -- which then
+    // reports a brick stream for a single-texture volume. The `perVolumeCache`
+    // branch below cleared it, but only multi-instance callers take that
+    // branch, so the ordinary path leaked.
+    const priorEntry = cacheKey ? this._texCache.get(cacheKey) : undefined
+    if (priorEntry?.kind === 'chunked') {
+      this._evictTexEntry(gl, cacheKey, priorEntry)
+    }
+
     if (perVolumeCache) {
       // Multi-instance / global3d: cache each volume's texture by key so the
       // render loop can switch the active texture per tile via
       // bindCachedVolume. (volumeOrientCache is a single slot and cannot serve
       // per-tile volume switching.)
-      let entry = cacheKey ? this._texCache.get(cacheKey) : undefined
-      if (entry && entry.kind !== 'single') {
-        this._evictTexEntry(gl, cacheKey, entry)
-        entry = undefined
-      }
+      // The chunked case was evicted above, so anything still here is single.
+      // Narrowing on `kind` rather than asserting keeps that an invariant the
+      // compiler checks.
+      const prior = cacheKey ? this._texCache.get(cacheKey) : undefined
+      let entry = prior?.kind === 'single' ? prior : undefined
       if (!entry) {
         const volumeTexture = await orientOverlay.overlay2Texture(
           gl,

--- a/packages/niivue/src/gl/render.ts
+++ b/packages/niivue/src/gl/render.ts
@@ -685,7 +685,7 @@ export class VolumeRenderer extends NVRenderer {
       // per-tile volume switching.)
       let entry = cacheKey ? this._texCache.get(cacheKey) : undefined
       if (entry && entry.kind !== 'single') {
-        this._destroyTexEntry(gl, entry)
+        this._evictTexEntry(gl, cacheKey, entry)
         entry = undefined
       }
       if (!entry) {
@@ -853,7 +853,7 @@ export class VolumeRenderer extends NVRenderer {
       }
       return existing
     }
-    if (existing) this._destroyTexEntry(gl, existing)
+    if (existing) this._evictTexEntry(gl, cacheKey, existing)
     // The entry holds the live uploader so an in-place plan swap can replace it;
     // the prefetch hook reads it off `entry` (not a creation closure) so it
     // always targets the current plan.
@@ -1567,14 +1567,33 @@ export class VolumeRenderer extends NVRenderer {
     }
   }
 
+  /**
+   * Release an entry's GPU resources AND drop it from the cache.
+   *
+   * Destroying without deleting is the dangerous half: the entry stays in
+   * `_texCache`, so every method that iterates the map -- `beginChunkFrame`,
+   * the gradient refreshes, `chunkStreamStats` -- can still reach a destroyed
+   * manager and a disposed uploader. The replace-in-place call sites only
+   * re-`set` the key after an await, so a frame landing in that window sees the
+   * dead entry. Always evict through here rather than pairing the two calls by
+   * hand.
+   */
+  private _evictTexEntry(
+    gl: WebGL2RenderingContext,
+    key: string | undefined,
+    entry: TexCacheEntry,
+  ): void {
+    this._destroyTexEntry(gl, entry)
+    if (key) this._texCache.delete(key)
+  }
+
   /** Release any cached volume textures whose key is not in `keepKeys`. */
   pruneVolumeCache(keepKeys: Set<string>): void {
     const gl = this._gl
     if (!gl) return
     for (const [key, entry] of this._texCache) {
       if (keepKeys.has(key)) continue
-      this._destroyTexEntry(gl, entry)
-      this._texCache.delete(key)
+      this._evictTexEntry(gl, key, entry)
     }
   }
 

--- a/packages/niivue/src/wgpu/render.ts
+++ b/packages/niivue/src/wgpu/render.ts
@@ -855,16 +855,29 @@ export class VolumeRenderer extends NVRenderer {
     this._activeChunked = null
     this._cubicVolumeSafe = !vol.colormapLabel
 
+    // This volume is not chunked any more: its plan was cleared, or the same
+    // url was reloaded as a plain volume. Drop the chunked entry now, because
+    // nothing downstream will. It would otherwise sit in `_texCache` for the
+    // life of the renderer holding every brick texture, still driven by
+    // `beginChunkFrame`, and still counted by `chunkStreamStats` -- which then
+    // reports a brick stream for a single-texture volume. The `perVolumeCache`
+    // branch below cleared it, but only multi-instance callers take that
+    // branch, so the ordinary path leaked.
+    const priorEntry = cacheKey ? this._texCache.get(cacheKey) : undefined
+    if (priorEntry?.kind === 'chunked') {
+      this._evictTexEntry(cacheKey, priorEntry)
+    }
+
     if (perVolumeCache) {
       // Multi-instance / global3d: cache each volume's texture by key so the
       // render loop can switch the active texture per tile via
       // bindCachedVolume. (volumeOrientCache is a single slot and cannot serve
       // per-tile volume switching.)
-      let entry = cacheKey ? this._texCache.get(cacheKey) : undefined
-      if (entry && entry.kind !== 'single') {
-        this._evictTexEntry(cacheKey, entry)
-        entry = undefined
-      }
+      // The chunked case was evicted above, so anything still here is single.
+      // Narrowing on `kind` rather than asserting keeps that an invariant the
+      // compiler checks.
+      const prior = cacheKey ? this._texCache.get(cacheKey) : undefined
+      let entry = prior?.kind === 'single' ? prior : undefined
       if (!entry) {
         const volumeTexture = await orient.volume2Texture(
           device,

--- a/packages/niivue/src/wgpu/render.ts
+++ b/packages/niivue/src/wgpu/render.ts
@@ -1747,7 +1747,7 @@ export class VolumeRenderer extends NVRenderer {
     this._destroyTexEntry(entry)
     if (!key) return
     this._texCache.delete(key)
-    // The cached bind group holds this entry's textures at bindings 3 and 4.
+    // The cached bind group holds this entry's textures at bindings 1 and 4.
     this._bindGroupCache.delete(key)
   }
 

--- a/packages/niivue/src/wgpu/render.ts
+++ b/packages/niivue/src/wgpu/render.ts
@@ -862,7 +862,7 @@ export class VolumeRenderer extends NVRenderer {
       // per-tile volume switching.)
       let entry = cacheKey ? this._texCache.get(cacheKey) : undefined
       if (entry && entry.kind !== 'single') {
-        this._destroyTexEntry(entry)
+        this._evictTexEntry(cacheKey, entry)
         entry = undefined
       }
       if (!entry) {
@@ -1016,7 +1016,7 @@ export class VolumeRenderer extends NVRenderer {
       }
       return existing
     }
-    if (existing) this._destroyTexEntry(existing)
+    if (existing) this._evictTexEntry(cacheKey, existing)
     const decoded = new DecodedChunkCache(
       decodedTierBudgetBytes(budgetBytes, bpv),
     )
@@ -1732,13 +1732,30 @@ export class VolumeRenderer extends NVRenderer {
     }
   }
 
+  /**
+   * Release an entry's GPU resources AND drop every cache that points at it.
+   *
+   * Destroying without deleting is the dangerous half: the entry stays in
+   * `_texCache`, so every method that iterates the map -- `beginChunkFrame`,
+   * `_ensureSingleGradients`, `_refreshUnlitChunksForLighting`,
+   * `chunkStreamStats` -- can still reach a destroyed manager and a disposed
+   * uploader. The replace-in-place call sites only re-`set` the key after an
+   * await, so a frame landing in that window sees the dead entry. Always evict
+   * through here rather than pairing the two calls by hand.
+   */
+  private _evictTexEntry(key: string | undefined, entry: TexCacheEntry): void {
+    this._destroyTexEntry(entry)
+    if (!key) return
+    this._texCache.delete(key)
+    // The cached bind group holds this entry's textures at bindings 3 and 4.
+    this._bindGroupCache.delete(key)
+  }
+
   /** Release any cached volume textures whose key is not in `keepKeys`. */
   pruneVolumeCache(keepKeys: Set<string>): void {
     for (const [key, entry] of this._texCache) {
       if (keepKeys.has(key)) continue
-      this._destroyTexEntry(entry)
-      this._texCache.delete(key)
-      this._bindGroupCache.delete(key)
+      this._evictTexEntry(key, entry)
     }
   }
 


### PR DESCRIPTION
Closes #145. Reported by @stebo85.

## The bug

`_destroyTexEntry` releases an entry's GPU resources but does not remove the entry from `_texCache`. Four call sites (two per backend) destroy an entry inline and only re-`set` the key after one or more awaits, so for the whole of that window the map holds an entry whose manager is destroyed, whose uploader is disposed, and whose decoded tier is cleared.

Every method that iterates the map can reach that entry: `beginChunkFrame`, `_ensureSingleGradients`, `_refreshUnlitChunksForLighting`, `_invalidateBindGroupCache`, `chunkStreamStats`. Steffen saw it as stale numbers out of `chunkStreamStats()`, which is the mildest symptom; a frame landing in the window drives a destroyed manager instead.

On WebGPU there is a second cache with the same key. `_bindGroupCache` was left populated, and `bindCachedVolume` reads it right after a `_texCache` hit, so a hit could return a bind group whose bindings 1 and 4 point at destroyed textures.

| File | Destroy | Re-set | Awaits in the window | Transition |
|---|---|---|---|---|
| `wgpu/render.ts` | 865 | 890 | 2 (`volume2Texture`, `volume2TextureGradientRGBA`) | chunked to single |
| `wgpu/render.ts` | 1019 | 1070 | 2 (`createChunkUploaderGPU`, `uploadChunk(0)`) | single to chunked |
| `gl/render.ts` | 688 | 721 | 1 (`overlay2Texture`) | chunked to single |
| `gl/render.ts` | 856 | 898 | 1 (`uploadChunk(0)`) | single to chunked |

`_destroyTexEntry` does clear `_activeChunked` and `_activeOverlayChunked` and splices `_combinedOverlayEntries`, so the active bindings were never at risk. It is the maps that were.

## Trigger

A cache-key collision across a kind change: the same `vol.url || vol.name` was cached as one kind and is now being built as the other. A same-key chunked reload is not affected, since it takes the in-place rebuild branch at `wgpu/render.ts:988` and returns early.

## The fix

A new `_evictTexEntry` on each backend does the destroy and the deletes together, and every eviction path routes through it. `pruneVolumeCache` was already doing this by hand and now calls the helper, so there is one place that knows the invariant instead of five. Both backends in the same change, per the parity rule in `AGENTS.md`.

## Two corrections to the report

The email version of this said one site per backend and described the trigger as a reload. Verifying against main turned up four sites rather than two, and narrowed the trigger to the kind change described above.

## The second bug, found while writing the test

`perVolumeCache` defaults to false, and the only caller that passes true is the multi-instance / global3d path (`NVViewGPU.ts:652`, `NVViewGL.ts:419`). Both chunked-to-single sites in the table sit inside that branch, so in ordinary single-instance use they are unreachable.

Which means the ordinary path had its own problem. A volume that stops being chunked takes the `else` branch, which uses the single-slot `volumeOrientCache` and never touches `_texCache` at all. Its chunked entry then stays for the life of the renderer: every brick texture still held (about 114 MiB for mni152 at 3x3x3), `beginChunkFrame` still driving it each frame, and `chunkStreamStats` still counting it. `pruneVolumeCache` does not clean it up either, being called only from the instances branch.

The second commit hoists the eviction above the `perVolumeCache` check so it runs on both paths, on both backends.

## Reproducing it

Open `examples/vox.gradopacity.explode.html` and, once the brain is up:

```js
const v = nv1.volumes[0]
console.log('before:', nv1.chunkStreamStats())
v.chunkPlan = undefined          // chunked -> single, same cache key
await nv1.updateGLVolume()
console.log('after: ', nv1.chunkStreamStats())
```

The volume starts chunked at 3x3x3. Clearing `chunkPlan` rebuilds it as a single texture under the same key `/volumes/mni152.nii.gz`.

On `main` (37bf47c8) `after` reads `{resident: 1, total: 27, ...}`: a 27-brick stream reported for a volume that is now a single texture. With this branch it reads `total: 0`. (`chunkStreamStats()` returns an object with zeroed counts, not null, whenever a view is attached; the `?? null` in `NVControlBase` only covers the no-view case.)

## Verification

`e2e/texcache-kind-change.spec.ts` pins the second bug in real Chromium, on both backends: force a 2x2x2 plan on mni152, assert 8 bricks, clear the plan, assert 0 bricks and 0 resident. The first assertion guards the second, so it cannot pass because the plan silently failed to take.

It now runs in CI, added to `.github/workflows/niivue-e2e.yml` -- an allowlist, because most of the e2e suite needs a GPU adapter headless runners lack. The WebGL2 case does not: it forces `--use-angle=swiftshader`, which is how it was proven to fail on main, and it passes on the runner. The WebGPU case skips there. `requestAdapter()` actually succeeds on the runner, but the GPU instance dies partway through, so the spec skips on GPU-loss errors specifically; a validation error from binding a destroyed texture, which is the failure mode this spec exists to catch, does not match the filter and still fails. The job also runs `--workers=1` now, since two concurrent Chromium instances sharing one software GPU were what killed it. Both backends do run locally, where there is a real adapter.

The workflow and job are renamed from "loader contracts" to "browser contracts", since a renderer cache test is not a loader contract; `main` has no branch protection, so no required check depended on the old job id.

The spec loads the real `mni152.nii.gz`, the same volume as the manual repro above. It briefly synthesized its own NIfTI instead, because `packages/dev-images` is Git LFS and this workflow checked out without it, so the page received a pointer file -- but that is a reason to fetch the object, not to invent a different volume. The job now runs `git lfs pull --include=packages/dev-images/images/volumes/mni152.nii.gz`, which costs 4.3 MB rather than the ~93 MB `lfs: true` would pull for the whole store. An unpulled pointer fails loudly as "not NIFTI" rather than quietly testing nothing.

Proven discriminating rather than assumed. With the renderer sources checked out from `main` it fails on both backends with `Expected: 0, Received: 8`, and it fails the same way on the first commit of this PR alone. It passes with the hoist. Re-proven after the switch to mni152.

`format`, `lint`, `typecheck`, `test` (1362 pass, 1 skip, 0 fail) and `build` all pass, plus `codespell` with the CI options.

## A correction to note

An earlier revision of this description claimed the browser measurement above proved the *first* commit was observable after the awaits settle. That was wrong. The flip it measures goes through the ordinary path, which the first commit does not touch, so the reading was unchanged by it. My original read stands: for the four sites in the table, the staleness is a mid-await window and is not directly assertable from a settled state. What the measurement actually found was the separate leak described above, which the second commit fixes and the e2e spec pins.
