### PR TITLE
Export the full public surface from every entry point

### DIFF
--- a/packages/niivue/AGENTS.md
+++ b/packages/niivue/AGENTS.md
@@ -334,18 +334,21 @@ touches `src/index.ts` and no other entry point as a defect until shown otherwis
 
 ### The only sanctioned differences
 
-`src/index.webgl2.ts` and `src/index.webgpu.ts` are the same file apart from two
-lines, the header comment and the default export:
+`src/index.webgl2.ts` and `src/index.webgpu.ts` are the same file apart from
+three lines: the header comment, the backend's own slide renderer, and the
+default export.
 
 ```bash
 diff src/index.webgl2.ts src/index.webgpu.ts
-# exactly two hunks:
+# exactly three hunks:
 #   the 'WebGL2-only distribution' header comment vs 'WebGPU-only'
+#   export { SlideRenderer } from './gl/slide'
+#                             vs   { SlideRendererGPU } from './wgpu/slide'
 #   export { default, default as NiiVue } from './NVControlWebGL2'
 #                                          vs   './NVControlWebGPU'
 ```
 
-A third hunk is a bug. That diff is the cheapest pre-push check there is.
+A fourth hunk is a bug. That diff is the cheapest pre-push check there is.
 
 Against the root entry, the one sanctioned omission is the **`*Detail` event
 payload types** re-exported from `./NVEvents` (`VolumeLoadedDetail`,
@@ -354,8 +357,14 @@ root entry exports belongs in both backend entries as well.
 
 ### Checking a branch
 
-Names the root entry exports that the backend entries do not, ignoring the
-sanctioned `*Detail` omission:
+`src/entryPoints.test.ts` asserts all of this and runs in the normal `bun test`
+target, so ordinary CI catches the drift now. It checks four things: the two
+backend entries differ only by their own slide renderer; neither exports a name
+the root entry lacks; nothing but `*Detail` types and the other backend's
+renderer is root-only; and every `*Detail` type `NVEvents.ts` declares is
+exported from root.
+
+By hand, the same question:
 
 ```bash
 names() {
@@ -366,30 +375,28 @@ names() {
 diff <(names src/index.ts) <(names src/index.webgl2.ts) | grep '^<' | grep -v 'Detail$'
 ```
 
-Nothing should ever come back on the `>` side: a symbol in a backend entry but
-not in root means the universal build cannot reach its own feature.
+### Keeping the three files in step
 
-### Known drift
+The backend entries are a mechanical function of the root entry: root, minus the
+`*Detail` names, with the header comment, the slide-renderer line and the default
+export swapped. Edit `src/index.ts` first and mirror the change into both backend
+files; the test above will tell you if you missed one.
 
-The rule above is the policy, not yet a description of the tree. As of
-2026-09-07 the root entry exports 68 non-`*Detail` names that neither backend
-entry has: the slide/WSI subsystem, several `NVTypes` annotation types,
-`lookupColorMap` / `makeLabelLut`, `writeVolume`, `NVWorker` and others. They
-accumulated one PR at a time for exactly the reason this section now exists.
-Re-run the check above for the current list rather than trusting that count.
+### The single-backend distributions are not backend-isolated
 
-Two calls are still open and should be settled before anyone bulk-fixes the
-drift:
+Separate from the export policy, and worth knowing before reasoning about what a
+subpath "costs": `dist/niivue.webgl2.js` and `dist/niivue.webgpu.js` currently
+share three of their five chunks, including the 1.83 MB one that holds both
+backends. The path is `NVControlBase.ts` -> `control/viewBoth.ts` -> both
+`gl/NVViewGL.ts` and `wgpu/NVViewGPU.ts` (`control/interactions.ts`,
+`control/viewWebGL2.ts` and `control/viewWebGPU.ts` reach it the same way), a
+static import that no entry point can tree-shake away. So the subpaths today
+select a default export, not a smaller bundle. The slide renderers *are* split
+per backend, because the entry point should not be the thing that cements the
+leak.
 
-- The non-`*Detail` names from `./NVEvents` (`NVEventMap`, `NVEventListener`,
-  `NVEventTarget`, `VolumeUpdatedChanges`) are root-only today. Either they
-  join the backend entries, or the exception widens to "the whole `./NVEvents`
-  module is root-only". Right now they read as drift under the stated rule.
-- `SlideRenderer` (`./gl/slide`) and `SlideRendererGPU` (`./wgpu/slide`) are
-  root-only and are genuinely backend-specific. If they are exposed at all, each
-  belongs in its own backend entry. That would be the first sanctioned
-  asymmetry between `index.webgl2.ts` and `index.webgpu.ts`, and it would cost
-  the two-hunk diff check above.
+Tracked as https://github.com/niivue/mono/issues/175, with the cause and the fix
+written up there. Delete this section when it lands.
 
 ## Code style and conventions
 

--- a/packages/niivue/AGENTS.md
+++ b/packages/niivue/AGENTS.md
@@ -311,6 +311,86 @@ nv1.setVolume(0, { calMin: 40, colormap: 'hot' })
 
 Same pattern for meshes, layers, tracts, connectomes.
 
+## Entry points and public exports
+
+The package ships three hand-maintained entry points:
+
+| Subpath | File | Distribution |
+|---------|------|--------------|
+| `@niivue/niivue` | `src/index.ts` | universal (carries both backends) |
+| `@niivue/niivue/webgl2` | `src/index.webgl2.ts` | WebGL2 only |
+| `@niivue/niivue/webgpu` | `src/index.webgpu.ts` | WebGPU only |
+
+(The other `package.json` subpaths, `./viewport`, `./assets/fonts` and
+`./assets/matcaps`, point straight at a module and have no hand-written index.)
+
+**A new public export goes in all three files.** Adding it to `src/index.ts`
+alone is the standing mistake, and nothing in the toolchain catches it: the
+typecheck passes, the build passes, `dist/index.d.ts` has the symbol, and the
+docs describe it. It surfaces only downstream, when someone writes
+`import { Thing } from '@niivue/niivue/webgl2'` against a package that plainly
+documents `Thing` and gets a build error. Reviewers should read a diff that
+touches `src/index.ts` and no other entry point as a defect until shown otherwise.
+
+### The only sanctioned differences
+
+`src/index.webgl2.ts` and `src/index.webgpu.ts` are the same file apart from two
+lines, the header comment and the default export:
+
+```bash
+diff src/index.webgl2.ts src/index.webgpu.ts
+# exactly two hunks:
+#   the 'WebGL2-only distribution' header comment vs 'WebGPU-only'
+#   export { default, default as NiiVue } from './NVControlWebGL2'
+#                                          vs   './NVControlWebGPU'
+```
+
+A third hunk is a bug. That diff is the cheapest pre-push check there is.
+
+Against the root entry, the one sanctioned omission is the **`*Detail` event
+payload types** re-exported from `./NVEvents` (`VolumeLoadedDetail`,
+`ClipPlaneChangeDetail`, and the rest). Those are root-only. Everything else the
+root entry exports belongs in both backend entries as well.
+
+### Checking a branch
+
+Names the root entry exports that the backend entries do not, ignoring the
+sanctioned `*Detail` omission:
+
+```bash
+names() {
+  tr '\n' ' ' < "$1" | grep -oE 'export (type )?\{[^}]*\} from' |
+  tr -d '{}' | sed 's/export \(type \)*//;s/ from//' | tr ',' '\n' |
+  sed 's/.* as //;s/^ *type *//;s/^ *//;s/ *$//' | grep -v '^$' | sort -u
+}
+diff <(names src/index.ts) <(names src/index.webgl2.ts) | grep '^<' | grep -v 'Detail$'
+```
+
+Nothing should ever come back on the `>` side: a symbol in a backend entry but
+not in root means the universal build cannot reach its own feature.
+
+### Known drift
+
+The rule above is the policy, not yet a description of the tree. As of
+2026-09-07 the root entry exports 68 non-`*Detail` names that neither backend
+entry has: the slide/WSI subsystem, several `NVTypes` annotation types,
+`lookupColorMap` / `makeLabelLut`, `writeVolume`, `NVWorker` and others. They
+accumulated one PR at a time for exactly the reason this section now exists.
+Re-run the check above for the current list rather than trusting that count.
+
+Two calls are still open and should be settled before anyone bulk-fixes the
+drift:
+
+- The non-`*Detail` names from `./NVEvents` (`NVEventMap`, `NVEventListener`,
+  `NVEventTarget`, `VolumeUpdatedChanges`) are root-only today. Either they
+  join the backend entries, or the exception widens to "the whole `./NVEvents`
+  module is root-only". Right now they read as drift under the stated rule.
+- `SlideRenderer` (`./gl/slide`) and `SlideRendererGPU` (`./wgpu/slide`) are
+  root-only and are genuinely backend-specific. If they are exposed at all, each
+  belongs in its own backend entry. That would be the first sanctioned
+  asymmetry between `index.webgl2.ts` and `index.webgpu.ts`, and it would cost
+  the two-hunk diff check above.
+
 ## Code style and conventions
 
 Linting/formatting is **Biome**, configured in the monorepo root `biome.json`. See the root `AGENTS.md` for the full rule list; key rules enforced here:
@@ -1454,7 +1534,15 @@ Exported from `volume/utils.ts` and from the package root. Returns `Float32Array
 
 ### Public exports
 
-From package root (`src/index.ts`): `NVExtensionContext`, `computeSlicePointerEvent`, `getImageDataRAS`, and types `BackgroundVolumeAccess`, `DrawingAccess`, `DrawingDims`, `NVExtensionEventMap`, `SharedBufferHandle`, `SlicePointerEvent`.
+From all three entry points (see **Entry points and public exports**):
+`NVExtensionContext`, `getImageDataRAS`, and types `BackgroundVolumeAccess`,
+`DrawingAccess`, `DrawingDims`, `MrsVolumeAccess`, `NVExtensionEventMap`,
+`SharedBufferHandle`, `SlicePointerEvent`.
+
+`computeSlicePointerEvent` is **not** exported from any entry point. It lives in
+`extension/context.ts` and is called from `control/interactions.ts`; this section
+used to list it as public, which it never was. Either re-export it from all three
+entries or leave it internal, but the doc should not promise it.
 
 ## Web Workers
 

--- a/packages/niivue/src/entryPoints.test.ts
+++ b/packages/niivue/src/entryPoints.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from 'bun:test'
+
+// The three hand-maintained entry points drift silently: a symbol added to
+// src/index.ts alone still typechecks, still builds, and still lands in
+// dist/index.d.ts. It fails only downstream, for someone importing it from
+// '@niivue/niivue/webgl2'. Four exports were missed across three PRs that way.
+// The policy these tests encode is written up in AGENTS.md, "Entry points and
+// public exports".
+
+const ENTRY = {
+  root: 'index.ts',
+  webgl2: 'index.webgl2.ts',
+  webgpu: 'index.webgpu.ts',
+} as const
+
+const read = async (file: string): Promise<string> =>
+  await Bun.file(`${import.meta.dir}/${file}`).text()
+
+// Exported names from every `export [type] { ... } from '...'` re-export,
+// resolving `as` aliases to the public name.
+function exportedNames(source: string): Set<string> {
+  const names = new Set<string>()
+  const block = /export[ \t]+(?:type[ \t]+)?\{([^}]*)\}[ \t]*from/g
+  for (const match of source.matchAll(block)) {
+    for (const spec of match[1].split(',')) {
+      const name = spec
+        .replace(/^\s*type\s+/, '')
+        .split(' as ')
+        .pop()
+        ?.trim()
+      if (name) names.add(name)
+    }
+  }
+  return names
+}
+
+const sorted = (values: Iterable<string>): string[] => [...values].sort()
+
+describe('entry points', () => {
+  test('the backend entries differ only by their own slide renderer', async () => {
+    const webgl2 = exportedNames(await read(ENTRY.webgl2))
+    const webgpu = exportedNames(await read(ENTRY.webgpu))
+    expect(sorted([...webgl2].filter((n) => !webgpu.has(n)))).toEqual([
+      'SlideRenderer',
+    ])
+    expect(sorted([...webgpu].filter((n) => !webgl2.has(n)))).toEqual([
+      'SlideRendererGPU',
+    ])
+  })
+
+  test('the backend entries export nothing the universal entry lacks', async () => {
+    const root = exportedNames(await read(ENTRY.root))
+    for (const file of [ENTRY.webgl2, ENTRY.webgpu]) {
+      const names = exportedNames(await read(file))
+      // A symbol here but not in root means the universal build cannot reach
+      // its own feature.
+      expect(sorted([...names].filter((n) => !root.has(n)))).toEqual([])
+    }
+  })
+
+  test('only *Detail types and the other backend are root-only', async () => {
+    const root = exportedNames(await read(ENTRY.root))
+    for (const [file, ownRenderer] of [
+      [ENTRY.webgl2, 'SlideRendererGPU'],
+      [ENTRY.webgpu, 'SlideRenderer'],
+    ] as const) {
+      const names = exportedNames(await read(file))
+      const missing = sorted([...root].filter((n) => !names.has(n)))
+      expect(missing.filter((n) => !n.endsWith('Detail'))).toEqual([
+        ownRenderer,
+      ])
+    }
+  })
+
+  test('every event detail type NVEvents declares is exported', async () => {
+    const events = await read('NVEvents.ts')
+    const declared = sorted(
+      [...events.matchAll(/export (?:interface|type) (\w*Detail)\b/g)].map(
+        (m) => m[1],
+      ),
+    )
+    expect(declared.length).toBeGreaterThan(0)
+    const root = exportedNames(await read(ENTRY.root))
+    // NVEventMap names these in its public signature, so a consumer that reads
+    // an event's detail has to be able to name the type too.
+    expect(declared.filter((n) => !root.has(n))).toEqual([])
+  })
+})

--- a/packages/niivue/src/index.ts
+++ b/packages/niivue/src/index.ts
@@ -70,6 +70,7 @@ export type {
   AnnotationRemovedDetail,
   AzimuthElevationChangeDetail,
   CanvasResizeDetail,
+  ClickToSegmentDetail,
   ClipPlaneChangeDetail,
   ColormapAddedDetail,
   DrawingChangedDetail,
@@ -83,6 +84,7 @@ export type {
   NVEventMap,
   NVEventTarget,
   PenValueChangedDetail,
+  PerfFrameDetail,
   PointerUpDetail,
   PropertyChangeDetail,
   SignalLoadedDetail,
@@ -91,6 +93,7 @@ export type {
   SliceTypeChangeDetail,
   ViewAttachedDetail,
   VolumeLoadedDetail,
+  VolumeOrderChangedDetail,
   VolumeRemovedDetail,
   VolumeUpdatedChanges,
   VolumeUpdatedDetail,
@@ -103,37 +106,51 @@ export type {
   AnnotationPoint,
   AnnotationScreenShape,
   AnnotationStats,
+  AnnotationStyle,
   AnnotationTool,
   BackendType,
   CanvasViewport,
   ColorMap,
+  CompletedAngle,
+  CompletedMeasurement,
   CustomLayoutTile,
   DragReleaseInfo,
   ImageFromUrlOptions,
   LodCompensationLevel,
   LodCompensationReport,
+  LUT,
   MeasurementScreenLine,
   MeshFromUrlOptions,
+  MeshKind,
   MeshLayerFromUrlOptions,
   MeshUpdate,
   MrsVolumeMeta,
   NIFTI1,
   NIFTI2,
+  NIFTIHeader,
   NiiVueLocation,
   NiiVueLocationValue,
   NiiVueOptions,
   NVBounds,
+  NVConnectomeData,
+  NVConnectomeEdge,
+  NVConnectomeNode,
   NVConnectomeOptions,
   NVFontData,
   NVGlobalCamera,
   NVImage,
   NVInstance,
   NVMesh,
+  NVMeshData,
   NVMeshLayer,
   NVSignal,
   NVSignalDisplay,
+  NVSignalPhysioRaw,
   NVSignalRaw,
+  NVSignalSpectroscopyRaw,
+  NVTractData,
   NVTractOptions,
+  PolygonWithHoles,
   SaveVolumeOptions,
   SignalAnnotation,
   SignalAxis,
@@ -142,6 +159,7 @@ export type {
   SignalSidecar,
   SignalSpectrumMode,
   SyncOpts,
+  TractScalarMeta,
   TypedVoxelArray,
   VectorAnnotation,
   ViewHitTest,
@@ -165,6 +183,7 @@ export {
   type PpmBandOptions,
   phaseCorrection,
   ppmRefForNucleus,
+  type SignalPlot,
 } from './signal/processing'
 export type { DziDescriptor } from './slide/dziSource'
 export {
@@ -197,7 +216,11 @@ export type {
 } from './slide/NVSlide'
 export { ManifestRangeSource, NVSlide } from './slide/NVSlide'
 export { SlideDrawing } from './slide/slideDrawing'
-export type { SlidePlaneTile } from './slide/slidePlane'
+export type {
+  AxialPlaneOptions,
+  SlidePlaneTile,
+  Vec3 as SlideVec3,
+} from './slide/slidePlane'
 export { axialPlaneTransform, slidePlaneTiles } from './slide/slidePlane'
 export type { SlideVectorKind, SlideVectorShape } from './slide/slideVector'
 export { SlideVectorLayer } from './slide/slideVector'
@@ -231,6 +254,12 @@ export type {
   UIKitOverlayFrame,
   UIKitOverlayRenderer,
 } from './view/NVOverlayHook'
+// Font atlas metrics: the shape of NVFontData.metrics
+export type { FontMetrics } from './view/NVFont'
+// Per-frame render timing: the payload of PerfFrameDetail
+export type { FrameReport } from './view/NVPerfMarks'
+// Base class every render entity extends; SlideRenderer's public supertype
+export { NVRenderer } from './view/NVRenderer'
 // Crosshair-focused multi-resolution (multi-LOD) streamed volumes
 export type {
   ChunkedVolumeFetch,
@@ -277,12 +306,16 @@ export { buildDerivedScalarVolume, isMrsiVolume } from './volume/mrsi'
 // Budget plans: the policy that shapes a streamed volume's octree
 export {
   type BudgetPlan,
+  type BudgetPlanContext,
   type BudgetPlanName,
   type BudgetPlanOptions,
   type BudgetPlanSpec,
   BUDGET_PLANS,
   resolveBudgetPlan,
+  type ResolvedOptions as ResolvedBudgetOptions,
 } from './volume/budgetPlans'
+// Decoded image, for a caller supplying its own `decodeImage`
+export type { DecodedImage } from './volume/imageDecode'
 export {
   type ChunkedVolumeOptions,
   NVChunkedVolume,
@@ -383,6 +416,7 @@ export {
   type TiffImage,
   tiffImageDescription,
   tiffResolutionMm,
+  type TiffTagValue,
 } from './volume/tiff'
 export {
   describeTiff,
@@ -407,6 +441,8 @@ export type {
 } from './volume/transforms'
 // Volume utilities for extensions
 export { extractVoxelFid, getImageDataRAS } from './volume/utils'
+// Volume writer options: the third argument to writeVolume
+export type { VolumeWriteOptions } from './volume/writers'
 export { SlideRendererGPU } from './wgpu/slide'
 // Worker bridge for external transform packages
 export { NVWorker } from './workers/NVWorker'

--- a/packages/niivue/src/index.ts
+++ b/packages/niivue/src/index.ts
@@ -260,6 +260,9 @@ export type { FontMetrics } from './view/NVFont'
 export type { FrameReport } from './view/NVPerfMarks'
 // Base class every render entity extends; SlideRenderer's public supertype
 export { NVRenderer } from './view/NVRenderer'
+// Screen-space projection, for placing external overlays over the 2D tiles
+export type { ScreenInfo, SliceTile } from './view/NVSliceLayout'
+export { projectMMToCanvas } from './view/sliceUtils'
 // Crosshair-focused multi-resolution (multi-LOD) streamed volumes
 export type {
   ChunkedVolumeFetch,

--- a/packages/niivue/src/index.webgl2.ts
+++ b/packages/niivue/src/index.webgl2.ts
@@ -232,6 +232,9 @@ export type { FontMetrics } from './view/NVFont'
 export type { FrameReport } from './view/NVPerfMarks'
 // Base class every render entity extends; SlideRenderer's public supertype
 export { NVRenderer } from './view/NVRenderer'
+// Screen-space projection, for placing external overlays over the 2D tiles
+export type { ScreenInfo, SliceTile } from './view/NVSliceLayout'
+export { projectMMToCanvas } from './view/sliceUtils'
 // Crosshair-focused multi-resolution (multi-LOD) streamed volumes
 export type {
   ChunkedVolumeFetch,

--- a/packages/niivue/src/index.webgl2.ts
+++ b/packages/niivue/src/index.webgl2.ts
@@ -1,14 +1,25 @@
 /**
  * NiiVue — WebGL2-only distribution.
+ *
+ * @packageDocumentation
  */
 
-// biome-ignore-all lint/performance/noBarrelFile: package entry point
-
-// Exploded-block picking: resolve a click on an exploded brick, then copy that
-// brick out as a standalone volume that keeps the parent's anatomical frame.
-export type { ExplodedBlockPick } from './control/interactions'
-export { pickExplodedBlock } from './control/interactions'
+// biome-ignore-all lint/performance/noBarrelFile assist/source/organizeImports: package entry point
+// Label colormap helpers for extensions producing label/atlas volumes
+export { lookupColorMap, makeLabelLut } from './cmap/NVCmaps'
+export { slice2DToMM } from './annotation/sliceProjection'
+// Viewport controller (OpenSeadragon-style smooth pan/zoom on the shared canvas).
+// Opt-in: not in the static graph so apps that don't need the UX don't pay for it.
+// Import directly: `import { NVCanvasViewportController } from '@niivue/niivue/viewport'`
 export type { NVCanvasViewportControllerOptions } from './control/NVCanvasViewportController'
+// Sparse-document settings policies: which settings saveDocument includes, and
+// how loadDocument fills settings a sparse document omits
+export type {
+  SettingsFill,
+  SettingsFillPolicy,
+  SettingsSavePolicy,
+} from './documentSettings'
+// Extension API
 export { NVExtensionContext } from './extension/context'
 export type {
   BackgroundVolumeAccess,
@@ -19,7 +30,13 @@ export type {
   SharedBufferHandle,
   SlicePointerEvent,
 } from './extension/types'
+// Whole-slide-image tile viewer (standalone 2D deep-zoom over HTTP byte ranges).
+// NVSlide is the backend-agnostic model; SlideRenderer (WebGL2) /
+// SlideRendererGPU (WebGPU) draw it.
+export { SlideRenderer } from './gl/slide'
+// Logger
 export type { LogLevel } from './logger'
+// Mesh writer types
 export type { WriteOptions } from './mesh/writers'
 // MRSI scene controller (FSLeyes MRS plugin workflow): anatomy + MRSI grid +
 // crosshair spectrum + metabolite maps, built on the core spectroscopy APIs.
@@ -33,6 +50,7 @@ export {
   PROTON_PEAK_ANNOTATIONS,
   paddedPpmRange,
 } from './mrs/MrsScene'
+// Enums
 export {
   DRAG_MODE,
   LAYER_GRADIENT_MODE,
@@ -43,37 +61,68 @@ export {
   VOLUME_RENDER_MODE,
 } from './NVConstants'
 export { default, default as NiiVue } from './NVControlWebGL2'
+// Document save options (settings policy + linkData)
+export type { SerializeOptions } from './NVDocument'
+// Event types
+export type {
+  NVEventListener,
+  NVEventMap,
+  NVEventTarget,
+  VolumeUpdatedChanges,
+} from './NVEvents'
+// Core types used in the public API
 export type {
   AffineMatrix,
   AffineTransform,
+  AnnotationConfig,
+  AnnotationPoint,
+  AnnotationScreenShape,
+  AnnotationStats,
+  AnnotationStyle,
+  AnnotationTool,
   BackendType,
   CanvasViewport,
   ColorMap,
+  CompletedAngle,
+  CompletedMeasurement,
   CustomLayoutTile,
   DragReleaseInfo,
   ImageFromUrlOptions,
   LodCompensationLevel,
   LodCompensationReport,
+  LUT,
   MeasurementScreenLine,
   MeshFromUrlOptions,
+  MeshKind,
   MeshLayerFromUrlOptions,
   MeshUpdate,
   MrsVolumeMeta,
+  NIFTI1,
+  NIFTI2,
+  NIFTIHeader,
   NiiVueLocation,
   NiiVueLocationValue,
   NiiVueOptions,
   NVBounds,
+  NVConnectomeData,
+  NVConnectomeEdge,
+  NVConnectomeNode,
   NVConnectomeOptions,
   NVFontData,
   NVGlobalCamera,
   NVImage,
   NVInstance,
   NVMesh,
+  NVMeshData,
   NVMeshLayer,
   NVSignal,
   NVSignalDisplay,
+  NVSignalPhysioRaw,
   NVSignalRaw,
+  NVSignalSpectroscopyRaw,
+  NVTractData,
   NVTractOptions,
+  PolygonWithHoles,
   SaveVolumeOptions,
   SignalAnnotation,
   SignalAxis,
@@ -82,11 +131,16 @@ export type {
   SignalSidecar,
   SignalSpectrumMode,
   SyncOpts,
+  TractScalarMeta,
+  TypedVoxelArray,
+  VectorAnnotation,
   ViewHitTest,
+  VolumeChunkExplode,
   VolumeChunkSource,
   VolumeChunkSourceRequest,
   VolumeUpdate,
 } from './NVTypes'
+// Signal load options
 export type { SignalFromUrlOptions } from './signal/NVSignal'
 // MRS / spectroscopy processing (used by the MrsScene controller above and by
 // other spectroscopy extensions)
@@ -101,13 +155,53 @@ export {
   type PpmBandOptions,
   phaseCorrection,
   ppmRefForNucleus,
+  type SignalPlot,
 } from './signal/processing'
+export type { DziDescriptor } from './slide/dziSource'
+export {
+  buildDziManifest,
+  DziSource,
+  parseDziDescriptor,
+} from './slide/dziSource'
 export type {
-  UIKitBackendHandle,
-  UIKitOverlayBounds,
-  UIKitOverlayFrame,
-  UIKitOverlayRenderer,
-} from './view/NVOverlayHook'
+  NVSlideColor,
+  NVSlideLevelChoice,
+  NVSlideLevelManifest,
+  NVSlideManifest,
+  NVSlideOptions,
+  NVSlideRangeEvent,
+  NVSlideRangeStatus,
+  NVSlideScreen,
+  NVSlideScreenRect,
+  NVSlideSpatialTransform,
+  NVSlideStats,
+  NVSlideTileCodec,
+  NVSlideTileFragment,
+  NVSlideTileManifest,
+  NVSlideViewport,
+  NVSlideVisibleTile,
+  NVSlideVisibleTiles,
+  NVSlideYAxis,
+  SlideSourceHost,
+  SlideTileDecoder,
+  SlideTileSource,
+} from './slide/NVSlide'
+export { ManifestRangeSource, NVSlide } from './slide/NVSlide'
+export { SlideDrawing } from './slide/slideDrawing'
+export type {
+  AxialPlaneOptions,
+  SlidePlaneTile,
+  Vec3 as SlideVec3,
+} from './slide/slidePlane'
+export { axialPlaneTransform, slidePlaneTiles } from './slide/slidePlane'
+export type { SlideVectorKind, SlideVectorShape } from './slide/slideVector'
+export { SlideVectorLayer } from './slide/slideVector'
+export type {
+  VolumeSliceAxis,
+  VolumeSliceSourceOptions,
+} from './slide/volumeSliceSource'
+export { VolumeSliceSource } from './slide/volumeSliceSource'
+export { buildDrawingLut, drawingBitmapToRGBA } from './view/NVDrawingTexture'
 // Allen "volume-viewer" JSON + PNG atlas datasets (multi-channel microscopy)
 export {
   type AllenAtlasImage,
@@ -125,21 +219,19 @@ export {
   fetchAllenAtlasInfo,
   loadAllenAtlasVolumes,
 } from './volume/allenAtlasLoader'
-// Budget plans: the policy that shapes a streamed volume's octree
-export {
-  BUDGET_PLANS,
-  type BudgetPlan,
-  type BudgetPlanName,
-  type BudgetPlanOptions,
-  type BudgetPlanSpec,
-  resolveBudgetPlan,
-} from './volume/budgetPlans'
-export type { ExtractedSubVolume } from './volume/ChunkExtract'
-export {
-  extractChunkBlock,
-  extractSubVolume,
-  subVolumeAffine,
-} from './volume/ChunkExtract'
+// UIKit overlay lifecycle hook — the seam @niivue/uikit widgets draw into
+export type {
+  UIKitBackendHandle,
+  UIKitOverlayBounds,
+  UIKitOverlayFrame,
+  UIKitOverlayRenderer,
+} from './view/NVOverlayHook'
+// Font atlas metrics: the shape of NVFontData.metrics
+export type { FontMetrics } from './view/NVFont'
+// Per-frame render timing: the payload of PerfFrameDetail
+export type { FrameReport } from './view/NVPerfMarks'
+// Base class every render entity extends; SlideRenderer's public supertype
+export { NVRenderer } from './view/NVRenderer'
 // Crosshair-focused multi-resolution (multi-LOD) streamed volumes
 export type {
   ChunkedVolumeFetch,
@@ -171,14 +263,38 @@ export {
   recordChunkPhase,
   resetChunkTiming,
 } from './volume/chunkTiming'
-// OME-Zarr chunk-streaming adapter for nv.loadChunkedVolume
-export { fetchOmeZarrChunkedSource } from './volume/fetchOmeZarrChunkedSource'
+// Exploded-block picking: resolve a click on an exploded brick, then copy that
+// brick out as a standalone volume that keeps the parent's anatomical frame.
+export type { ExplodedBlockPick } from './control/interactions'
+export { pickExplodedBlock } from './control/interactions'
+export type { ExtractedSubVolume } from './volume/ChunkExtract'
+export {
+  extractChunkBlock,
+  extractSubVolume,
+  subVolumeAffine,
+} from './volume/ChunkExtract'
 // MRSI (spatial spectroscopic imaging) volume helpers
 export { buildDerivedScalarVolume, isMrsiVolume } from './volume/mrsi'
+// Budget plans: the policy that shapes a streamed volume's octree
+export {
+  type BudgetPlan,
+  type BudgetPlanContext,
+  type BudgetPlanName,
+  type BudgetPlanOptions,
+  type BudgetPlanSpec,
+  BUDGET_PLANS,
+  resolveBudgetPlan,
+  type ResolvedOptions as ResolvedBudgetOptions,
+} from './volume/budgetPlans'
+// Decoded image, for a caller supplying its own `decodeImage`
+export type { DecodedImage } from './volume/imageDecode'
 export {
   type ChunkedVolumeOptions,
   NVChunkedVolume,
 } from './volume/NVChunkedVolume'
+// Volume construction/serialization for extensions building derived volumes
+// (e.g. wrapping segmentation labels into an overlay NVImage)
+export { nii2volume, writeVolume } from './volume/NVVolume'
 export {
   type ImageJStackInfo,
   type OmeChannel,
@@ -215,6 +331,8 @@ export {
   parseOmeroColor,
   parseOmeZarrAttrs,
 } from './volume/omeZarr'
+// OME-Zarr chunk-streaming adapter for nv.loadChunkedVolume
+export { fetchOmeZarrChunkedSource } from './volume/fetchOmeZarrChunkedSource'
 export {
   type ByteCacheStats,
   ByteLruCache,
@@ -228,6 +346,18 @@ export {
   withChunkTiming,
 } from './volume/omeZarrChunkedSource'
 export type { OmeZarrChunkPoolOptions } from './volume/omeZarrChunkWorkerPool'
+export {
+  clearPersistentByteCaches,
+  OME_ZARR_PERSIST_BYTES,
+  openCacheStorageBacking,
+  openPersistentByteCache,
+  PERSISTENT_CACHE_NAME,
+  PersistentByteCache,
+  type PersistentCacheBacking,
+  type PersistentCacheOptions,
+  type PersistentCacheStats,
+  withPersistentBytes,
+} from './volume/persistentByteCache'
 export {
   defaultOmeZarrLevel,
   fetchOmeZarr,
@@ -247,18 +377,6 @@ export {
   openOmeZarr,
 } from './volume/omeZarrLoader'
 export {
-  clearPersistentByteCaches,
-  OME_ZARR_PERSIST_BYTES,
-  openCacheStorageBacking,
-  openPersistentByteCache,
-  PERSISTENT_CACHE_NAME,
-  PersistentByteCache,
-  type PersistentCacheBacking,
-  type PersistentCacheOptions,
-  type PersistentCacheStats,
-  withPersistentBytes,
-} from './volume/persistentByteCache'
-export {
   createStreamingNVImage,
   type StreamingVolumeSpec,
 } from './volume/streamingVolume'
@@ -270,6 +388,7 @@ export {
   type TiffImage,
   tiffImageDescription,
   tiffResolutionMm,
+  type TiffTagValue,
 } from './volume/tiff'
 export {
   describeTiff,
@@ -284,5 +403,17 @@ export {
   tiffTimepointCount,
   tiffVolumeAffine,
 } from './volume/tiffVolume'
-export type { TransformInfo, TransformOptions } from './volume/transforms'
+// Transform types
+export type {
+  OptionField,
+  ResultDefaults,
+  TransformInfo,
+  TransformOptions,
+  VolumeTransform,
+} from './volume/transforms'
+// Volume utilities for extensions
 export { extractVoxelFid, getImageDataRAS } from './volume/utils'
+// Volume writer options: the third argument to writeVolume
+export type { VolumeWriteOptions } from './volume/writers'
+// Worker bridge for external transform packages
+export { NVWorker } from './workers/NVWorker'

--- a/packages/niivue/src/index.webgpu.ts
+++ b/packages/niivue/src/index.webgpu.ts
@@ -232,6 +232,9 @@ export type { FontMetrics } from './view/NVFont'
 export type { FrameReport } from './view/NVPerfMarks'
 // Base class every render entity extends; SlideRenderer's public supertype
 export { NVRenderer } from './view/NVRenderer'
+// Screen-space projection, for placing external overlays over the 2D tiles
+export type { ScreenInfo, SliceTile } from './view/NVSliceLayout'
+export { projectMMToCanvas } from './view/sliceUtils'
 // Crosshair-focused multi-resolution (multi-LOD) streamed volumes
 export type {
   ChunkedVolumeFetch,

--- a/packages/niivue/src/index.webgpu.ts
+++ b/packages/niivue/src/index.webgpu.ts
@@ -1,14 +1,25 @@
 /**
  * NiiVue — WebGPU-only distribution.
+ *
+ * @packageDocumentation
  */
 
-// biome-ignore-all lint/performance/noBarrelFile: package entry point
-
-// Exploded-block picking: resolve a click on an exploded brick, then copy that
-// brick out as a standalone volume that keeps the parent's anatomical frame.
-export type { ExplodedBlockPick } from './control/interactions'
-export { pickExplodedBlock } from './control/interactions'
+// biome-ignore-all lint/performance/noBarrelFile assist/source/organizeImports: package entry point
+// Label colormap helpers for extensions producing label/atlas volumes
+export { lookupColorMap, makeLabelLut } from './cmap/NVCmaps'
+export { slice2DToMM } from './annotation/sliceProjection'
+// Viewport controller (OpenSeadragon-style smooth pan/zoom on the shared canvas).
+// Opt-in: not in the static graph so apps that don't need the UX don't pay for it.
+// Import directly: `import { NVCanvasViewportController } from '@niivue/niivue/viewport'`
 export type { NVCanvasViewportControllerOptions } from './control/NVCanvasViewportController'
+// Sparse-document settings policies: which settings saveDocument includes, and
+// how loadDocument fills settings a sparse document omits
+export type {
+  SettingsFill,
+  SettingsFillPolicy,
+  SettingsSavePolicy,
+} from './documentSettings'
+// Extension API
 export { NVExtensionContext } from './extension/context'
 export type {
   BackgroundVolumeAccess,
@@ -19,7 +30,13 @@ export type {
   SharedBufferHandle,
   SlicePointerEvent,
 } from './extension/types'
+// Whole-slide-image tile viewer (standalone 2D deep-zoom over HTTP byte ranges).
+// NVSlide is the backend-agnostic model; SlideRenderer (WebGL2) /
+// SlideRendererGPU (WebGPU) draw it.
+export { SlideRendererGPU } from './wgpu/slide'
+// Logger
 export type { LogLevel } from './logger'
+// Mesh writer types
 export type { WriteOptions } from './mesh/writers'
 // MRSI scene controller (FSLeyes MRS plugin workflow): anatomy + MRSI grid +
 // crosshair spectrum + metabolite maps, built on the core spectroscopy APIs.
@@ -33,6 +50,7 @@ export {
   PROTON_PEAK_ANNOTATIONS,
   paddedPpmRange,
 } from './mrs/MrsScene'
+// Enums
 export {
   DRAG_MODE,
   LAYER_GRADIENT_MODE,
@@ -43,37 +61,68 @@ export {
   VOLUME_RENDER_MODE,
 } from './NVConstants'
 export { default, default as NiiVue } from './NVControlWebGPU'
+// Document save options (settings policy + linkData)
+export type { SerializeOptions } from './NVDocument'
+// Event types
+export type {
+  NVEventListener,
+  NVEventMap,
+  NVEventTarget,
+  VolumeUpdatedChanges,
+} from './NVEvents'
+// Core types used in the public API
 export type {
   AffineMatrix,
   AffineTransform,
+  AnnotationConfig,
+  AnnotationPoint,
+  AnnotationScreenShape,
+  AnnotationStats,
+  AnnotationStyle,
+  AnnotationTool,
   BackendType,
   CanvasViewport,
   ColorMap,
+  CompletedAngle,
+  CompletedMeasurement,
   CustomLayoutTile,
   DragReleaseInfo,
   ImageFromUrlOptions,
   LodCompensationLevel,
   LodCompensationReport,
+  LUT,
   MeasurementScreenLine,
   MeshFromUrlOptions,
+  MeshKind,
   MeshLayerFromUrlOptions,
   MeshUpdate,
   MrsVolumeMeta,
+  NIFTI1,
+  NIFTI2,
+  NIFTIHeader,
   NiiVueLocation,
   NiiVueLocationValue,
   NiiVueOptions,
   NVBounds,
+  NVConnectomeData,
+  NVConnectomeEdge,
+  NVConnectomeNode,
   NVConnectomeOptions,
   NVFontData,
   NVGlobalCamera,
   NVImage,
   NVInstance,
   NVMesh,
+  NVMeshData,
   NVMeshLayer,
   NVSignal,
   NVSignalDisplay,
+  NVSignalPhysioRaw,
   NVSignalRaw,
+  NVSignalSpectroscopyRaw,
+  NVTractData,
   NVTractOptions,
+  PolygonWithHoles,
   SaveVolumeOptions,
   SignalAnnotation,
   SignalAxis,
@@ -82,11 +131,16 @@ export type {
   SignalSidecar,
   SignalSpectrumMode,
   SyncOpts,
+  TractScalarMeta,
+  TypedVoxelArray,
+  VectorAnnotation,
   ViewHitTest,
+  VolumeChunkExplode,
   VolumeChunkSource,
   VolumeChunkSourceRequest,
   VolumeUpdate,
 } from './NVTypes'
+// Signal load options
 export type { SignalFromUrlOptions } from './signal/NVSignal'
 // MRS / spectroscopy processing (used by the MrsScene controller above and by
 // other spectroscopy extensions)
@@ -101,13 +155,53 @@ export {
   type PpmBandOptions,
   phaseCorrection,
   ppmRefForNucleus,
+  type SignalPlot,
 } from './signal/processing'
+export type { DziDescriptor } from './slide/dziSource'
+export {
+  buildDziManifest,
+  DziSource,
+  parseDziDescriptor,
+} from './slide/dziSource'
 export type {
-  UIKitBackendHandle,
-  UIKitOverlayBounds,
-  UIKitOverlayFrame,
-  UIKitOverlayRenderer,
-} from './view/NVOverlayHook'
+  NVSlideColor,
+  NVSlideLevelChoice,
+  NVSlideLevelManifest,
+  NVSlideManifest,
+  NVSlideOptions,
+  NVSlideRangeEvent,
+  NVSlideRangeStatus,
+  NVSlideScreen,
+  NVSlideScreenRect,
+  NVSlideSpatialTransform,
+  NVSlideStats,
+  NVSlideTileCodec,
+  NVSlideTileFragment,
+  NVSlideTileManifest,
+  NVSlideViewport,
+  NVSlideVisibleTile,
+  NVSlideVisibleTiles,
+  NVSlideYAxis,
+  SlideSourceHost,
+  SlideTileDecoder,
+  SlideTileSource,
+} from './slide/NVSlide'
+export { ManifestRangeSource, NVSlide } from './slide/NVSlide'
+export { SlideDrawing } from './slide/slideDrawing'
+export type {
+  AxialPlaneOptions,
+  SlidePlaneTile,
+  Vec3 as SlideVec3,
+} from './slide/slidePlane'
+export { axialPlaneTransform, slidePlaneTiles } from './slide/slidePlane'
+export type { SlideVectorKind, SlideVectorShape } from './slide/slideVector'
+export { SlideVectorLayer } from './slide/slideVector'
+export type {
+  VolumeSliceAxis,
+  VolumeSliceSourceOptions,
+} from './slide/volumeSliceSource'
+export { VolumeSliceSource } from './slide/volumeSliceSource'
+export { buildDrawingLut, drawingBitmapToRGBA } from './view/NVDrawingTexture'
 // Allen "volume-viewer" JSON + PNG atlas datasets (multi-channel microscopy)
 export {
   type AllenAtlasImage,
@@ -125,21 +219,19 @@ export {
   fetchAllenAtlasInfo,
   loadAllenAtlasVolumes,
 } from './volume/allenAtlasLoader'
-// Budget plans: the policy that shapes a streamed volume's octree
-export {
-  BUDGET_PLANS,
-  type BudgetPlan,
-  type BudgetPlanName,
-  type BudgetPlanOptions,
-  type BudgetPlanSpec,
-  resolveBudgetPlan,
-} from './volume/budgetPlans'
-export type { ExtractedSubVolume } from './volume/ChunkExtract'
-export {
-  extractChunkBlock,
-  extractSubVolume,
-  subVolumeAffine,
-} from './volume/ChunkExtract'
+// UIKit overlay lifecycle hook — the seam @niivue/uikit widgets draw into
+export type {
+  UIKitBackendHandle,
+  UIKitOverlayBounds,
+  UIKitOverlayFrame,
+  UIKitOverlayRenderer,
+} from './view/NVOverlayHook'
+// Font atlas metrics: the shape of NVFontData.metrics
+export type { FontMetrics } from './view/NVFont'
+// Per-frame render timing: the payload of PerfFrameDetail
+export type { FrameReport } from './view/NVPerfMarks'
+// Base class every render entity extends; SlideRenderer's public supertype
+export { NVRenderer } from './view/NVRenderer'
 // Crosshair-focused multi-resolution (multi-LOD) streamed volumes
 export type {
   ChunkedVolumeFetch,
@@ -171,14 +263,38 @@ export {
   recordChunkPhase,
   resetChunkTiming,
 } from './volume/chunkTiming'
-// OME-Zarr chunk-streaming adapter for nv.loadChunkedVolume
-export { fetchOmeZarrChunkedSource } from './volume/fetchOmeZarrChunkedSource'
+// Exploded-block picking: resolve a click on an exploded brick, then copy that
+// brick out as a standalone volume that keeps the parent's anatomical frame.
+export type { ExplodedBlockPick } from './control/interactions'
+export { pickExplodedBlock } from './control/interactions'
+export type { ExtractedSubVolume } from './volume/ChunkExtract'
+export {
+  extractChunkBlock,
+  extractSubVolume,
+  subVolumeAffine,
+} from './volume/ChunkExtract'
 // MRSI (spatial spectroscopic imaging) volume helpers
 export { buildDerivedScalarVolume, isMrsiVolume } from './volume/mrsi'
+// Budget plans: the policy that shapes a streamed volume's octree
+export {
+  type BudgetPlan,
+  type BudgetPlanContext,
+  type BudgetPlanName,
+  type BudgetPlanOptions,
+  type BudgetPlanSpec,
+  BUDGET_PLANS,
+  resolveBudgetPlan,
+  type ResolvedOptions as ResolvedBudgetOptions,
+} from './volume/budgetPlans'
+// Decoded image, for a caller supplying its own `decodeImage`
+export type { DecodedImage } from './volume/imageDecode'
 export {
   type ChunkedVolumeOptions,
   NVChunkedVolume,
 } from './volume/NVChunkedVolume'
+// Volume construction/serialization for extensions building derived volumes
+// (e.g. wrapping segmentation labels into an overlay NVImage)
+export { nii2volume, writeVolume } from './volume/NVVolume'
 export {
   type ImageJStackInfo,
   type OmeChannel,
@@ -215,6 +331,8 @@ export {
   parseOmeroColor,
   parseOmeZarrAttrs,
 } from './volume/omeZarr'
+// OME-Zarr chunk-streaming adapter for nv.loadChunkedVolume
+export { fetchOmeZarrChunkedSource } from './volume/fetchOmeZarrChunkedSource'
 export {
   type ByteCacheStats,
   ByteLruCache,
@@ -228,6 +346,18 @@ export {
   withChunkTiming,
 } from './volume/omeZarrChunkedSource'
 export type { OmeZarrChunkPoolOptions } from './volume/omeZarrChunkWorkerPool'
+export {
+  clearPersistentByteCaches,
+  OME_ZARR_PERSIST_BYTES,
+  openCacheStorageBacking,
+  openPersistentByteCache,
+  PERSISTENT_CACHE_NAME,
+  PersistentByteCache,
+  type PersistentCacheBacking,
+  type PersistentCacheOptions,
+  type PersistentCacheStats,
+  withPersistentBytes,
+} from './volume/persistentByteCache'
 export {
   defaultOmeZarrLevel,
   fetchOmeZarr,
@@ -247,18 +377,6 @@ export {
   openOmeZarr,
 } from './volume/omeZarrLoader'
 export {
-  clearPersistentByteCaches,
-  OME_ZARR_PERSIST_BYTES,
-  openCacheStorageBacking,
-  openPersistentByteCache,
-  PERSISTENT_CACHE_NAME,
-  PersistentByteCache,
-  type PersistentCacheBacking,
-  type PersistentCacheOptions,
-  type PersistentCacheStats,
-  withPersistentBytes,
-} from './volume/persistentByteCache'
-export {
   createStreamingNVImage,
   type StreamingVolumeSpec,
 } from './volume/streamingVolume'
@@ -270,6 +388,7 @@ export {
   type TiffImage,
   tiffImageDescription,
   tiffResolutionMm,
+  type TiffTagValue,
 } from './volume/tiff'
 export {
   describeTiff,
@@ -284,5 +403,17 @@ export {
   tiffTimepointCount,
   tiffVolumeAffine,
 } from './volume/tiffVolume'
-export type { TransformInfo, TransformOptions } from './volume/transforms'
+// Transform types
+export type {
+  OptionField,
+  ResultDefaults,
+  TransformInfo,
+  TransformOptions,
+  VolumeTransform,
+} from './volume/transforms'
+// Volume utilities for extensions
 export { extractVoxelFid, getImageDataRAS } from './volume/utils'
+// Volume writer options: the third argument to writeVolume
+export type { VolumeWriteOptions } from './volume/writers'
+// Worker bridge for external transform packages
+export { NVWorker } from './workers/NVWorker'

--- a/packages/niivue/src/view/NVSliceLayout.ts
+++ b/packages/niivue/src/view/NVSliceLayout.ts
@@ -12,7 +12,7 @@ import type { BuildLineFn, LineData } from './NVLine'
 
 // ---------- Types ----------
 
-type ScreenInfo = { mnMM: vec3; mxMM: vec3; fovMM: vec3 }
+export type ScreenInfo = { mnMM: vec3; mxMM: vec3; fovMM: vec3 }
 
 export type SliceTile = {
   leftTopWidthHeight?: number[]


### PR DESCRIPTION
## Why

The package has three hand-maintained entry points (`src/index.ts`,
`src/index.webgl2.ts`, `src/index.webgpu.ts`). A symbol added to the root alone
still typechecks, still builds, and still lands in `dist/index.d.ts`. It fails
only downstream, for someone importing from `@niivue/niivue/webgl2`. Nothing in
this monorepo imports from the backend subpaths, so nothing catches it.

The drift had reached **68 non-`*Detail` names** that reached the root entry and
neither backend. The rule that would have prevented it was written down nowhere.

## What this does

**1. Writes the policy down** (`packages/niivue/AGENTS.md`)

Everything except `*Detail` event types goes in all three entry points. The
backend entries are the root entry minus those types, with exactly three lines
swapped: the header comment, the backend's own slide renderer, and the default
export. A fourth difference is a bug.

**2. Closes the drift and pins it**

`index.webgl2.ts` and `index.webgpu.ts` are regenerated from the root, 225 to
318 exported names each. `diff` between the two backend entries is now exactly
the three sanctioned hunks.

`src/entryPoints.test.ts` (new, 4 tests, runs in the normal `bun test` target)
asserts that shape, plus that every `*Detail` type `NVEvents.ts` declares is
actually exported. Mutation-checked: removing `ClickToSegmentDetail` from the
root and `LUT` from webgl2 fails 3 of the 4 tests.

**3. Exports 29 types that public signatures already named**

A TypeScript compiler-API scan over genuinely public positions (heritage
clauses, public members, function parameters and returns, type-alias bodies)
found 29 internal types that the API hands you but that you could not import to
name:

- `ClickToSegmentDetail`, `PerfFrameDetail` and `VolumeOrderChangedDetail`,
  which `NVEventMap` references but **no** entry point exported. You could
  receive one of these events and be unable to type its detail.
- The `NVTypes` members reachable through `NVImage` / `NVMesh` / `NVEventMap` /
  `NiiVueOptions`: `LUT`, `MeshKind`, `NIFTIHeader`, `NVMeshData`,
  `PolygonWithHoles`, the connectome and tract types, and the rest.
- `SignalPlot`, `AxialPlaneOptions`, `FontMetrics`, `FrameReport`, `NVRenderer`,
  `BudgetPlanContext`, `DecodedImage`, `TiffTagValue`, `VolumeWriteOptions`.

Two are aliased where the source name is too generic for a package-wide
namespace: `slidePlane`'s `Vec3` becomes `SlideVec3` (the package already
exports `Vec3f` and `Vec3i`), and `budgetPlans`' `ResolvedOptions` becomes
`ResolvedBudgetOptions`.

**4. Exports the screen-space projection surface** (partially addresses #150)

`projectMMToCanvas` is the sole export of `view/sliceUtils.ts` and reached no
entry point, so @stebo85 has been reimplementing the projection math to place
HTML overlays on 2D slices. Now exported, together with `SliceTile` (where the
`mvpMatrix` and `leftTopWidthHeight` come from) and `ScreenInfo` (which
`SliceTile.screen` names, and which was declared unexported, so `SliceTile`
alone would have been a type you could hold but not destructure).

## Issues

- Partially addresses #150. The remaining half, a documented getter to
  enumerate the current frame's tiles, is API design rather than an export fix,
  so #150 stays open.
- Refs #175. The audit found that `dist/niivue.webgl2.js` and
  `dist/niivue.webgpu.js` share three of their five chunks, including the
  1.83 MB one that holds *both* backends, via a static
  `NVControlBase.ts` -> `control/viewBoth.ts` -> `gl/` + `wgpu/` import. The
  subpaths select a default export, not a smaller bundle. Not fixed here:
  breaking that edge is a refactor, not an entry-point change. AGENTS.md
  documents the leak and points at the issue.
- Refs #176. Five symbols the entry points expose that may belong internal
  (`NVWorker` is the clear removal; `slice2DToMM` needs a promote-or-retract
  decision). Not touched here, because each removal is breaking and the call is
  the maintainers'. Worth noting that closing the drift **widened** their
  exposure: all five now appear in the `webgl2` and `webgpu` subpaths too, where
  previously they appeared in neither. Cheapest to decide before 1.0.0.

## No runtime change

Every commit here adds re-exports, one `export` keyword on a type declaration,
and documentation. No implementation was modified.

## Verification

`lint` (572 files), `typecheck`, `test` (1367 tests, 88 files, 0 fail),
`build`, `check-boundaries`, and codespell with CI's exact invocation all pass.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RxnaB17kqcirGHNyAjPbgG
