### PR TITLE
docs(niivue): write down the entry-point export checks that keep failing silently

### DIFF
--- a/packages/niivue/AGENTS.md
+++ b/packages/niivue/AGENTS.md
@@ -382,6 +382,33 @@ The backend entries are a mechanical function of the root entry: root, minus the
 export swapped. Edit `src/index.ts` first and mirror the change into both backend
 files; the test above will tell you if you missed one.
 
+### Before removing an export
+
+An export in this package has consumers you will not find by searching
+`packages/niivue`. The extensions, `nv-ohif`, `nv-react`, `uikit`, the demo apps
+and `examples/` all import from `@niivue/niivue` by package name.
+
+Two steps, both required:
+
+```bash
+# 1. Search the whole workspace, enumerated -- never a remembered list of packages
+grep -rn '\bTheSymbol\b' --exclude-dir=node_modules --exclude-dir=dist packages apps
+
+# 2. Typecheck the dependents, not just this package
+bunx nx affected -t typecheck        # NOT --projects=niivue
+```
+
+`nx run-many`/`--projects=niivue` passes happily while a sibling package is
+broken, because the sibling's `typecheck` never runs. `nx affected` follows the
+`workspace:*` edges and catches it.
+
+This is not hypothetical. Issue #176 proposed removing five exports on the
+finding that they had no consumers. Every one of the five had a consumer:
+`NVWorker` in `nv-ext-drawing` and `nv-ext-image-processing`, `slice2DToMM` in
+`nv-ohif`, `nii2volume` in an e2e spec and a demo bundle, and the two drawing
+helpers in `examples/slides.js`. The search that missed them used a
+hand-remembered package list and a niivue-scoped gate.
+
 ### The single-backend distributions are not backend-isolated
 
 Separate from the export policy, and worth knowing before reasoning about what a

--- a/packages/niivue/AGENTS.md
+++ b/packages/niivue/AGENTS.md
@@ -382,6 +382,75 @@ The backend entries are a mechanical function of the root entry: root, minus the
 export swapped. Edit `src/index.ts` first and mirror the change into both backend
 files; the test above will tell you if you missed one.
 
+### Rebasing a branch that adds an export
+
+A long-lived branch that adds an export can collide with one that already landed,
+and git will not tell you. The re-export lines sit in different hunks, so the
+merge is clean; the duplicate becomes a `tsc` error only once both are in the same
+file:
+
+```
+src/index.ts(264,27): error TS2300: Duplicate identifier 'SliceTile'.
+src/index.ts(452,32): error TS2300: Duplicate identifier 'SliceTile'.
+```
+
+GitHub reporting a branch MERGEABLE is not evidence of anything here. Mergeable is
+a statement about text, not about types, and a branch that merges cleanly can
+still break `main` on the next typecheck. A branch already marked CONFLICTING is
+the safer case, because someone has to look at it.
+
+Before merging a branch that adds a public export and predates the last change to
+`src/index.ts`, check the symbol against all three entries on `main`:
+
+```bash
+git fetch origin
+for f in index index.webgl2 index.webgpu; do
+  printf '%-14s ' "$f"
+  git show "origin/main:packages/niivue/src/$f.ts" | grep -c '\bTheSymbol\b'
+done
+```
+
+Any non-zero count means the branch must drop its own line and widen the existing
+one instead.
+
+PR #170 is the worked example: it adds `SliceTile` and `projectMMToCanvas`,
+both of which #177 had already exported from all three entries, plus a genuinely
+new `CanvasTilePoint`. The rebase keeps only the new name.
+
+### Types named in public signatures
+
+A type that appears in a public getter, setter, method parameter or return type
+has to be exported from all three entries. Otherwise a consumer can call the
+method and still not be able to name what it hands back.
+
+`entryPoints.test.ts` does not catch this, and cannot as written. It checks that
+the three entries agree with each other, and that every `*Detail` type in
+`NVEvents.ts` is exported. A type that no entry exports is consistent across all
+three, so it passes. Export the types in a method's signature in the same commit
+as the method.
+
+To find what has already slipped through, list the PascalCase names used in
+`NVControlBase`'s public signatures and subtract the ones the root entry
+re-exports:
+
+```bash
+cd packages/niivue/src
+grep -oE '^  (async )?(get |set )?[a-zA-Z_][a-zA-Z0-9_]*\(.*' NVControlBase.ts \
+  | grep -oE '\b[A-Z][A-Za-z0-9_]+\b' | sort -u > /tmp/used.txt
+tr '\n' ' ' < index.ts | grep -oE 'export (type )?\{[^}]*\} from' | tr -d '{}' \
+  | sed 's/export \(type \)*//;s/ from//' | tr ',' '\n' \
+  | sed 's/.* as //;s/^ *type *//;s/^ *//;s/ *$//' | grep -v '^$' | sort -u > /tmp/exported.txt
+# keep only names this package declares as an exported type
+comm -23 /tmp/used.txt /tmp/exported.txt | while read -r t; do
+  grep -rqE "^export (type|interface|class|enum) $t\b" . --exclude-dir=node_modules && echo "$t"
+done
+```
+
+Read the output as candidates, not findings. The last filter drops builtins and
+private classes, but the scan still misses a type that appears only on a
+continuation line of a multi-line return type, so it under-reports. Confirm each
+hit is used in a genuinely public member before adding it to the entries.
+
 ### Before removing an export
 
 An export in this package has consumers you will not find by searching


