### PR TITLE
docs(niivue): list the newly exported types in the public API reference

### DIFF
--- a/packages/niivue/FEATURES.md
+++ b/packages/niivue/FEATURES.md
@@ -97,6 +97,8 @@ TRX, TT, TSF (scalars), VTK lines.
 | `getClipPlaneDepthAziElev(i)` | Method | No | |
 | `setClipPlaneDepthAziElev(i, d, a, e)` | Method | No | |
 | `activeClipPlaneIndex`, `currentClipPlaneIndex` | Prop | No | |
+| `focusBox` | Prop (get/set) | No | `FocusBox \| null`; world-mm AABB outlined as 12 edges on the 3D render tile(s). Assigning redraws; `null` clears. Not serialized |
+| `lodBoxes` | Prop (get/set) | No | `FocusBox[] \| null`; the same outline for a set of boxes, e.g. one per streamed LOD brick coloured by level |
 
 ## 5. Layout & View Mode
 
@@ -174,6 +176,11 @@ TRX, TT, TSF (scalars), VTK lines.
 | `loadDrawing(…)` | Method | Yes | |
 | `drawPenAutoClose`, `drawPenFilled` | Prop | No | |
 | `maxDrawUndoBitmaps` | Prop | No | Default 8 |
+| `slideTool` | Prop (get/set) | No | `SlideDrawTool`: `'pen' \| 'eraser' \| 'bucket' \| 'filled' \| 'wand' \| 'vector'`. Selects the active tool for slide drawing |
+
+`slideTool` applies to whole-slide (WSI) drawing, which is a separate surface
+from the volume pen above: `slideDrawAt`, `slideDrawEnd`, `slideDrawUndo`,
+`slideWandTolerance` and `slideVector`. Only the tool selector is listed here.
 
 ## 10. Vector Annotations
 

--- a/packages/niivue/FEATURES.md
+++ b/packages/niivue/FEATURES.md
@@ -28,7 +28,7 @@ Source of truth: `packages/niivue/src/index.ts` (package exports),
 | `attachToCanvas(canvas, isAntiAlias?)` | Method | Yes | Binds to a `HTMLCanvasElement` | Alt. to `attachTo` |
 | `destroy()` | Method | No | Releases GPU resources + listeners | Call before tearing down view |
 | `resize()` | Method | No | Force canvas resize | Call on SwiftUI size-class change |
-| `reinitializeView(options)` | Method | Yes | Recreate view (e.g. backend swap) | Rare; advanced |
+| `reinitializeView(options)` | Method | Yes | Recreate view (e.g. backend swap); `ReinitializeOptions` | Rare; advanced |
 | `backend` | Prop (get) | No | `'webgpu' \| 'webgl2' \| undefined` | Read for UI capability gating |
 | `isAntiAlias` | Prop (get) | No | Read-only | — |
 | `devicePixelRatio` / `forceDevicePixelRatio` | Prop | No | Override DPR | Tune for Retina/ProMotion |
@@ -368,8 +368,9 @@ From the package root (`@niivue/niivue`):
   `NVImage`, `NVMesh`, `NVMeshLayer`, `NVTractOptions`, `NVConnectomeOptions`,
   `NVFontData`, `ColorMap`, `CustomLayoutTile`, `BackendType`, `NIFTI1`,
   `NIFTI2`, `TypedVoxelArray`, `SyncOpts`, `SaveVolumeOptions`, `ViewHitTest`,
-  `DragReleaseInfo`, `ImageFromUrlOptions`, `MeshFromUrlOptions`,
-  `MeshLayerFromUrlOptions`, `VolumeUpdate`, `MeshUpdate`.
+  `DragReleaseInfo`, `FocusBox`, `ImageFromUrlOptions`, `MeshFromUrlOptions`,
+  `MeshLayerFromUrlOptions`, `VolumeUpdate`, `MeshUpdate`,
+  `ReinitializeOptions`, `SlideDrawTool`.
 - **Events:** `NVEventMap`, `NVEventListener`, `NVEventTarget`, and every
   `*Detail` type.
 - **Extension API:** `NVExtensionContext`, `BackgroundVolumeAccess`,
@@ -383,7 +384,10 @@ From the package root (`@niivue/niivue`):
 
 Package subpath entries also ship bundled asset barrels:
 `@niivue/niivue/assets/fonts`, `@niivue/niivue/assets/matcaps`, plus explicit
-`/webgpu` and `/webgl2` entry points if you want to pin a backend.
+`/webgpu` and `/webgl2` entry points if you want to pin a backend. Those two
+pin the API surface, not the bundle: both currently pull a shared chunk that
+contains each renderer, so neither is smaller than the universal entry. See
+issue #175.
 
 ---
 


### PR DESCRIPTION
Doc-only follow-up to #180. One file, `packages/niivue/FEATURES.md`.

That file opens with "Source of truth: `packages/niivue/src/index.ts` (package exports)", and #180 changed `index.ts`, so its section 21 list went stale on merge.

## Changes

**Section 21, "Exported Enums & Types"** now lists the three types #180 added: `FocusBox`, `ReinitializeOptions` and `SlideDrawTool`. `FocusBox` is placed between `DragReleaseInfo` and `ImageFromUrlOptions`, matching where `index.ts` puts it.

**Section 1** names the options type on the `reinitializeView(options)` row, the way the `new NiiVue(options)` row above it already names `NiiVueOptions`. Naming it was pointless before #180, since a reader could not import it.

**Section 21 closing paragraph** corrects what the backend subpaths buy. It said `/webgl2` and `/webgpu` exist "if you want to pin a backend", which reads as a bundle-size claim. They pin the API surface; both still pull a shared chunk containing each renderer, so neither is smaller than the universal entry. That is measured in #175 (three of five chunks byte-identical, including the 1.83 MB one), so the reference now points there rather than leaving a reader to act on a size win that does not exist.

## Verification

```
codespell (CI options)   pass
```

No source touched, so the code gates are unaffected. All three type names are reachable from the package root on current `main`, verified against `origin/main:packages/niivue/src/index{,.webgl2,.webgpu}.ts`.

## Feature rows for the accessors

Second commit. Listing a type as exported while nothing describes the API that takes it is only half a fix, so the three accessors now have rows.

`focusBox` and `lodBoxes` go in section 4 with the other scene-level state, not section 7, which is entirely ray-march parameters. Both are transient world-mm overlays drawn as 12 edges on the 3D render tiles, both redraw on assign, neither is serialized.

`slideTool` goes in section 9. FEATURES.md had no slide coverage at all, so a lone tool-selector row there would imply the volume pen and the slide pen are the same surface. They are not, and the row carries a note naming the rest of that surface (`slideDrawAt`, `slideDrawEnd`, `slideDrawUndo`, `slideWandTolerance`, `slideVector`) rather than pretending the selector is all of it. Documenting whole-slide drawing properly is a bigger job and still open.

Every symbol named in the new text was checked to exist in `NVControlBase.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RxnaB17kqcirGHNyAjPbgG
