### PR TITLE
feat(niivue): add a um ruler step below mm

### DIFF
--- a/packages/niivue/src/view/NVRuler.test.ts
+++ b/packages/niivue/src/view/NVRuler.test.ts
@@ -57,11 +57,11 @@ function measure(
     [1, 1, 1, 1],
     [0, 0, 0, zoom],
   )
-  const m = /^(\d+) (cm|mm)$/.exec(label)
+  const m = /^(\d+) (cm|mm|um)$/.exec(label)
   if (!m) throw new Error(`no ruler drawn (label: "${label}")`)
   const barPx =
     Math.max(...lines.map((l) => l[1])) - Math.min(...lines.map((l) => l[0]))
-  const labelMM = Number(m[1]) * (m[2] === 'cm' ? 10 : 1)
+  const labelMM = Number(m[1]) * (m[2] === 'cm' ? 10 : m[2] === 'um' ? 1e-3 : 1)
   return { pxPerMM: barPx / labelMM, barPx, label }
 }
 
@@ -97,6 +97,44 @@ describe('buildRuler', () => {
         ),
       ).not.toThrow()
     }
+  })
+
+  test('subMillimetreFovStillGetsABar_labelledInUm', () => {
+    // A microscopy field of view narrower than the smallest nice mm value
+    // used to fall off the end of chooseRulerSize and draw no ruler at all.
+    // maxMM = 0.65 * 0.4 = 0.26, so the um ladder picks 200 um.
+    const r = measure(0, false, 1, {
+      extentsMax: vec3.fromValues(0.4, 0.4, 0.4),
+    })
+    expect(r.label).toBe('200 um')
+    // The bar must still be as long as its label claims: fit scale is
+    // min(2000 / 0.4, 400 / 0.4) px per mm.
+    expect(r.pxPerMM).toBeCloseTo(400 / 0.4, 3)
+  })
+
+  test('umLadderWalksTheSubMmDecades_notJustOne', () => {
+    // A single pass of NICE_VALUES spans one decade; without the decade walk
+    // a few-hundred-micron slide window would get a 10 um sliver of a bar.
+    // maxMM = 0.65 * 0.3 = 0.195, so the ladder picks 100 um.
+    const r = measure(0, false, 1, {
+      extentsMax: vec3.fromValues(0.3, 0.3, 0.3),
+    })
+    expect(r.label).toBe('100 um')
+    expect(r.pxPerMM).toBeCloseTo(400 / 0.3, 3)
+  })
+
+  test('boundaryBetweenMmAndUm_isTheSmallestNiceMmValue', () => {
+    // mm keeps every field of view where 1 mm still fits in 65% of the tile;
+    // just below that the um ladder takes over at its top (500 um), so the
+    // handover does not jump to a tiny bar.
+    const mm = measure(0, false, 1, {
+      extentsMax: vec3.fromValues(1.6, 1.6, 1.6), // maxMM = 1.04
+    })
+    expect(mm.label).toBe('1 mm')
+    const um = measure(0, false, 1, {
+      extentsMax: vec3.fromValues(1.5, 1.5, 1.5), // maxMM = 0.975
+    })
+    expect(um.label).toBe('500 um')
   })
 
   test('barLengthMatchesItsLabelInEveryOrientation', () => {

--- a/packages/niivue/src/view/NVRuler.ts
+++ b/packages/niivue/src/view/NVRuler.ts
@@ -63,6 +63,18 @@ function chooseRulerSize(
       return { lengthMM: v, label: `${v} mm` }
     }
   }
+  // Fall back to um for sub-mm fields of view. One pass of the nice-value
+  // ladder only spans a decade, so walk it across the sub-mm decades: a slide
+  // zoomed to a few hundred microns gets a 100 um bar, not a 10 um sliver.
+  for (const decade of [100, 10, 1]) {
+    for (const v of NICE_VALUES) {
+      const um = v * decade
+      const mm = um / 1000 // um -> mm
+      if (mm <= maxMM) {
+        return { lengthMM: mm, label: `${um} um` }
+      }
+    }
+  }
   return null
 }
 


### PR DESCRIPTION
## Summary

`chooseRulerSize` in `packages/niivue/src/view/NVRuler.ts` tried cm (for `fovMM >= 50`), then mm, and returned `null` below that -- so a microscopy field of view narrower than the smallest nice mm value drew no scale bar at all. This matters for the ZARRo whole-slide use case, where a slide zoomed to a few hundred microns should still get a ruler.

## Change

Add a um step below the mm fallback, on the same `NICE_VALUES` ladder. Because one pass of the ladder only spans a single decade, the um step walks the ladder across the sub-mm decades (hundreds, tens, ones of um), so a few-hundred-micron window gets a useful bar (e.g. `100 um`) instead of a `10 um` sliver. Labels use ASCII `um`, matching the existing micrometre spelling elsewhere in the package (OME-TIFF / Allen atlas readers). The cm and mm paths are untouched, and the mm-to-um handover is clean: mm keeps every window where 1 mm fits in 65% of the tile, and the um ladder takes over at 500 um just below that.

## Tests

New cases in `packages/niivue/src/view/NVRuler.test.ts`, in the existing style (the `measure` helper's label parser now also accepts `um`; all pre-existing cm/mm pins pass unchanged):

- `subMillimetreFovStillGetsABar_labelledInUm` -- a 0.4 mm field of view yields a `200 um` bar whose pixel length matches its label.
- `umLadderWalksTheSubMmDecades_notJustOne` -- a 0.3 mm window gets `100 um`, not a single-decade sliver.
- `boundaryBetweenMmAndUm_isTheSmallestNiceMmValue` -- `1 mm` just above the handover, `500 um` just below.

Gates run from `packages/niivue`: `bunx biome check src`, `bunx tsc --noEmit`, `bun test src/view/NVRuler.test.ts` (6 pass), `bun test src/view` (109 pass), and codespell with the CI options -- all clean.

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)
