### PR TITLE
feat(niivue): visible mm window per world axis on NVSliceLayout

### DIFF
--- a/packages/niivue/src/index.ts
+++ b/packages/niivue/src/index.ts
@@ -266,7 +266,14 @@ export type { FrameReport } from './view/NVPerfMarks'
 // Base class every render entity extends; SlideRenderer's public supertype
 export { NVRenderer } from './view/NVRenderer'
 // Screen-space projection, for placing external overlays over the 2D tiles
-export type { ScreenInfo, SliceTile } from './view/NVSliceLayout'
+export type {
+  AxisWindowMM,
+  ScreenInfo,
+  SliceTile,
+  VisibleWindowMM,
+} from './view/NVSliceLayout'
+// The world-mm span each axis currently shows, for brick prefetchers and axis chrome
+export { tileVisibleWindowMM, visibleWindowMM } from './view/NVSliceLayout'
 export { projectMMToCanvas } from './view/sliceUtils'
 // Crosshair-focused multi-resolution (multi-LOD) streamed volumes
 export type {

--- a/packages/niivue/src/index.webgl2.ts
+++ b/packages/niivue/src/index.webgl2.ts
@@ -238,7 +238,14 @@ export type { FrameReport } from './view/NVPerfMarks'
 // Base class every render entity extends; SlideRenderer's public supertype
 export { NVRenderer } from './view/NVRenderer'
 // Screen-space projection, for placing external overlays over the 2D tiles
-export type { ScreenInfo, SliceTile } from './view/NVSliceLayout'
+export type {
+  AxisWindowMM,
+  ScreenInfo,
+  SliceTile,
+  VisibleWindowMM,
+} from './view/NVSliceLayout'
+// The world-mm span each axis currently shows, for brick prefetchers and axis chrome
+export { tileVisibleWindowMM, visibleWindowMM } from './view/NVSliceLayout'
 export { projectMMToCanvas } from './view/sliceUtils'
 // Crosshair-focused multi-resolution (multi-LOD) streamed volumes
 export type {

--- a/packages/niivue/src/index.webgpu.ts
+++ b/packages/niivue/src/index.webgpu.ts
@@ -238,7 +238,14 @@ export type { FrameReport } from './view/NVPerfMarks'
 // Base class every render entity extends; SlideRenderer's public supertype
 export { NVRenderer } from './view/NVRenderer'
 // Screen-space projection, for placing external overlays over the 2D tiles
-export type { ScreenInfo, SliceTile } from './view/NVSliceLayout'
+export type {
+  AxisWindowMM,
+  ScreenInfo,
+  SliceTile,
+  VisibleWindowMM,
+} from './view/NVSliceLayout'
+// The world-mm span each axis currently shows, for brick prefetchers and axis chrome
+export { tileVisibleWindowMM, visibleWindowMM } from './view/NVSliceLayout'
 export { projectMMToCanvas } from './view/sliceUtils'
 // Crosshair-focused multi-resolution (multi-LOD) streamed volumes
 export type {

--- a/packages/niivue/src/view/NVSliceLayout.test.ts
+++ b/packages/niivue/src/view/NVSliceLayout.test.ts
@@ -387,10 +387,14 @@ describe('visibleWindowMM', () => {
     expect(tileVisibleWindowMM(render)).toBeNull()
     expect(visibleWindowMM([render])).toEqual([null, null, null])
 
-    const global3d = {
-      ...screenSlicesLayout(mpr())[0],
-      space: 'global3d',
-    } as SliceTile
+    // Same tile, only `space` differs: without the flag it reports a window, so
+    // this pins the skip rather than a tile that was empty anyway. The tile-level
+    // entry has to refuse it too: its ortho window is in instance space, and a
+    // caller reading those numbers as world mm cannot tell the difference.
+    const canvasTile = screenSlicesLayout(mpr())[0]
+    expect(tileVisibleWindowMM(canvasTile)).not.toBeNull()
+    const global3d = { ...canvasTile, space: 'global3d' } as SliceTile
+    expect(tileVisibleWindowMM(global3d)).toBeNull()
     expect(visibleWindowMM([global3d])).toEqual([null, null, null])
 
     expect(

--- a/packages/niivue/src/view/NVSliceLayout.test.ts
+++ b/packages/niivue/src/view/NVSliceLayout.test.ts
@@ -1,13 +1,19 @@
 import { describe, expect, test } from 'bun:test'
-import { vec3 } from 'gl-matrix'
+import { vec3, vec4 } from 'gl-matrix'
+import * as NVTransforms from '@/math/NVTransforms'
 import * as NVConstants from '@/NVConstants'
 import type NVModel from '@/NVModel'
 import {
+  type AxisWindowMM,
   crosshairRadiusMM,
   fitSlicesAndGraph,
   type SliceLayoutConfig,
   type SliceTile,
   screenSlicesLayout,
+  slicePanUV,
+  tileVisibleWindowMM,
+  type VisibleWindowMM,
+  visibleWindowMM,
 } from './NVSliceLayout'
 
 // Wide pane (2000x400) with a cube volume: a single-orientation slice is ~square
@@ -211,5 +217,196 @@ describe('isSingleViewFillCanvas', () => {
     expect(on.map((t) => t.leftTopWidthHeight)).toEqual(
       off.map((t) => t.leftTopWidthHeight),
     )
+  })
+})
+
+// ---------- visibleWindowMM ----------
+
+// Deliberately asymmetric and anisotropic: equal spans or a centre on the
+// origin hide a swapped U/V index and a dropped pan.
+const EXTENTS_MIN = vec3.fromValues(-20, -5, -40)
+const EXTENTS_MAX = vec3.fromValues(60, 25, 10)
+
+const mpr = (over: Partial<SliceLayoutConfig> = {}): SliceLayoutConfig =>
+  cfg({
+    canvasWH: [800, 600],
+    sliceType: NVConstants.SLICE_TYPE.MULTIPLANAR,
+    extentsMin: EXTENTS_MIN,
+    extentsMax: EXTENTS_MAX,
+    ...over,
+  })
+
+const win = (w: VisibleWindowMM, axis: number): AxisWindowMM => {
+  const got = w[axis]
+  if (!got) throw new Error(`axis ${axis} has no visible window`)
+  return got
+}
+
+describe('visibleWindowMM', () => {
+  test('unpannedMultiplanarIsExactlyTheDataExtents', () => {
+    const w = visibleWindowMM(screenSlicesLayout(mpr()))
+    for (const axis of [0, 1, 2]) {
+      expect(win(w, axis).minMM).toBeCloseTo(EXTENTS_MIN[axis], 9)
+      expect(win(w, axis).maxMM).toBeCloseTo(EXTENTS_MAX[axis], 9)
+    }
+  })
+
+  test('zoomNarrowsAboutTheCentreAndPanSlidesTheWindow', () => {
+    const tiles = screenSlicesLayout(mpr())
+    const plain = visibleWindowMM(tiles)
+    const zoomed = visibleWindowMM(tiles, [0, 0, 0, 4])
+    const panned = visibleWindowMM(tiles, [7, -3, 11, 4])
+    for (const axis of [0, 1, 2]) {
+      const p = win(plain, axis)
+      const z = win(zoomed, axis)
+      const centre = (p.minMM + p.maxMM) / 2
+      expect(z.maxMM - z.minMM).toBeCloseTo((p.maxMM - p.minMM) / 4, 9)
+      expect((z.minMM + z.maxMM) / 2).toBeCloseTo(centre, 9)
+      // Pan is a world-mm offset of the window, so the span is untouched and
+      // the centre moves by -pan.
+      const q = win(panned, axis)
+      expect(q.maxMM - q.minMM).toBeCloseTo(z.maxMM - z.minMM, 9)
+      expect((q.minMM + q.maxMM) / 2).toBeCloseTo(centre - [7, -3, 11][axis], 9)
+    }
+  })
+
+  test('radiologicalMirrorsTheScreenButNotTheWorldWindow', () => {
+    // The convention negates the ortho bounds AND panU, so what is on screen
+    // swaps sides while the mm interval it covers is identical. A helper that
+    // "handled" radiological would be wrong here.
+    const pan = [7, -3, 11, 2]
+    const neuro = visibleWindowMM(screenSlicesLayout(mpr()), pan)
+    const radio = visibleWindowMM(
+      screenSlicesLayout(mpr({ isRadiologicalConvention: true })),
+      pan,
+    )
+    expect(radio).toEqual(neuro)
+  })
+
+  test('matchesWhatTheMvpActuallyProjects', () => {
+    // The claim the helper makes: its window edges are the edges of the tile.
+    // Push them through the same matrix the renderer builds and they must land
+    // on the clip-space border.
+    const IDX = [
+      [0, 1, 2],
+      [0, 2, 1],
+      [1, 2, 0],
+    ]
+    for (const isRadiological of [false, true]) {
+      const tiles = screenSlicesLayout(
+        mpr({ isRadiologicalConvention: isRadiological }),
+      )
+      const pan = [7, -3, 11, 2.5]
+      for (const tile of tiles) {
+        const map = IDX[tile.axCorSag]
+        if (!map) continue
+        const w = tileVisibleWindowMM(tile, pan)
+        if (!w) throw new Error('2D tile returned no window')
+        const [mvp] = NVTransforms.calculateMvpMatrix2D(
+          tile.leftTopWidthHeight as number[],
+          Array.from((tile.screen as { mnMM: vec3 }).mnMM),
+          Array.from((tile.screen as { mxMM: vec3 }).mxMM),
+          Infinity,
+          undefined,
+          tile.azimuth as number,
+          tile.elevation as number,
+          isRadiological,
+          undefined,
+          undefined,
+          slicePanUV(pan, tile.axCorSag),
+        )
+        const u = win(w, map[0])
+        const v = win(w, map[1])
+        // Depth mid-range keeps the sample inside near/far.
+        const depth = (EXTENTS_MIN[map[2]] + EXTENTS_MAX[map[2]]) / 2
+        for (const [uMM, vMM] of [
+          [u.minMM, v.minMM],
+          [u.maxMM, v.maxMM],
+        ]) {
+          const world = [0, 0, 0]
+          world[map[0]] = uMM
+          world[map[1]] = vMM
+          world[map[2]] = depth
+          const clip = vec4.create()
+          vec4.transformMat4(
+            clip,
+            vec4.fromValues(world[0], world[1], world[2], 1),
+            mvp,
+          )
+          expect(Math.abs(clip[0] / clip[3])).toBeCloseTo(1, 6)
+          expect(Math.abs(clip[1] / clip[3])).toBeCloseTo(1, 6)
+        }
+      }
+    }
+  })
+
+  test('depthOnlyAxesStayNull', () => {
+    // A sagittal tile shows a plane at one X, not a range of X. Reporting a
+    // zero-width window there would let a caller mistake it for a thin slab.
+    const sag = mpr({
+      sliceType: NVConstants.SLICE_TYPE.SAGITTAL,
+      isSingleViewFillCanvas: false,
+    })
+    const w = visibleWindowMM(screenSlicesLayout(sag))
+    expect(w[0]).toBeNull()
+    expect(win(w, 1).minMM).toBeCloseTo(EXTENTS_MIN[1], 9)
+    expect(win(w, 2).maxMM).toBeCloseTo(EXTENTS_MAX[2], 9)
+  })
+
+  test('reportsTheOrthoWindowNotTheData', () => {
+    // A filled single view keeps the image scale and grows the window into the
+    // margin, so the visible mm reach past the volume. Documented, and the
+    // reason callers wanting the visible DATA have to intersect themselves.
+    const sag = mpr({ sliceType: NVConstants.SLICE_TYPE.SAGITTAL })
+    const boxed = visibleWindowMM(
+      screenSlicesLayout({ ...sag, isSingleViewFillCanvas: false }),
+    )
+    const filled = visibleWindowMM(screenSlicesLayout(sag))
+    // fillScreen rebuilds the bounds from a float32 centre, so compare with a
+    // tolerance rather than exactly.
+    const eps = 1e-4
+    let widened = 0
+    for (const axis of [1, 2]) {
+      const f = win(filled, axis)
+      const b = win(boxed, axis)
+      expect(f.minMM).toBeLessThanOrEqual(b.minMM + eps)
+      expect(f.maxMM).toBeGreaterThanOrEqual(b.maxMM - eps)
+      // Centre holds: filling eats margin, it does not slide the image.
+      expect((f.minMM + f.maxMM) / 2).toBeCloseTo((b.minMM + b.maxMM) / 2, 4)
+      if (f.maxMM - f.minMM > b.maxMM - b.minMM + eps) widened++
+    }
+    // Only the axis with slack grows -- the other already spanned the pane.
+    expect(widened).toBe(1)
+  })
+
+  test('skipsRenderGlobal3dAndScreenlessTiles', () => {
+    const render = {
+      axCorSag: NVConstants.SLICE_TYPE.RENDER,
+      leftTopWidthHeight: [0, 0, 400, 400],
+    } as unknown as SliceTile
+    expect(tileVisibleWindowMM(render)).toBeNull()
+    expect(visibleWindowMM([render])).toEqual([null, null, null])
+
+    const global3d = {
+      ...screenSlicesLayout(mpr())[0],
+      space: 'global3d',
+    } as SliceTile
+    expect(visibleWindowMM([global3d])).toEqual([null, null, null])
+
+    expect(
+      tileVisibleWindowMM({
+        axCorSag: NVConstants.SLICE_TYPE.AXIAL,
+      } as unknown as SliceTile),
+    ).toBeNull()
+  })
+
+  test('degenerateZoomFallsBackToOneToOne', () => {
+    // 0 or NaN would otherwise widen the window to infinity and poison any
+    // bounds a caller derives from it.
+    const tiles = screenSlicesLayout(mpr())
+    const plain = visibleWindowMM(tiles)
+    for (const zoom of [0, -1, Number.NaN]) {
+      expect(visibleWindowMM(tiles, [0, 0, 0, zoom])).toEqual(plain)
+    }
   })
 })

--- a/packages/niivue/src/view/NVSliceLayout.ts
+++ b/packages/niivue/src/view/NVSliceLayout.ts
@@ -1042,6 +1042,107 @@ export function screenSlicePick(
   )
 }
 
+// ---------- Visible window ----------
+
+/** A world-mm interval along one world axis. */
+export type AxisWindowMM = { minMM: number; maxMM: number }
+
+/**
+ * The visible world-mm window on each world axis, indexed `[X, Y, Z]`.
+ *
+ * An axis is `null` when no tile shows a range along it -- either nothing is
+ * laid out, or every tile that touches the axis has it as its depth axis.
+ */
+export type VisibleWindowMM = [
+  AxisWindowMM | null,
+  AxisWindowMM | null,
+  AxisWindowMM | null,
+]
+
+/**
+ * World-mm window a single 2D tile currently shows, per world axis.
+ *
+ * `screen.mnMM`/`mxMM` are the tile's ortho window before interaction and are
+ * stored tile-local (`[u, v, depth]`), so this both applies the 2D pan/zoom the
+ * way {@link NVTransforms.calculateMvpMatrix2D} does -- shrink about the window
+ * centre by `zoom`, then shift by `-pan` -- and remaps the result back onto
+ * world XYZ via {@link IDX_MAP}.
+ *
+ * Radiological convention is deliberately not a parameter: it negates both the
+ * ortho bounds and `panU`, which mirrors what lands on the left of the screen
+ * but leaves the world-mm interval identical.
+ *
+ * Only the two in-plane axes get a window. The depth axis is left `null`
+ * because a slice tile shows a plane there, not a range; callers that want the
+ * slice position already have it from `tile.sliceMM` or the crosshair.
+ *
+ * @param tile - a 2D slice tile (returns null for render or non-orientation tiles)
+ * @param pan2Dxyzmm - the scene's `[panX, panY, panZ, zoom]`
+ * @returns per-world-axis windows, or null for a tile with no 2D ortho window
+ */
+export function tileVisibleWindowMM(
+  tile: SliceTile,
+  pan2Dxyzmm: ArrayLike<number> = [0, 0, 0, 1],
+): VisibleWindowMM | null {
+  const map = IDX_MAP[tile.axCorSag]
+  if (!map || !tile.screen) return null
+  const { mnMM, mxMM } = tile.screen
+  const pan = slicePanUV(pan2Dxyzmm, tile.axCorSag)
+  // A zero or non-finite zoom would blow the window up to infinity; treat it
+  // the same 1:1 way the MVP does.
+  const zoom = Number.isFinite(pan[2]) && pan[2] > 0 ? pan[2] : 1
+  const out: VisibleWindowMM = [null, null, null]
+  for (let i = 0; i < 2; i++) {
+    const centre = (mnMM[i] + mxMM[i]) / 2 - pan[i]
+    const half = Math.abs(mxMM[i] - mnMM[i]) / (2 * zoom)
+    if (!Number.isFinite(centre) || !Number.isFinite(half)) continue
+    out[map[i]] = { minMM: centre - half, maxMM: centre + half }
+  }
+  return out
+}
+
+/**
+ * Union of every 2D tile's visible window, per world axis.
+ *
+ * The answer to "which world mm are on screen right now" for a whole layout:
+ * a standard multiplanar returns all three axes, a sagittal-only layout returns
+ * Y and Z with X `null`. The window is the ortho window, so it can reach past
+ * the data -- a tile filling the canvas has margin around the volume, and
+ * `isMultiplanarEqualSize` pads the short axes. Intersect with the volume
+ * extents yourself if you want the visible part of the data rather than of the
+ * world.
+ *
+ * `global3d` tiles are skipped along with render tiles: their window lives in
+ * instance space and would need the tile's position/scale/orientation applied
+ * before it means anything in world mm.
+ *
+ * @param tiles - the laid-out screen slices
+ * @param pan2Dxyzmm - the scene's `[panX, panY, panZ, zoom]`
+ */
+export function visibleWindowMM(
+  tiles: SliceTile[],
+  pan2Dxyzmm: ArrayLike<number> = [0, 0, 0, 1],
+): VisibleWindowMM {
+  const out: VisibleWindowMM = [null, null, null]
+  for (const tile of tiles) {
+    if (tile.space === 'global3d') continue
+    const windows = tileVisibleWindowMM(tile, pan2Dxyzmm)
+    if (!windows) continue
+    for (let axis = 0; axis < 3; axis++) {
+      const win = windows[axis]
+      if (!win) continue
+      const prev = out[axis]
+      out[axis] = prev
+        ? {
+            minMM: Math.min(prev.minMM, win.minMM),
+            maxMM: Math.max(prev.maxMM, win.maxMM),
+          }
+        : win
+    }
+  }
+  return out
+}
+
 // ---------- Cross-lines ----------
 
 export function buildCrossLines(

--- a/packages/niivue/src/view/NVSliceLayout.ts
+++ b/packages/niivue/src/view/NVSliceLayout.ts
@@ -1044,7 +1044,14 @@ export function screenSlicePick(
 
 // ---------- Visible window ----------
 
-/** A world-mm interval along one world axis. */
+/**
+ * A world-mm interval along one world axis.
+ *
+ * Closed at both ends: `maxMM` is the last millimetre visible, not one past it.
+ * Worth stating because the neighbouring box types disagree -- `FocusBox` is
+ * inclusive, `MultiLodBounds` is exclusive -- so a caller converting between
+ * them cannot tell which this is from the shape alone.
+ */
 export type AxisWindowMM = { minMM: number; maxMM: number }
 
 /**
@@ -1116,6 +1123,16 @@ export function tileVisibleWindowMM(
  * `isMultiplanarEqualSize` pads the short axes. Intersect with the volume
  * extents yourself if you want the visible part of the data rather than of the
  * world.
+ *
+ * A union is what a prefetcher wants: the mm a caller must have loaded to cover
+ * everything on screen. It is NOT what "keep this point visible in every tile"
+ * wants, which needs the intersection. The two coincide in every layout today,
+ * because tiles sharing a world axis are laid out from the same extents and get
+ * the same window (checked on standard and equal-size multiplanar, and on a
+ * custom layout with deliberately mismatched pane aspects). Per-tile fill would
+ * break the tie -- one tile widened, its neighbour not -- so a caller with
+ * every-tile semantics should reduce over {@link tileVisibleWindowMM} itself
+ * rather than assume this stays interchangeable.
  *
  * Render and `global3d` tiles are skipped, for the reasons on
  * {@link tileVisibleWindowMM}.

--- a/packages/niivue/src/view/NVSliceLayout.ts
+++ b/packages/niivue/src/view/NVSliceLayout.ts
@@ -1076,16 +1076,21 @@ export type VisibleWindowMM = [
  * because a slice tile shows a plane there, not a range; callers that want the
  * slice position already have it from `tile.sliceMM` or the crosshair.
  *
- * @param tile - a 2D slice tile (returns null for render or non-orientation tiles)
+ * `global3d` tiles return null: their ortho window is in instance space and
+ * would need the tile's position/scale/orientation applied before it means
+ * anything in world mm. Returning the raw numbers would label instance-space
+ * millimetres as world millimetres, which no caller can detect.
+ *
+ * @param tile - a 2D slice tile (returns null for render, global3d or non-orientation tiles)
  * @param pan2Dxyzmm - the scene's `[panX, panY, panZ, zoom]`
- * @returns per-world-axis windows, or null for a tile with no 2D ortho window
+ * @returns per-world-axis windows, or null for a tile with no 2D world-mm ortho window
  */
 export function tileVisibleWindowMM(
   tile: SliceTile,
   pan2Dxyzmm: ArrayLike<number> = [0, 0, 0, 1],
 ): VisibleWindowMM | null {
   const map = IDX_MAP[tile.axCorSag]
-  if (!map || !tile.screen) return null
+  if (!map || !tile.screen || tile.space === 'global3d') return null
   const { mnMM, mxMM } = tile.screen
   const pan = slicePanUV(pan2Dxyzmm, tile.axCorSag)
   // A zero or non-finite zoom would blow the window up to infinity; treat it
@@ -1112,9 +1117,8 @@ export function tileVisibleWindowMM(
  * extents yourself if you want the visible part of the data rather than of the
  * world.
  *
- * `global3d` tiles are skipped along with render tiles: their window lives in
- * instance space and would need the tile's position/scale/orientation applied
- * before it means anything in world mm.
+ * Render and `global3d` tiles are skipped, for the reasons on
+ * {@link tileVisibleWindowMM}.
  *
  * @param tiles - the laid-out screen slices
  * @param pan2Dxyzmm - the scene's `[panX, panY, panZ, zoom]`
@@ -1125,7 +1129,6 @@ export function visibleWindowMM(
 ): VisibleWindowMM {
   const out: VisibleWindowMM = [null, null, null]
   for (const tile of tiles) {
-    if (tile.space === 'global3d') continue
     const windows = tileVisibleWindowMM(tile, pan2Dxyzmm)
     if (!windows) continue
     for (let axis = 0; axis < 3; axis++) {


### PR DESCRIPTION
## What

Two functions on `NVSliceLayout` that answer "what world-mm span is each axis currently showing":

```ts
tileVisibleWindowMM(tile, pan2Dxyzmm?): VisibleWindowMM | null
visibleWindowMM(tiles, pan2Dxyzmm?): VisibleWindowMM
```

`VisibleWindowMM` is `[x, y, z]`, each entry either `{ minMM, maxMM }` or `null`. The tile-level entry reports only the two in-plane axes of that tile; the depth axis stays null, because a slice tile shows a plane there rather than a range, and callers that want the slice position already have it from `tile.sliceMM` or the crosshair. The scene-level entry unions across tiles, so in a standard multiplanar layout all three axes come back populated.

The window is the ortho window the tile actually projects, not the data extents: pan slides it, zoom narrows it about the centre, and it can extend past the volume. Intersect with the volume extents yourself if you want the visible part of the data rather than of the world.

## Why

This is the piece that #165 and #169 are both reaching for. Landing it on its own means it can be tested against every layout branch directly, and it makes #169's rework substantially smaller.

## Notes

- Render tiles and `global3d` tiles return null. A `global3d` tile's ortho window lives in instance space and would need the tile's position, scale and orientation applied before it means anything in world mm; returning the raw numbers would label instance-space millimetres as world millimetres, which no caller could detect.
- Radiological layout mirrors the screen but not the world window, and there is a test pinning that.
- A zero or non-finite zoom falls back to 1:1 rather than producing an infinite window.
- All four symbols (both functions plus `AxisWindowMM` and `VisibleWindowMM`) are exported from `index.ts`, `index.webgl2.ts` and `index.webgpu.ts`, per the rule added in #181, and were confirmed present in the emitted `.d.ts` for all three distributions.

## Tests

8 new tests in `NVSliceLayout.test.ts` (23 in the file, all passing), including one that checks the reported window against what the tile's MVP actually projects, so the helper is pinned to the real projection rather than to a reimplementation of it.

Full gate run locally: format, lint, typecheck, test, build, check-boundaries, and codespell with CI's options. All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RxnaB17kqcirGHNyAjPbgG