### PR DESCRIPTION
Doc-only. 96 lines added to `packages/niivue/AGENTS.md`, all inside the existing "Entry points and public exports" section. No source, no test, no behaviour change.

Three failure modes hit this package recently, all of them silent: a green gate, a clean merge, and a passing parity test each reported success while the export surface was wrong. Each section below writes down the check that would have caught it.

## Before removing an export

An export here has consumers you will not find by searching `packages/niivue`. The extensions, `nv-ohif`, `nv-react`, `uikit`, the demo apps and `examples/` all import from `@niivue/niivue` by package name.

Two required steps: an enumerated `grep` across `packages apps`, and `bunx nx affected -t typecheck` rather than `--projects=niivue`. A niivue-scoped gate passes green while a sibling package is broken, because the sibling's `typecheck` target never runs; `nx affected` follows the `workspace:*` edges and catches it.

Grounded in #176, which proposed removing five exports on the finding that they had no consumers. All five had consumers: `NVWorker` in two extensions, `slice2DToMM` in `nv-ohif`, `nii2volume` in an e2e spec and a demo bundle, and the two drawing helpers in `examples/slides.js`. The search that missed them used a hand-remembered package list and a niivue-scoped gate.

## Rebasing a branch that adds an export

A branch that adds an export another branch already landed merges cleanly, because the two re-export lines sit in different hunks. The duplicate surfaces only as `TS2300: Duplicate identifier` on the next typecheck, after the merge.

The line worth internalising: GitHub reporting a branch MERGEABLE is a statement about text, not about types. A branch that merges cleanly can still break `main`.

Includes a three-line check of a symbol against all three entry files on `origin/main`. PR #170 is the worked example: it re-adds `SliceTile` and `projectMMToCanvas`, both already exported by #177, alongside a genuinely new `CanvasTilePoint`.

## Types named in public signatures

A type in a public getter, setter, parameter or return type has to be exported from all three entries, or a consumer can call the method and still not name what it returns.

`entryPoints.test.ts` cannot catch this as written. It checks the three entries against each other; a type exported from *none* of them is perfectly consistent across all three and passes. The test guards drift between entries, not completeness of the surface.

So this section carries the scan that does find them, framed as producing candidates to confirm rather than findings, with its known blind spot stated (it misses a type appearing only on a continuation line of a multi-line return type).

That scan is what produced #180: it turned up `SlideDrawTool`, which the hand-written list I first drafted for this file had missed. That is the argument for shipping the check rather than a table of current offenders, which would have been wrong on the day it landed and staler after every fix.

## Issues

Closes #176. That issue asked whether five exports should be removed before 1.0.0; the answer was no, all five are load-bearing, and its stated outcome was that `AGENTS.md` should record the two-step verification that would have caught the wrong premise. That section is commit 1 here, so landing this closes it.

No issue tracks the "Types named in public signatures" or rebase sections. Both came out of reviewing the open PR queue rather than from a filed report. #180, the export fix the scan produced, has no tracking issue either.

Not related to #175 despite the adjacency: the "single-backend distributions are not backend-isolated" section is pre-existing on `main` and is untouched here.

## Notes

- Only `packages/niivue/AGENTS.md` is touched, across both commits.
- Every command in the new text was run against this tree before being written down, including the `TS2300` error text, which was reproduced by temporarily adding #170's line to `index.ts`.
- No overlap with `main`: the two commits this branch is behind do not touch `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RxnaB17kqcirGHNyAjPbgG
