### PR TITLE
fix(niivue): export the types named in public signatures

### DIFF
--- a/packages/niivue/src/index.ts
+++ b/packages/niivue/src/index.ts
@@ -12,6 +12,8 @@ export { slice2DToMM } from './annotation/sliceProjection'
 // Opt-in: not in the static graph so apps that don't need the UX don't pay for it.
 // Import directly: `import { NVCanvasViewportController } from '@niivue/niivue/viewport'`
 export type { NVCanvasViewportControllerOptions } from './control/NVCanvasViewportController'
+// Options accepted by reinitializeView (backend switch, anti-alias, DPR)
+export type { ReinitializeOptions } from './control/viewLifecycle'
 // Sparse-document settings policies: which settings saveDocument includes, and
 // how loadDocument fills settings a sparse document omits
 export type {
@@ -61,6 +63,8 @@ export {
   VOLUME_RENDER_MODE,
 } from './NVConstants'
 export { default, default as NiiVue } from './NVControl'
+// Slide drawing tool names (see the `slideTool` accessor)
+export type { SlideDrawTool } from './NVControlBase'
 // Document save options (settings policy + linkData)
 export type { SerializeOptions } from './NVDocument'
 // Event types
@@ -115,6 +119,7 @@ export type {
   CompletedMeasurement,
   CustomLayoutTile,
   DragReleaseInfo,
+  FocusBox,
   ImageFromUrlOptions,
   LodCompensationLevel,
   LodCompensationReport,

--- a/packages/niivue/src/index.webgl2.ts
+++ b/packages/niivue/src/index.webgl2.ts
@@ -12,6 +12,8 @@ export { slice2DToMM } from './annotation/sliceProjection'
 // Opt-in: not in the static graph so apps that don't need the UX don't pay for it.
 // Import directly: `import { NVCanvasViewportController } from '@niivue/niivue/viewport'`
 export type { NVCanvasViewportControllerOptions } from './control/NVCanvasViewportController'
+// Options accepted by reinitializeView (backend switch, anti-alias, DPR)
+export type { ReinitializeOptions } from './control/viewLifecycle'
 // Sparse-document settings policies: which settings saveDocument includes, and
 // how loadDocument fills settings a sparse document omits
 export type {
@@ -61,6 +63,8 @@ export {
   VOLUME_RENDER_MODE,
 } from './NVConstants'
 export { default, default as NiiVue } from './NVControlWebGL2'
+// Slide drawing tool names (see the `slideTool` accessor)
+export type { SlideDrawTool } from './NVControlBase'
 // Document save options (settings policy + linkData)
 export type { SerializeOptions } from './NVDocument'
 // Event types
@@ -87,6 +91,7 @@ export type {
   CompletedMeasurement,
   CustomLayoutTile,
   DragReleaseInfo,
+  FocusBox,
   ImageFromUrlOptions,
   LodCompensationLevel,
   LodCompensationReport,

--- a/packages/niivue/src/index.webgpu.ts
+++ b/packages/niivue/src/index.webgpu.ts
@@ -12,6 +12,8 @@ export { slice2DToMM } from './annotation/sliceProjection'
 // Opt-in: not in the static graph so apps that don't need the UX don't pay for it.
 // Import directly: `import { NVCanvasViewportController } from '@niivue/niivue/viewport'`
 export type { NVCanvasViewportControllerOptions } from './control/NVCanvasViewportController'
+// Options accepted by reinitializeView (backend switch, anti-alias, DPR)
+export type { ReinitializeOptions } from './control/viewLifecycle'
 // Sparse-document settings policies: which settings saveDocument includes, and
 // how loadDocument fills settings a sparse document omits
 export type {
@@ -61,6 +63,8 @@ export {
   VOLUME_RENDER_MODE,
 } from './NVConstants'
 export { default, default as NiiVue } from './NVControlWebGPU'
+// Slide drawing tool names (see the `slideTool` accessor)
+export type { SlideDrawTool } from './NVControlBase'
 // Document save options (settings policy + linkData)
 export type { SerializeOptions } from './NVDocument'
 // Event types
@@ -87,6 +91,7 @@ export type {
   CompletedMeasurement,
   CustomLayoutTile,
   DragReleaseInfo,
+  FocusBox,
   ImageFromUrlOptions,
   LodCompensationLevel,
   LodCompensationReport,


### PR DESCRIPTION
Three public members of the `NiiVue` control name a type that no entry point exports. The value is reachable at runtime, but a consumer cannot write the type down:

| Public member | Type | Declared in |
| --- | --- | --- |
| `get/set focusBox` | `FocusBox` | `NVTypes.ts` |
| `reinitializeView()` | `ReinitializeOptions` | `control/viewLifecycle.ts` |
| `get slideTool` | `SlideDrawTool` | `NVControlBase.ts` |

So this does not compile today:

```ts
import { NiiVue } from '@niivue/niivue'
import type { FocusBox } from '@niivue/niivue' // TS2305

function outline(nv: NiiVue, box: FocusBox) {
  nv.focusBox = box
}
```

The only way to name any of them is a deep import into `dist/`, which is not a supported entry.

## Why the parity test does not catch this

`src/entryPoints.test.ts` compares the three entry files against each other. A type exported from *none* of them is perfectly consistent, so all four tests stay green while the surface is still incomplete. That test guards drift between entries; it says nothing about whether the surface is complete in the first place.

The check that does find these is the scan in `packages/niivue/AGENTS.md` under "Types named in public signatures". It reports clean on this branch and reported these three before it.

## Scope

Added to all three hand-maintained entries (`index.ts`, `index.webgl2.ts`, `index.webgpu.ts`), placed in the existing module ordering. Type-only re-exports; no runtime change, no behaviour change, nothing renamed or removed.

`DecodedChunkStats` (returned by `chunkStreamStats()`) is a fourth instance of the same gap and is deliberately **not** touched here, because #171 already exports it. Every other open PR was checked and none of them touch these three symbols, so this should not conflict with anything in flight.

## Issues

No GitHub issue tracks this. It came out of the scan added in #181 ("Types named in public signatures"), not from a filed report. Related but distinct: #176 was the opposite question, whether to *remove* five exports, and was answered no.

## Verification

```
bunx nx run niivue:typecheck    pass
bunx nx run niivue:test         1369 pass, 1 skip, 0 fail
bunx nx run niivue:lint         pass
bunx nx run niivue:build        pass
bun run check-boundaries        pass
```

All three names land in the emitted declarations for all three distributions:

```
index.d.ts          FocusBox=1 ReinitializeOptions=1 SlideDrawTool=1
index.webgl2.d.ts   FocusBox=1 ReinitializeOptions=1 SlideDrawTool=1
index.webgpu.d.ts   FocusBox=1 ReinitializeOptions=1 SlideDrawTool=1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RxnaB17kqcirGHNyAjPbgG
